### PR TITLE
Sanitize custom CSS output

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -205,7 +205,9 @@ class DiscordServerStats {
         $sanitized['cache_duration'] = isset($input['cache_duration']) ? absint($input['cache_duration']) : 300;
 
         // CSS personnalisé
-        $sanitized['custom_css'] = isset($input['custom_css']) ? wp_strip_all_tags($input['custom_css']) : '';
+        $sanitized['custom_css'] = isset($input['custom_css'])
+            ? wp_strip_all_tags(wp_unslash($input['custom_css']))
+            : '';
 
         return $sanitized;
     }
@@ -1152,7 +1154,7 @@ class DiscordServerStats {
         
         <?php if (!empty($options['custom_css'])) : ?>
         <style type="text/css">
-            <?php echo $options['custom_css']; ?>
+            <?php echo wp_strip_all_tags($options['custom_css']); ?>
         </style>
         <?php endif; ?>
         


### PR DESCRIPTION
## Summary
- sanitize the saved custom_css option by unslashing and stripping any HTML tags
- wrap the custom CSS output in wp_strip_all_tags before printing in the shortcode renderer

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c8481a5194832e88a4c99840a9672f