### PR TITLE
Sanitize Discord server ID as string

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -151,8 +151,13 @@ class Discord_Bot_JLG_Admin {
         );
 
         if (isset($input['server_id'])) {
-            $server_id              = trim($input['server_id']);
-            $sanitized['server_id'] = '' === $server_id ? '' : absint($server_id);
+            $server_id = sanitize_text_field($input['server_id']);
+
+            if ('' === $server_id) {
+                $sanitized['server_id'] = '';
+            } elseif (preg_match('/^\d+$/', $server_id)) {
+                $sanitized['server_id'] = $server_id;
+            }
         }
 
         if (isset($input['bot_token'])) {

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -110,7 +110,7 @@ class Discord_Bot_JLG_API {
     }
 
     private function get_stats_from_widget($options) {
-        $widget_url = 'https://discord.com/api/guilds/' . trim($options['server_id']) . '/widget.json';
+        $widget_url = 'https://discord.com/api/guilds/' . $options['server_id'] . '/widget.json';
 
         $response = wp_remote_get(
             $widget_url,
@@ -149,7 +149,7 @@ class Discord_Bot_JLG_API {
             return false;
         }
 
-        $api_url = 'https://discord.com/api/v10/guilds/' . trim($options['server_id']) . '?with_counts=true';
+        $api_url = 'https://discord.com/api/v10/guilds/' . $options['server_id'] . '?with_counts=true';
 
         $response = wp_remote_get(
             $api_url,


### PR DESCRIPTION
## Summary
- sanitize the saved Discord server ID using `sanitize_text_field` and ensure it only contains digits
- pass the validated server ID string directly to the Discord API endpoints

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68c945dc95e8832e97f9401060ffaa7f