### PR TITLE
Check HTTP response codes when retrieving Discord stats

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -647,15 +647,20 @@ class DiscordServerStats {
                 'User-Agent' => 'WordPress Discord Stats Plugin'
             )
         ));
-        
+
         if (is_wp_error($response)) {
             // Essayer avec l'API Bot si le widget échoue
             return $this->get_discord_stats_via_bot();
         }
-        
+
+        $code = wp_remote_retrieve_response_code($response);
+        if (200 !== $code) {
+            return $this->get_discord_stats_via_bot();
+        }
+
         $body = wp_remote_retrieve_body($response);
         $data = json_decode($body, true);
-        
+
         if (!$data || !isset($data['presence_count'])) {
             return $this->get_discord_stats_via_bot();
         }
@@ -690,14 +695,19 @@ class DiscordServerStats {
                 'User-Agent' => 'WordPress Discord Stats Plugin'
             )
         ));
-        
+
         if (is_wp_error($response)) {
             return $this->get_demo_stats();
         }
-        
+
+        $code = wp_remote_retrieve_response_code($response);
+        if (200 !== $code) {
+            return $this->get_demo_stats();
+        }
+
         $body = wp_remote_retrieve_body($response);
         $data = json_decode($body, true);
-        
+
         if (!$data || !isset($data['approximate_presence_count'])) {
             return $this->get_demo_stats();
         }


### PR DESCRIPTION
## Summary
- Use `wp_remote_retrieve_response_code` to verify widget API responses
- Fallback to demo stats when Bot API returns non-200 status

## Testing
- `php -l discord-bot-jlg/discord-bot-jlg.php`


------
https://chatgpt.com/codex/tasks/task_e_68c80dec3afc832e9037ae925e5c3310