### PR TITLE
Limit admin stylesheet to plugin pages

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -734,11 +734,10 @@ class Discord_Bot_JLG_Admin {
             'discord-bot_page_discord-bot-demo',
         );
 
-        $current_screen = function_exists('get_current_screen') ? get_current_screen() : null;
-        $screen_id      = $current_screen ? $current_screen->id : '';
+        if (function_exists('get_current_screen')) {
+            $current_screen = get_current_screen();
 
-        if ('' !== $screen_id) {
-            if (!in_array($screen_id, $allowed_ids, true)) {
+            if ($current_screen && !in_array($current_screen->id, $allowed_ids, true)) {
                 return;
             }
         } elseif (!in_array($hook_suffix, $allowed_ids, true)) {


### PR DESCRIPTION
## Summary
- prevent enqueueing the admin stylesheet outside the plugin's admin pages by checking the current screen and fallback hook suffix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caf61b4cd0832ebb6539d9737ba004