### PR TITLE
Remove duplicate CSS block in Discord bot template

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -1131,24 +1131,6 @@ class DiscordServerStats {
                 text-align: <?php echo esc_attr($atts['align']); ?>;
             }
         </style>
-            
-            /* Animations améliorées */
-            #<?php echo $unique_id; ?>.discord-animated .discord-number {
-                transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-            }
-            
-            #<?php echo $unique_id; ?>.discord-animated .discord-stat:hover .discord-number {
-                transform: scale(1.1);
-            }
-            
-            /* Titre */
-            #<?php echo $unique_id; ?> .discord-stats-title {
-                font-size: 18px;
-                font-weight: bold;
-                margin-bottom: 15px;
-                text-align: <?php echo esc_attr($atts['align']); ?>;
-            }
-        </style>
         
         <?php if (!empty($options['custom_css'])) : ?>
         <style type="text/css">


### PR DESCRIPTION
## Summary
- remove the duplicated animation/title CSS block that appeared after the Discord stats style tag
- ensure the template now has only one properly closed style block before the PHP logic resumes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8481c80c4832ea252a613251a2cab