### PR TITLE
Load Discord assets only when shortcode renders

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -68,8 +68,6 @@ class DiscordServerStats {
 
         add_shortcode('discord_stats', array($this->shortcode, 'render_shortcode'));
 
-        add_action('wp_enqueue_scripts', array($this->shortcode, 'enqueue_styles'));
-
         add_action('widgets_init', array($this->widget, 'register_widget'));
 
         add_action('wp_ajax_refresh_discord_stats', array($this->api, 'ajax_refresh_stats'));


### PR DESCRIPTION
## Summary
- stop enqueuing the frontend assets at plugin bootstrap
- register the styles/scripts on demand and enqueue them only when the shortcode renders output
- add a footer hook to print late-queued styles so stats pages still receive the CSS

## Testing
- php -l discord-bot-jlg/inc/class-discord-shortcode.php
- php -l discord-bot-jlg/discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cfa54160832e8e5bdbd75cec938f