### PR TITLE
Add localization support scaffolding for Discord Bot plugin

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -5,6 +5,8 @@
  * Description: Affiche les statistiques de votre serveur Discord (membres en ligne et total)
  * Version: 1.0
  * Author: Jérôme Le Gousse
+ * Text Domain: discord-bot-jlg
+ * Domain Path: /languages
  * License: GPL v2 or later
  */
 
@@ -34,6 +36,12 @@ require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-admin.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-shortcode.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-widget.php';
+
+function discord_bot_jlg_load_textdomain() {
+    load_plugin_textdomain('discord-bot-jlg', false, dirname(plugin_basename(__FILE__)) . '/languages');
+}
+
+add_action('plugins_loaded', 'discord_bot_jlg_load_textdomain');
 
 class DiscordServerStats {
 

--- a/discord-bot-jlg/languages/.gitkeep
+++ b/discord-bot-jlg/languages/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to keep the languages directory in version control until translations are added.


### PR DESCRIPTION
## Summary
- declare the plugin text domain and languages directory in the main plugin header
- load the plugin text domain on `plugins_loaded` so translations can be used
- add a placeholder languages directory ready to receive translation files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad684af68832ebf43a4f13006b882