### PR TITLE
Limit admin stylesheet loading to plugin screens

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -729,12 +729,19 @@ class Discord_Bot_JLG_Admin {
     }
 
     public function enqueue_admin_styles($hook_suffix) {
-        $allowed_hooks = array(
+        $allowed_ids = array(
             'toplevel_page_discord-bot-jlg',
             'discord-bot_page_discord-bot-demo',
         );
 
-        if (!in_array($hook_suffix, $allowed_hooks, true)) {
+        $current_screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        $screen_id      = $current_screen ? $current_screen->id : '';
+
+        if ('' !== $screen_id) {
+            if (!in_array($screen_id, $allowed_ids, true)) {
+                return;
+            }
+        } elseif (!in_array($hook_suffix, $allowed_ids, true)) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- restrict admin stylesheet loading to the Discord Bot settings and demo screens only by checking the current screen ID or hook suffix

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cac4640798832e9139b68288326f7c