### PR TITLE
Harmonise minimum refresh interval at 10 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pour activer l'auto-actualisation, utilisez par exemple :
 [discord_stats refresh="true" refresh_interval="60"]
 ```
 
-Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moins 10 secondes (10 000 ms).
+Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moins 10 secondes (10 000 ms). Toute valeur plus basse est automatiquement portée à 10 secondes pour éviter les erreurs 429 de Discord.
 
 ### Widget
 Un widget « Discord Bot - JLG » est disponible via le menu « Widgets ».

--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -94,6 +94,12 @@
         var locale = config.locale || 'fr-FR';
         var formatter;
 
+        var minIntervalSeconds = parseInt(config.minRefreshInterval, 10);
+        if (isNaN(minIntervalSeconds) || minIntervalSeconds <= 0) {
+            minIntervalSeconds = 10;
+        }
+        var minIntervalMs = minIntervalSeconds * 1000;
+
         try {
             formatter = new Intl.NumberFormat(locale);
         } catch (error) {
@@ -116,9 +122,13 @@
             }
 
             // L'attribut data-refresh est exprimé en secondes côté PHP.
+            if (interval < minIntervalSeconds) {
+                interval = minIntervalSeconds;
+            }
+
             var intervalMs = interval * 1000;
-            if (intervalMs < 10000) {
-                return;
+            if (intervalMs < minIntervalMs) {
+                intervalMs = minIntervalMs;
             }
 
             setInterval(function () {

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -615,7 +615,7 @@ class Discord_Bot_JLG_Admin {
 // MODE DÉMO (pour tester l'apparence)
 [discord_stats demo="true" show_discord_icon="true" theme="dark" layout="vertical"]</pre>
 
-            <p style="margin-top: 10px;"><em>ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10&nbsp;secondes (10 000&nbsp;ms).</em></p>
+            <p style="margin-top: 10px;"><em>ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10&nbsp;secondes (10 000&nbsp;ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429.</em></p>
 
             <h4>Tous les paramètres disponibles :</h4>
             <div style="background: white; padding: 15px; border-radius: 4px;">

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -6,6 +6,8 @@ if (!defined('ABSPATH')) {
 
 class Discord_Bot_JLG_API {
 
+    const MIN_PUBLIC_REFRESH_INTERVAL = 10;
+
     private $option_name;
     private $cache_key;
     private $default_cache_duration;
@@ -85,9 +87,10 @@ class Discord_Bot_JLG_API {
 
         $rate_limit_key = $this->cache_key . '_refresh_lock';
         $cache_duration = $this->get_cache_duration($options);
-        $rate_limit_window = (int) apply_filters('discord_bot_jlg_public_refresh_interval', $cache_duration, $options);
-        if ($rate_limit_window < 30) {
-            $rate_limit_window = 30;
+        $default_public_refresh = max(self::MIN_PUBLIC_REFRESH_INTERVAL, (int) $cache_duration);
+        $rate_limit_window = (int) apply_filters('discord_bot_jlg_public_refresh_interval', $default_public_refresh, $options);
+        if ($rate_limit_window < self::MIN_PUBLIC_REFRESH_INTERVAL) {
+            $rate_limit_window = self::MIN_PUBLIC_REFRESH_INTERVAL;
         }
 
         if ($is_public_request) {

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -130,8 +130,12 @@ class Discord_Bot_JLG_Shortcode {
         }
 
         $refresh_interval = 0;
+        $min_refresh_interval = defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
+            ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
+            : 10;
+
         if ($refresh && empty($stats['is_demo'])) {
-            $refresh_interval = max(10, intval($atts['refresh_interval']));
+            $refresh_interval = max($min_refresh_interval, intval($atts['refresh_interval']));
         }
 
         if ($refresh_interval > 0) {
@@ -258,6 +262,9 @@ class Discord_Bot_JLG_Shortcode {
                 'action'  => 'refresh_discord_stats',
                 'nonce'   => wp_create_nonce('refresh_discord_stats'),
                 'locale'  => $locale,
+                'minRefreshInterval' => defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
+                    ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
+                    : 10,
             )
         );
 


### PR DESCRIPTION
## Summary
- expose a shared 10 second minimum refresh interval in the API and enforce it on the AJAX rate limiter and shortcode output
- pass the minimum interval to the front-end script so it clamps client timers instead of silently aborting
- update admin help text and README to explain the automatic adjustment that prevents Discord 429 errors

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cb0868778c832eb4c1bf9e92b9b399