### PR TITLE
Add uninstall cleanup for Discord Bot JLG plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Un widget « Discord Bot - JLG » est disponible via le menu « Widgets ».
 - Mise en cache des statistiques ;
 - Page de démonstration intégrée.
 
+## Désinstallation
+La suppression du plugin depuis WordPress efface automatiquement l’option `discord_server_stats_options` et le transient `discord_server_stats_cache` associés aux statistiques du serveur.
+
 ## Support
 - Portail développeur Discord : https://discord.com/developers/applications
 - Notes de version disponibles dans l’interface du plugin.

--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -18,6 +18,18 @@ define('DISCORD_BOT_JLG_OPTION_NAME', 'discord_server_stats_options');
 define('DISCORD_BOT_JLG_CACHE_KEY', 'discord_server_stats_cache');
 define('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION', 300);
 
+/**
+ * Supprime les données enregistrées par le plugin lors de la désinstallation.
+ *
+ * @return void
+ */
+function discord_bot_jlg_uninstall() {
+    delete_option(DISCORD_BOT_JLG_OPTION_NAME);
+    delete_transient(DISCORD_BOT_JLG_CACHE_KEY);
+}
+
+register_uninstall_hook(__FILE__, 'discord_bot_jlg_uninstall');
+
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-admin.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-shortcode.php';


### PR DESCRIPTION
## Summary
- register an uninstall hook that removes the plugin option and cached transient
- document the automatic cleanup performed on uninstall in the README

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b313961c832e95e8d07cc03bf84b