### PR TITLE
Log Discord stats fetch errors

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -1,6 +1,8 @@
 (function () {
     'use strict';
 
+    var ERROR_CLASS = 'discord-stats-error';
+
     function updateStats(container, config, formatter) {
         var url = config.ajaxUrl + '?action=refresh_discord_stats&_ajax_nonce=' + encodeURIComponent(config.nonce);
 
@@ -11,6 +13,10 @@
             .then(function (data) {
                 if (!data || !data.success || !data.data) {
                     return;
+                }
+
+                if (container && container.classList) {
+                    container.classList.remove(ERROR_CLASS);
                 }
 
                 var online = container.querySelector('.discord-online .discord-number');
@@ -31,8 +37,12 @@
                     }, 300);
                 }
             })
-            .catch(function () {
-                // Ignorer les erreurs réseau afin de ne pas casser l'interface.
+            .catch(function (error) {
+                console.error('Erreur lors de la mise à jour des statistiques Discord :', error);
+
+                if (container && container.classList) {
+                    container.classList.add(ERROR_CLASS);
+                }
             });
     }
 


### PR DESCRIPTION
## Summary
- log Discord stats fetch failures to surface issues in the console
- flag the stats container with an error class when a refresh fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c967124948832eab2a7c929a4829bd