### PR TITLE
Prevent cache purge on failed stat refresh

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -80,7 +80,6 @@ class Discord_Bot_JLG_API {
             wp_send_json_error('Mode démo actif');
         }
 
-        $this->clear_cache();
         $stats = $this->get_stats(
             array(
                 'bypass_cache' => true,


### PR DESCRIPTION
## Summary
- stop deleting the cached Discord stats before triggering a manual refresh
- rely on `get_stats()` to update the transient so that failed refresh attempts keep the previous values

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cfa45cd8832e8e30ce5226caab23