### PR TITLE
Add DocBlocks for Discord admin, API and shortcode classes

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -4,16 +4,32 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/**
+ * Gère l'intégration du plugin dans l'administration WordPress (menus, pages, formulaires et assets).
+ */
 class Discord_Bot_JLG_Admin {
 
     private $option_name;
     private $api;
 
+    /**
+     * Initialise l'instance avec la clé d'option et le client API utilisé pour les vérifications.
+     *
+     * @param string              $option_name Nom de l'option stockant la configuration du plugin.
+     * @param Discord_Bot_JLG_API $api         Service d'accès aux statistiques Discord.
+     *
+     * @return void
+     */
     public function __construct($option_name, Discord_Bot_JLG_API $api) {
         $this->option_name = $option_name;
         $this->api         = $api;
     }
 
+    /**
+     * Enregistre le menu principal et les sous-menus du plugin dans l'administration WordPress.
+     *
+     * @return void
+     */
     public function add_admin_menu() {
         $discord_icon = 'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbD0iI2E0YWFiOCIgZD0iTTIwLjMxNyA0LjM3YTE5LjggMTkuOCAwIDAwLTQuODg1LTEuNTE1LjA3NC4wNzQgMCAwMC0uMDc5LjAzN2MtLjIxLjM3NS0uNDQ0Ljg2NC0uNjA4IDEuMjVhMTguMjcgMTguMjcgMCAwMC01LjQ4NyAwYy0uMTY1LS4zOTctLjQwNC0uODg1LS42MTgtMS4yNWEuMDc3LjA3NyAwIDAwLS4wNzktLjAzN0ExOS43NCAxOS43NCAwIDAwMy42NzcgNC4zN2EuMDcuMDcgMCAwMC0uMDMyLjAyN0MuNTMzIDkuMDQ2LS4zMiAxMy41OC4wOTkgMTguMDU3YS4wOC4wOCAwIDAwLjAzMS4wNTdBMTkuOSAxOS45IDAgMDA2LjA3MyAyMWEuMDc4LjA3OCAwIDAwLjA4NC0uMDI4IDEzLjQgMTMuNCAwIDAwMS4xNTUtMi4xLjA3Ni4wNzYgMCAwMC0uMDQxLS4xMDYgMTMuMSAxMy4xIDAgMDEtMS44NzItLjg5Mi4wNzcuMDc3IDAgMDEtLjAwOC0uMTI4IDE0IDE0IDAgMDAuMzctLjI5Mi4wNzQuMDc0IDAgMDEuMDc3LS4wMWMzLjkyNyAxLjc5MyA4LjE4IDEuNzkzIDEyLjA2IDAgYS4wNzQuMDc0IDAgMDEuMDc4LjAwOS4xMTkuMDk5LjI0Ni4xOTguMzczLjI5MmEuMDc3LjA3NyAwIDAxLS4wMDYuMTI3IDEyLjMgMTIuMyAwIDAxLTEuODczLjg5Mi4wNzcuMDc3IDAgMDAtLjA0MS4xMDdjMy43NDQgMS40MDMgMS4xNTUgMi4xLS4wODQuMDI4YS4wNzguMDc4IDAgMDAxOS45MDItMS45MDMuMDc2LjA3NiAwIDAwLjAzLS4wNTdjLjUzNy00LjU4LS45MDQtOC41NTMtMy44MjMtMTIuMDU3YS4wNi4wNiAwIDAwLS4wMzEtLjAyOHpNOC4wMiAxNS4yNzhjLTEuMTgzIDAtMi4xNTctMS4wODUtMi4xNTctMi40MiAwLTEuMzMzLjk1Ni0yLjQxOSAyLjE1Ny0yLjQxOSAxLjIxIDAgMi4xNzYgMS4wOTYgMi4xNTcgMi40MiAwIDEuMzM0LS45NTYgMi40MTktMi4xNTcgMi40MTl6bTcuOTc1IDBjLTEuMTgzIDAtMi4xNTctMS4wODUtMi4xNTctMi40MiAwLTEuMzMzLjk1NS0yLjQxOSAyLjE1Ny0yLjQxOXMyLjE1NyAxLjA5NiAyLjE1NyAyLjQyYzAgMS4zMzQtLjk1NiAyLjQxOS0yLjE1NyAyLjQxOXoiLz48L3N2Zz4=';
 
@@ -46,6 +62,11 @@ class Discord_Bot_JLG_Admin {
         );
     }
 
+    /**
+     * Enregistre les sections, champs et options nécessaires pour la configuration du plugin.
+     *
+     * @return void
+     */
     public function settings_init() {
         register_setting(
             'discord_stats_settings',
@@ -134,6 +155,13 @@ class Discord_Bot_JLG_Admin {
         );
     }
 
+    /**
+     * Valide et nettoie les options soumises depuis le formulaire d'administration.
+     *
+     * @param mixed $input Valeurs brutes envoyées par WordPress lors de l'enregistrement des options.
+     *
+     * @return array Options validées et normalisées prêtes à être stockées.
+     */
     public function sanitize_options($input) {
         if (!is_array($input)) {
             $input = array();
@@ -184,6 +212,11 @@ class Discord_Bot_JLG_Admin {
         return $sanitized;
     }
 
+    /**
+     * Affiche la section d'aide dédiée à la configuration de l'API Discord.
+     *
+     * @return void
+     */
     public function api_section_callback() {
         ?>
         <div style="background: #f0f4ff; padding: 20px; border-radius: 8px; margin: 20px 0;">
@@ -274,10 +307,20 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Affiche un rappel concernant la personnalisation de l'affichage des statistiques.
+     *
+     * @return void
+     */
     public function display_section_callback() {
         echo '<p>Personnalisez l\'affichage des statistiques Discord.</p>';
     }
 
+    /**
+     * Rend le champ permettant de saisir l'identifiant du serveur Discord.
+     *
+     * @return void
+     */
     public function server_id_render() {
         $options = get_option($this->option_name);
         ?>
@@ -288,6 +331,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Rend le champ de saisie du token du bot Discord.
+     *
+     * @return void
+     */
     public function bot_token_render() {
         $options = get_option($this->option_name);
         ?>
@@ -298,6 +346,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Rend la case à cocher activant le mode démonstration.
+     *
+     * @return void
+     */
     public function demo_mode_render() {
         $options   = get_option($this->option_name);
         $demo_mode = isset($options['demo_mode']) ? (int) $options['demo_mode'] : 0;
@@ -309,6 +362,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Rend la case à cocher contrôlant l'affichage du nombre d'utilisateurs en ligne.
+     *
+     * @return void
+     */
     public function show_online_render() {
         $options = get_option($this->option_name);
         $value   = isset($options['show_online']) ? (int) $options['show_online'] : 0;
@@ -319,6 +377,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Rend la case à cocher contrôlant l'affichage du nombre total de membres.
+     *
+     * @return void
+     */
     public function show_total_render() {
         $options = get_option($this->option_name);
         $value   = isset($options['show_total']) ? (int) $options['show_total'] : 0;
@@ -329,6 +392,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Rend le champ texte permettant de définir le titre du widget.
+     *
+     * @return void
+     */
     public function widget_title_render() {
         $options = get_option($this->option_name);
         ?>
@@ -338,6 +406,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Rend le champ numérique dédié au réglage de la durée du cache.
+     *
+     * @return void
+     */
     public function cache_duration_render() {
         $options = get_option($this->option_name);
         ?>
@@ -348,6 +421,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Rend la zone de texte pour ajouter du CSS personnalisé.
+     *
+     * @return void
+     */
     public function custom_css_render() {
         $options = get_option($this->option_name);
         ?>
@@ -356,6 +434,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Affiche la page principale de configuration du plugin.
+     *
+     * @return void
+     */
     public function options_page() {
         ?>
         <div class="wrap">
@@ -473,6 +556,11 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Affiche la page de guide et de démonstration du plugin.
+     *
+     * @return void
+     */
     public function demo_page() {
         ?>
         <div class="wrap">
@@ -728,6 +816,13 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    /**
+     * Enfile les feuilles de style nécessaires sur les écrans d'administration du plugin.
+     *
+     * @param string $hook_suffix Identifiant du hook fourni par WordPress pour la page courante.
+     *
+     * @return void
+     */
     public function enqueue_admin_styles($hook_suffix) {
         $allowed_ids = array(
             'toplevel_page_discord-bot-jlg',
@@ -752,6 +847,11 @@ class Discord_Bot_JLG_Admin {
         );
     }
 
+    /**
+     * Teste la connexion à l'API Discord et affiche un message selon le résultat obtenu.
+     *
+     * @return void
+     */
     public function test_discord_connection() {
         $options = get_option($this->option_name);
         if (!is_array($options)) {

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -4,6 +4,9 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/**
+ * Fournit les appels à l'API Discord ainsi que la gestion du cache et des données de démonstration.
+ */
 class Discord_Bot_JLG_API {
 
     const MIN_PUBLIC_REFRESH_INTERVAL = 10;
@@ -12,12 +15,33 @@ class Discord_Bot_JLG_API {
     private $cache_key;
     private $default_cache_duration;
 
+    /**
+     * Prépare le service d'accès aux statistiques avec les clés et durées nécessaires.
+     *
+     * @param string $option_name            Nom de l'option contenant la configuration du plugin.
+     * @param string $cache_key              Clef de cache utilisée pour mémoriser les statistiques.
+     * @param int    $default_cache_duration Durée du cache utilisée à défaut (en secondes).
+     *
+     * @return void
+     */
     public function __construct($option_name, $cache_key, $default_cache_duration = 300) {
         $this->option_name = $option_name;
         $this->cache_key = $cache_key;
         $this->default_cache_duration = (int) $default_cache_duration;
     }
 
+    /**
+     * Récupère les statistiques du serveur en tenant compte du cache, du mode démo ou d'un forçage explicite.
+     *
+     * @param array $args {
+     *     Arguments permettant de modifier le comportement de récupération.
+     *
+     *     @type bool $force_demo   Si vrai, renvoie systématiquement les statistiques de démonstration.
+     *     @type bool $bypass_cache Si vrai, ignore la valeur mise en cache et interroge l'API directement.
+     * }
+     *
+     * @return array Statistiques du serveur (clés `online`, `total`, `server_name`, éventuellement `is_demo`).
+     */
     public function get_stats($args = array()) {
         $args = wp_parse_args(
             $args,
@@ -66,6 +90,11 @@ class Discord_Bot_JLG_API {
         return $stats;
     }
 
+    /**
+     * Gère la requête AJAX d'actualisation des statistiques et renvoie une réponse JSON.
+     *
+     * @return void
+     */
     public function ajax_refresh_stats() {
         $nonce = isset($_POST['_ajax_nonce']) ? sanitize_text_field(wp_unslash($_POST['_ajax_nonce'])) : '';
 
@@ -159,10 +188,20 @@ class Discord_Bot_JLG_API {
         wp_send_json_error('Impossible de récupérer les stats');
     }
 
+    /**
+     * Supprime les statistiques mises en cache pour forcer une prochaine récupération.
+     *
+     * @return void
+     */
     public function clear_cache() {
         delete_transient($this->cache_key);
     }
 
+    /**
+     * Génère des statistiques fictives pour la démonstration ou en cas d'absence de configuration.
+     *
+     * @return array Statistiques de démonstration comprenant les clés `online`, `total`, `server_name` et `is_demo`.
+     */
     public function get_demo_stats() {
         $base_online = 42;
         $base_total  = 256;

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -4,6 +4,9 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/**
+ * Implémente le shortcode `[discord_stats]` et gère les assets associés côté public.
+ */
 class Discord_Bot_JLG_Shortcode {
 
     private $option_name;
@@ -13,11 +16,26 @@ class Discord_Bot_JLG_Shortcode {
     private static $inline_css_added    = false;
     private static $footer_hook_added   = false;
 
+    /**
+     * Conserve la clé d'option et le service API utilisés lors du rendu du shortcode.
+     *
+     * @param string              $option_name Nom de l'option stockant les réglages d'affichage.
+     * @param Discord_Bot_JLG_API $api         Service fournissant les statistiques Discord.
+     *
+     * @return void
+     */
     public function __construct($option_name, Discord_Bot_JLG_API $api) {
         $this->option_name = $option_name;
         $this->api         = $api;
     }
 
+    /**
+     * Génère l'affichage du shortcode avec les options fusionnées entre réglages et attributs.
+     *
+     * @param array|string $atts Attributs reçus du shortcode WordPress.
+     *
+     * @return string HTML du composant de statistiques prêt à être inséré dans la page.
+     */
     public function render_shortcode($atts) {
         $options = get_option($this->option_name);
         if (!is_array($options)) {
@@ -271,6 +289,11 @@ class Discord_Bot_JLG_Shortcode {
         self::$assets_registered = true;
     }
 
+    /**
+     * Force l'impression tardive des feuilles de style si elles sont encore en file d'attente.
+     *
+     * @return void
+     */
     public function print_late_styles() {
         if (wp_style_is('discord-bot-jlg-inline', 'enqueued')) {
             wp_print_styles('discord-bot-jlg-inline');


### PR DESCRIPTION
## Summary
- document the Discord admin class with an overview and detailed DocBlocks for every public method
- explain the responsibilities of the API service class and add DocBlocks clarifying parameters and return values
- describe the shortcode class and annotate its public methods to aid tooling and maintainability

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cb2a24d654832e8ac31f1095abffec