### PR TITLE
Use POST requests with nonce form data

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -2,9 +2,15 @@
     'use strict';
 
     function updateStats(container, config, formatter) {
-        var url = config.ajaxUrl + '?action=refresh_discord_stats&_ajax_nonce=' + encodeURIComponent(config.nonce);
+        var formData = new FormData();
+        formData.append('action', config.action || 'refresh_discord_stats');
+        formData.append('_ajax_nonce', config.nonce);
 
-        fetch(url)
+        fetch(config.ajaxUrl, {
+            method: 'POST',
+            body: formData,
+            credentials: 'same-origin'
+        })
             .then(function (response) {
                 return response.json();
             })
@@ -37,7 +43,7 @@
     }
 
     function initializeDiscordBot() {
-        if (typeof window.fetch !== 'function') {
+        if (typeof window.fetch !== 'function' || typeof window.FormData !== 'function') {
             return;
         }
 

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -65,7 +65,11 @@ class Discord_Bot_JLG_API {
     }
 
     public function ajax_refresh_stats() {
-        check_ajax_referer('refresh_discord_stats');
+        $nonce = isset($_POST['_ajax_nonce']) ? sanitize_text_field(wp_unslash($_POST['_ajax_nonce'])) : '';
+
+        if (empty($nonce) || !wp_verify_nonce($nonce, 'refresh_discord_stats')) {
+            wp_send_json_error('Nonce invalide', 403);
+        }
 
         $options = get_option($this->option_name);
         if (!is_array($options)) {

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -232,6 +232,7 @@ class Discord_Bot_JLG_Shortcode {
             'discordBotJlg',
             array(
                 'ajaxUrl' => admin_url('admin-ajax.php'),
+                'action'  => 'refresh_discord_stats',
                 'nonce'   => wp_create_nonce('refresh_discord_stats'),
                 'locale'  => $locale,
             )


### PR DESCRIPTION
## Summary
- send Discord stats refresh requests via POST using FormData and include same-origin credentials
- expose the AJAX action to the frontend configuration and verify the nonce from POST values on the server

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68c96710fa48832ea6458d31467815d2