### PR TITLE
Allow unauthenticated refresh action

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -38,9 +38,10 @@ class DiscordServerStats {
         // Styles
         add_action('wp_enqueue_scripts', array($this, 'enqueue_styles'));
         add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_styles'));
-        
+
         // AJAX pour refresh manuel
         add_action('wp_ajax_refresh_discord_stats', array($this, 'ajax_refresh_stats'));
+        add_action('wp_ajax_nopriv_refresh_discord_stats', array($this, 'ajax_refresh_stats'));
     }
     
     // Activation du plugin


### PR DESCRIPTION
## Summary
- allow the Discord stats refresh action to run for unauthenticated visitors by registering the nopriv AJAX hook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c874a44214832e8b307209d7ccc9a3