### PR TITLE
Fix shortcode attributes HTML quoting

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -120,13 +120,13 @@ class Discord_Bot_JLG_Shortcode {
         }
 
         $attributes = array(
-            'id="' . esc_attr($unique_id) . '"',
-            'class="' . esc_attr(implode(' ', $container_classes)) . '"',
-            'data-demo="' . esc_attr(!empty($stats['is_demo']) ? 'true' : 'false') . '"',
+            sprintf('id="%s"', esc_attr($unique_id)),
+            sprintf('class="%s"', esc_attr(implode(' ', $container_classes))),
+            sprintf('data-demo="%s"', esc_attr(!empty($stats['is_demo']) ? 'true' : 'false')),
         );
 
         if (!empty($style_declarations)) {
-            $attributes[] = 'style="' . esc_attr(implode('; ', $style_declarations)) . '"';
+            $attributes[] = sprintf('style="%s"', esc_attr(implode('; ', $style_declarations)));
         }
 
         $refresh_interval = 0;
@@ -135,7 +135,7 @@ class Discord_Bot_JLG_Shortcode {
         }
 
         if ($refresh_interval > 0) {
-            $attributes[] = 'data-refresh="' . esc_attr($refresh_interval) . '"';
+            $attributes[] = sprintf('data-refresh="%s"', esc_attr($refresh_interval));
         }
 
         $discord_svg = '<svg class="discord-logo-svg" viewBox="0 0 127.14 96.36" xmlns="http://www.w3.org/2000/svg"><path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/></svg>';


### PR DESCRIPTION
## Summary
- build HTML attribute strings in the shortcode renderer with sprintf so that they use straight double quotes in the output
- keep the inline style and refresh attributes consistent and backslash-free

## Testing
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cac4657714832e82acbac0282052a6