### PR TITLE
Limit admin stylesheet to plugin screens

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -64,7 +64,7 @@ class DiscordServerStats {
 
         add_action('admin_menu', array($this->admin, 'add_admin_menu'));
         add_action('admin_init', array($this->admin, 'settings_init'));
-        add_action('admin_enqueue_scripts', array($this->admin, 'enqueue_admin_styles'));
+        add_action('admin_enqueue_scripts', array($this->admin, 'enqueue_admin_styles'), 10, 1);
 
         add_shortcode('discord_stats', array($this->shortcode, 'render_shortcode'));
 

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -728,7 +728,16 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
-    public function enqueue_admin_styles() {
+    public function enqueue_admin_styles($hook_suffix) {
+        $allowed_hooks = array(
+            'toplevel_page_discord-bot-jlg',
+            'discord-bot_page_discord-bot-demo',
+        );
+
+        if (!in_array($hook_suffix, $allowed_hooks, true)) {
+            return;
+        }
+
         wp_enqueue_style(
             'discord-bot-jlg-admin',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg-admin.css',


### PR DESCRIPTION
## Summary
- update the admin stylesheet hook to receive the screen suffix and restrict loading to the plugin's menu pages
- register the `admin_enqueue_scripts` action with the expected argument count so WordPress passes the hook suffix

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php
- php -l discord-bot-jlg/discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68cac02f626c832eabf5ec9e8fb3806d