### PR TITLE
Escape custom CSS output

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -1165,7 +1165,7 @@ class DiscordServerStats {
         
         <?php if (!empty($options['custom_css'])) : ?>
         <style type="text/css">
-            <?php echo $options['custom_css']; ?>
+            <?php echo esc_html( $options['custom_css'] ); ?>
         </style>
         <?php endif; ?>
         


### PR DESCRIPTION
## Summary
- escape the Custom CSS field when rendering the shortcode output to prevent unescaped HTML.
- keep the sanitize_textarea_field sanitization in place to ensure stored CSS remains filtered.

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c85ce1ea74832ea57da1f705f4f87d