### PR TITLE
Internationalize admin UI and refresh translations

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -18,8 +18,8 @@ class Discord_Bot_JLG_Admin {
         $discord_icon = 'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbD0iI2E0YWFiOCIgZD0iTTIwLjMxNyA0LjM3YTE5LjggMTkuOCAwIDAwLTQuODg1LTEuNTE1LjA3NC4wNzQgMCAwMC0uMDc5LjAzN2MtLjIxLjM3NS0uNDQ0Ljg2NC0uNjA4IDEuMjVhMTguMjcgMTguMjcgMCAwMC01LjQ4NyAwYy0uMTY1LS4zOTctLjQwNC0uODg1LS42MTgtMS4yNWEuMDc3LjA3NyAwIDAwLS4wNzktLjAzN0ExOS43NCAxOS43NCAwIDAwMy42NzcgNC4zN2EuMDcuMDcgMCAwMC0uMDMyLjAyN0MuNTMzIDkuMDQ2LS4zMiAxMy41OC4wOTkgMTguMDU3YS4wOC4wOCAwIDAwLjAzMS4wNTdBMTkuOSAxOS45IDAgMDA2LjA3MyAyMWEuMDc4LjA3OCAwIDAwLjA4NC0uMDI4IDEzLjQgMTMuNCAwIDAwMS4xNTUtMi4xLjA3Ni4wNzYgMCAwMC0uMDQxLS4xMDYgMTMuMSAxMy4xIDAgMDEtMS44NzItLjg5Mi4wNzcuMDc3IDAgMDEtLjAwOC0uMTI4IDE0IDE0IDAgMDAuMzctLjI5Mi4wNzQuMDc0IDAgMDEuMDc3LS4wMWMzLjkyNyAxLjc5MyA4LjE4IDEuNzkzIDEyLjA2IDAgYS4wNzQuMDc0IDAgMDEuMDc4LjAwOS4xMTkuMDk5LjI0Ni4xOTguMzczLjI5MmEuMDc3LjA3NyAwIDAxLS4wMDYuMTI3IDEyLjMgMTIuMyAwIDAxLTEuODczLjg5Mi4wNzcuMDc3IDAgMDAtLjA0MS4xMDdjMy43NDQgMS40MDMgMS4xNTUgMi4xLS4wODQuMDI4YS4wNzguMDc4IDAgMDAxOS45MDItMS45MDMuMDc2LjA3NiAwIDAwLjAzLS4wNTdjLjUzNy00LjU4LS45MDQtOC41NTMtMy44MjMtMTIuMDU3YS4wNi4wNiAwIDAwLS4wMzEtLjAyOHpNOC4wMiAxNS4yNzhjLTEuMTgzIDAtMi4xNTctMS4wODUtMi4xNTctMi40MiAwLTEuMzMzLjk1Ni0yLjQxOSAyLjE1Ny0yLjQxOSAxLjIxIDAgMi4xNzYgMS4wOTYgMi4xNTcgMi40MiAwIDEuMzM0LS45NTYgMi40MTktMi4xNTcgMi40MTl6bTcuOTc1IDBjLTEuMTgzIDAtMi4xNTctMS4wODUtMi4xNTctMi40MiAwLTEuMzMzLjk1NS0yLjQxOSAyLjE1Ny0yLjQxOXMyLjE1NyAxLjA5NiAyLjE1NyAyLjQyYzAgMS4zMzQtLjk1NiAyLjQxOS0yLjE1NyAyLjQxOXoiLz48L3N2Zz4=';
 
         add_menu_page(
-            'Discord Bot - JLG',
-            'Discord Bot',
+            __('Discord Bot - JLG', 'discord-bot-jlg'),
+            __('Discord Bot', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-jlg',
             array($this, 'options_page'),
@@ -29,8 +29,8 @@ class Discord_Bot_JLG_Admin {
 
         add_submenu_page(
             'discord-bot-jlg',
-            'Configuration',
-            'Configuration',
+            __('Configuration', 'discord-bot-jlg'),
+            __('Configuration', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-jlg',
             array($this, 'options_page')
@@ -38,8 +38,8 @@ class Discord_Bot_JLG_Admin {
 
         add_submenu_page(
             'discord-bot-jlg',
-            'Guide & Démo',
-            'Guide & Démo',
+            __('Guide & Démo', 'discord-bot-jlg'),
+            __('Guide & Démo', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-demo',
             array($this, 'demo_page')
@@ -57,14 +57,14 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_section(
             'discord_stats_api_section',
-            'Configuration Discord API',
+            __('Configuration Discord API', 'discord-bot-jlg'),
             array($this, 'api_section_callback'),
             'discord_stats_settings'
         );
 
         add_settings_field(
             'server_id',
-            'ID du Serveur Discord',
+            __('ID du Serveur Discord', 'discord-bot-jlg'),
             array($this, 'server_id_render'),
             'discord_stats_settings',
             'discord_stats_api_section'
@@ -72,7 +72,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'bot_token',
-            'Token du Bot Discord',
+            __('Token du Bot Discord', 'discord-bot-jlg'),
             array($this, 'bot_token_render'),
             'discord_stats_settings',
             'discord_stats_api_section'
@@ -80,14 +80,14 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_section(
             'discord_stats_display_section',
-            'Options d\'affichage',
+            __('Options d\'affichage', 'discord-bot-jlg'),
             array($this, 'display_section_callback'),
             'discord_stats_settings'
         );
 
         add_settings_field(
             'demo_mode',
-            'Mode démonstration',
+            __('Mode démonstration', 'discord-bot-jlg'),
             array($this, 'demo_mode_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -95,7 +95,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'show_online',
-            'Afficher les membres en ligne',
+            __('Afficher les membres en ligne', 'discord-bot-jlg'),
             array($this, 'show_online_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -103,7 +103,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'show_total',
-            'Afficher le total des membres',
+            __('Afficher le total des membres', 'discord-bot-jlg'),
             array($this, 'show_total_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -111,7 +111,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'widget_title',
-            'Titre du widget',
+            __('Titre du widget', 'discord-bot-jlg'),
             array($this, 'widget_title_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -119,7 +119,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'cache_duration',
-            'Durée du cache (secondes)',
+            __('Durée du cache (secondes)', 'discord-bot-jlg'),
             array($this, 'cache_duration_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -127,7 +127,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'custom_css',
-            'CSS personnalisé',
+            __('CSS personnalisé', 'discord-bot-jlg'),
             array($this, 'custom_css_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -187,7 +187,7 @@ class Discord_Bot_JLG_Admin {
     public function api_section_callback() {
         ?>
         <div style="background: #f0f4ff; padding: 20px; border-radius: 8px; margin: 20px 0;">
-            <h3 style="margin-top: 0;">📚 Guide étape par étape</h3>
+            <h3 style="margin-top: 0;"><?php echo esc_html__('📚 Guide étape par étape', 'discord-bot-jlg'); ?></h3>
             <?php
             $this->render_api_steps();
             $this->render_api_previews();
@@ -200,48 +200,65 @@ class Discord_Bot_JLG_Admin {
      * Affiche les étapes de configuration de l'API Discord.
      */
     private function render_api_steps() {
+        $developer_portal_url = 'https://discord.com/developers/applications';
         ?>
-        <h4>Étape 1 : Créer un Bot Discord</h4>
+        <h4><?php esc_html_e('Étape 1 : Créer un Bot Discord', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Rendez-vous sur <a href="https://discord.com/developers/applications" target="_blank" style="color: #5865F2;">Discord Developer Portal</a></li>
-            <li>Cliquez sur <strong>"New Application"</strong> en haut à droite</li>
-            <li>Donnez un nom à votre application (ex: "Stats Bot")</li>
-            <li>Dans le menu de gauche, cliquez sur <strong>"Bot"</strong></li>
-            <li>Cliquez sur <strong>"Add Bot"</strong></li>
-            <li>Sous "Token", cliquez sur <strong>"Copy"</strong> pour copier le token du bot</li>
-            <li>⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez jamais !</li>
+            <li>
+                <?php
+                printf(
+                    wp_kses(
+                        __('Rendez-vous sur <a href="%1$s" target="_blank" style="color: #5865F2;">Discord Developer Portal</a>', 'discord-bot-jlg'),
+                        array(
+                            'a' => array(
+                                'href'   => array(),
+                                'style'  => array(),
+                                'target' => array(),
+                            ),
+                        )
+                    ),
+                    esc_url($developer_portal_url)
+                );
+                ?>
+            </li>
+            <li><?php esc_html_e('Cliquez sur "New Application" en haut à droite', 'discord-bot-jlg'); ?></li>
+            <li><?php esc_html_e('Donnez un nom à votre application (ex: "Stats Bot")', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses(__('Dans le menu de gauche, cliquez sur <strong>"Bot"</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php echo wp_kses(__('Cliquez sur <strong>"Add Bot"</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php echo wp_kses(__('Sous "Token", cliquez sur <strong>"Copy"</strong> pour copier le token du bot', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php echo wp_kses(__('⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez jamais !', 'discord-bot-jlg'), array('strong' => array())); ?></li>
         </ol>
 
-        <h4>Étape 2 : Inviter le Bot sur votre serveur</h4>
+        <h4><?php esc_html_e('Étape 2 : Inviter le Bot sur votre serveur', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Dans le menu de gauche, allez dans <strong>"OAuth2"</strong> > <strong>"URL Generator"</strong></li>
-            <li>Dans "Scopes", cochez <strong>"bot"</strong></li>
-            <li>Dans "Bot Permissions", sélectionnez :</li>
+            <li><?php echo wp_kses(__('Dans le menu de gauche, allez dans <strong>"OAuth2"</strong> &gt; <strong>"URL Generator"</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php echo wp_kses(__('Dans "Scopes", cochez <strong>"bot"</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php echo wp_kses(__('Dans "Bot Permissions", sélectionnez :', 'discord-bot-jlg'), array()); ?></li>
                 <ul>
-                    <li>✅ View Channels</li>
-                    <li>✅ Read Messages</li>
-                    <li>✅ Send Messages (optionnel)</li>
+                    <li><?php esc_html_e('✅ View Channels', 'discord-bot-jlg'); ?></li>
+                    <li><?php esc_html_e('✅ Read Messages', 'discord-bot-jlg'); ?></li>
+                    <li><?php esc_html_e('✅ Send Messages (optionnel)', 'discord-bot-jlg'); ?></li>
                 </ul>
-            <li>Copiez l'URL générée en bas de la page</li>
-            <li>Ouvrez cette URL dans votre navigateur</li>
-            <li>Sélectionnez votre serveur et cliquez sur <strong>"Autoriser"</strong></li>
+            <li><?php esc_html_e("Copiez l'URL générée en bas de la page", 'discord-bot-jlg'); ?></li>
+            <li><?php esc_html_e('Ouvrez cette URL dans votre navigateur', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses(__('Sélectionnez votre serveur et cliquez sur <strong>"Autoriser"</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
         </ol>
 
-        <h4>Étape 3 : Obtenir l'ID de votre serveur</h4>
+        <h4><?php esc_html_e("Étape 3 : Obtenir l'ID de votre serveur", 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Ouvrez Discord (application ou web)</li>
-            <li>Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)</li>
-            <li>Dans <strong>"Avancés"</strong>, activez <strong>"Mode développeur"</strong></li>
-            <li>Retournez sur votre serveur</li>
-            <li>Faites un <strong>clic droit sur le nom du serveur</strong></li>
-            <li>Cliquez sur <strong>"Copier l'ID"</strong></li>
+            <li><?php esc_html_e('Ouvrez Discord (application ou web)', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses(__('Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php echo wp_kses(__('Dans <strong>"Avancés"</strong>, activez <strong>"Mode développeur"</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php esc_html_e('Retournez sur votre serveur', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses(__('Faites un <strong>clic droit sur le nom du serveur</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php echo wp_kses(__('Cliquez sur <strong>"Copier l\'ID"</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
         </ol>
 
-        <h4>Étape 4 : Activer le Widget (optionnel mais recommandé)</h4>
+        <h4><?php esc_html_e('Étape 4 : Activer le Widget (optionnel mais recommandé)', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Dans Discord, allez dans <strong>Paramètres du serveur</strong></li>
-            <li>Dans <strong>"Widget"</strong>, activez <strong>"Activer le widget du serveur"</strong></li>
-            <li>Cela permet une méthode de fallback si le bot a des problèmes</li>
+            <li><?php echo wp_kses(__('Dans Discord, allez dans <strong>Paramètres du serveur</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php echo wp_kses(__('Dans <strong>"Widget"</strong>, activez <strong>"Activer le widget du serveur"</strong>', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+            <li><?php esc_html_e('Cela permet une méthode de fallback si le bot a des problèmes', 'discord-bot-jlg'); ?></li>
         </ol>
         <?php
     }
@@ -252,10 +269,15 @@ class Discord_Bot_JLG_Admin {
     private function render_api_previews() {
         ?>
         <div style="background: #fff3cd; padding: 10px; border-radius: 4px; margin-top: 15px;">
-            <strong>💡 Conseil :</strong> Après avoir rempli les champs ci-dessous, utilisez le bouton "Tester la connexion" pour vérifier que tout fonctionne !
+            <?php
+            echo wp_kses(
+                __('<strong>💡 Conseil :</strong> Après avoir rempli les champs ci-dessous, utilisez le bouton "Tester la connexion" pour vérifier que tout fonctionne !', 'discord-bot-jlg'),
+                array('strong' => array())
+            );
+            ?>
             <?php
             $this->render_preview_block(
-                'Avec logo Discord officiel :',
+                __('Avec logo Discord officiel :', 'discord-bot-jlg'),
                 '[discord_stats demo="true" show_discord_icon="true" discord_icon_position="left"]',
                 array(
                     'container_style' => 'margin: 20px 0;',
@@ -263,7 +285,7 @@ class Discord_Bot_JLG_Admin {
             );
 
             $this->render_preview_block(
-                'Logo Discord centré en haut :',
+                __('Logo Discord centré en haut :', 'discord-bot-jlg'),
                 '[discord_stats demo="true" show_discord_icon="true" discord_icon_position="top" align="center" theme="dark"]',
                 array(
                     'container_style' => 'margin: 20px 0;',
@@ -275,7 +297,10 @@ class Discord_Bot_JLG_Admin {
     }
 
     public function display_section_callback() {
-        echo '<p>Personnalisez l\'affichage des statistiques Discord.</p>';
+        printf(
+            '<p>%s</p>',
+            esc_html__("Personnalisez l'affichage des statistiques Discord.", 'discord-bot-jlg')
+        );
     }
 
     public function server_id_render() {
@@ -284,7 +309,7 @@ class Discord_Bot_JLG_Admin {
         <input type="text" name="<?php echo esc_attr($this->option_name); ?>[server_id]"
                value="<?php echo esc_attr(isset($options['server_id']) ? $options['server_id'] : ''); ?>"
                class="regular-text" />
-        <p class="description">L'ID de votre serveur Discord</p>
+        <p class="description"><?php echo esc_html__("L'ID de votre serveur Discord", 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -294,7 +319,7 @@ class Discord_Bot_JLG_Admin {
         <input type="password" name="<?php echo esc_attr($this->option_name); ?>[bot_token]"
                value="<?php echo esc_attr(isset($options['bot_token']) ? $options['bot_token'] : ''); ?>"
                class="regular-text" />
-        <p class="description">Le token de votre bot Discord (gardez-le secret !)</p>
+        <p class="description"><?php echo esc_html__("Le token de votre bot Discord (gardez-le secret !)", 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -304,8 +329,8 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[demo_mode]"
                value="1" <?php checked($demo_mode, 1); ?> />
-        <label>Activer le mode démonstration (affiche des données fictives pour tester l'apparence)</label>
-        <p class="description">🎨 Parfait pour tester les styles et dispositions sans configuration Discord</p>
+        <label><?php echo esc_html__("Activer le mode démonstration (affiche des données fictives pour tester l'apparence)", 'discord-bot-jlg'); ?></label>
+        <p class="description"><?php echo esc_html__('🎨 Parfait pour tester les styles et dispositions sans configuration Discord', 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -315,7 +340,7 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_online]"
                value="1" <?php checked($value, 1); ?> />
-        <label>Afficher le nombre d'utilisateurs en ligne</label>
+        <label><?php echo esc_html__("Afficher le nombre d'utilisateurs en ligne", 'discord-bot-jlg'); ?></label>
         <?php
     }
 
@@ -325,7 +350,7 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_total]"
                value="1" <?php checked($value, 1); ?> />
-        <label>Afficher le nombre total de membres</label>
+        <label><?php echo esc_html__("Afficher le nombre total de membres", 'discord-bot-jlg'); ?></label>
         <?php
     }
 
@@ -344,7 +369,7 @@ class Discord_Bot_JLG_Admin {
         <input type="number" name="<?php echo esc_attr($this->option_name); ?>[cache_duration]"
                value="<?php echo esc_attr(isset($options['cache_duration']) ? $options['cache_duration'] : ''); ?>"
                min="60" max="3600" class="small-text" />
-        <p class="description">Minimum 60 secondes, maximum 3600 secondes (1 heure)</p>
+        <p class="description"><?php echo esc_html__('Minimum 60 secondes, maximum 3600 secondes (1 heure)', 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -352,14 +377,14 @@ class Discord_Bot_JLG_Admin {
         $options = get_option($this->option_name);
         ?>
         <textarea name="<?php echo esc_attr($this->option_name); ?>[custom_css]" rows="5" cols="50"><?php echo esc_textarea(isset($options['custom_css']) ? $options['custom_css'] : ''); ?></textarea>
-        <p class="description">CSS personnalisé pour styliser l'affichage</p>
+        <p class="description"><?php echo esc_html__("CSS personnalisé pour styliser l'affichage", 'discord-bot-jlg'); ?></p>
         <?php
     }
 
     public function options_page() {
         ?>
         <div class="wrap">
-            <h1>🎮 Discord Bot - JLG - Configuration</h1>
+            <h1><?php echo esc_html__('🎮 Discord Bot - JLG - Configuration', 'discord-bot-jlg'); ?></h1>
             <?php $this->handle_test_connection_request(); ?>
 
             <div style="display: flex; gap: 20px; margin-top: 20px;">
@@ -420,14 +445,14 @@ class Discord_Bot_JLG_Admin {
     private function render_connection_test_panel() {
         ?>
         <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
-            <h3 style="margin-top: 0;">🔧 Test de connexion</h3>
-            <p>Vérifiez que votre configuration fonctionne :</p>
+            <h3 style="margin-top: 0;"><?php echo esc_html__('🔧 Test de connexion', 'discord-bot-jlg'); ?></h3>
+            <p><?php echo esc_html__('Vérifiez que votre configuration fonctionne :', 'discord-bot-jlg'); ?></p>
             <form method="get" action="<?php echo esc_url(admin_url('admin.php')); ?>">
                 <input type="hidden" name="page" value="discord-bot-jlg" />
                 <input type="hidden" name="test_connection" value="1" />
                 <?php wp_nonce_field('discord_test_connection'); ?>
                 <p>
-                    <button type="submit" class="button button-secondary" style="width: 100%;">Tester la connexion</button>
+                    <button type="submit" class="button button-secondary" style="width: 100%;"><?php echo esc_html__('Tester la connexion', 'discord-bot-jlg'); ?></button>
                 </p>
             </form>
         </div>
@@ -440,21 +465,21 @@ class Discord_Bot_JLG_Admin {
     private function render_quick_links_panel() {
         ?>
         <div style="background: #e8f5e9; padding: 20px; border-radius: 8px;">
-            <h3 style="margin-top: 0;">🚀 Liens rapides</h3>
+            <h3 style="margin-top: 0;"><?php echo esc_html__('🚀 Liens rapides', 'discord-bot-jlg'); ?></h3>
             <ul style="list-style: none; padding: 0;">
                 <li style="margin-bottom: 10px;">
                     <a href="<?php echo esc_url(admin_url('admin.php?page=discord-bot-demo')); ?>" class="button button-primary" style="width: 100%;">
-                        📖 Guide & Démo
+                        <?php echo esc_html__('📖 Guide & Démo', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
                 <li style="margin-bottom: 10px;">
                     <a href="https://discord.com/developers/applications" target="_blank" class="button" style="width: 100%;">
-                        🔗 Discord Developer Portal
+                        <?php echo esc_html__('🔗 Discord Developer Portal', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
                 <li>
                     <a href="<?php echo esc_url(admin_url('widgets.php')); ?>" class="button" style="width: 100%;">
-                        📐 Gérer les Widgets
+                        <?php echo esc_html__('📐 Gérer les Widgets', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
             </ul>
@@ -468,7 +493,7 @@ class Discord_Bot_JLG_Admin {
     private function render_admin_footer_note() {
         ?>
         <div style="margin-top: 30px; padding: 15px; background: #f0f0f0; border-radius: 8px; text-align: center;">
-            <p style="margin: 0;">Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse</p>
+            <p style="margin: 0;"><?php echo esc_html__('Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse', 'discord-bot-jlg'); ?></p>
         </div>
         <?php
     }
@@ -476,7 +501,7 @@ class Discord_Bot_JLG_Admin {
     public function demo_page() {
         ?>
         <div class="wrap">
-            <h1>📖 Guide & Démonstration</h1>
+            <h1><?php echo esc_html__('📖 Guide & Démonstration', 'discord-bot-jlg'); ?></h1>
             <?php $this->render_demo_intro_notice(); ?>
 
             <hr style="margin: 30px 0;">
@@ -503,7 +528,14 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_intro_notice() {
         ?>
         <div style="background: #fff3cd; padding: 10px 20px; border-radius: 8px; margin: 20px 0;">
-            <p><strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode démo. Vous pouvez les copier-coller directement !</p>
+            <p>
+                <?php
+                echo wp_kses(
+                    __('<strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode démo. Vous pouvez les copier-coller directement !', 'discord-bot-jlg'),
+                    array('strong' => array())
+                );
+                ?>
+            </p>
         </div>
         <?php
     }
@@ -514,35 +546,35 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_previews() {
         $previews = array(
             array(
-                'title' => 'Standard horizontal :',
+                'title' => __('Standard horizontal :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true"]',
             ),
             array(
-                'title' => 'Vertical pour sidebar :',
+                'title' => __('Vertical pour sidebar :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" layout="vertical" theme="minimal"]',
                 'inner_wrapper_style' => 'max-width: 300px;',
             ),
             array(
-                'title' => 'Compact mode sombre :',
+                'title' => __('Compact mode sombre :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" compact="true" theme="dark"]',
             ),
             array(
-                'title' => 'Avec titre personnalisé :',
+                'title' => __('Avec titre personnalisé :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" show_title="true" title="🎮 Notre Communauté Gaming" align="center"]',
             ),
             array(
-                'title' => 'Icônes personnalisées :',
+                'title' => __('Icônes personnalisées :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" icon_online="🔥" label_online="Actifs" icon_total="⚔️" label_total="Guerriers"]',
             ),
             array(
-                'title' => 'Minimaliste (nombres uniquement) :',
+                'title' => __('Minimaliste (nombres uniquement) :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" hide_labels="true" hide_icons="true" theme="minimal"]',
             ),
         );
         ?>
         <div style="background: #e3f2fd; padding: 20px; border-radius: 8px;">
-            <h2>🎨 Prévisualisation en direct</h2>
-            <p>Testez différentes configurations visuelles :</p>
+            <h2><?php echo esc_html__('🎨 Prévisualisation en direct', 'discord-bot-jlg'); ?></h2>
+            <p><?php echo esc_html__('Testez différentes configurations visuelles :', 'discord-bot-jlg'); ?></p>
             <?php
             foreach ($previews as $preview) {
                 $options = array('container_style' => 'margin: 20px 0;');
@@ -560,15 +592,73 @@ class Discord_Bot_JLG_Admin {
      * Affiche le guide détaillé d'utilisation et les exemples.
      */
     private function render_demo_guide_section() {
+        $appearance_items = array(
+            __('<strong>layout</strong> : horizontal, vertical, compact', 'discord-bot-jlg'),
+            __('<strong>theme</strong> : discord, dark, light, minimal', 'discord-bot-jlg'),
+            __('<strong>align</strong> : left, center, right', 'discord-bot-jlg'),
+            __('<strong>width</strong> : largeur CSS (ex: "300px", "100%")', 'discord-bot-jlg'),
+            __('<strong>compact</strong> : true/false (version réduite)', 'discord-bot-jlg'),
+            __('<strong>animated</strong> : true/false (animations hover)', 'discord-bot-jlg'),
+            __('<strong>class</strong> : classes CSS additionnelles', 'discord-bot-jlg'),
+        );
+
+        $logo_items = array(
+            __('<strong>show_discord_icon</strong> : true/false (afficher le logo officiel)', 'discord-bot-jlg'),
+            __('<strong>discord_icon_position</strong> : left, right, top (position du logo)', 'discord-bot-jlg'),
+        );
+
+        $data_items = array(
+            __('<strong>show_online</strong> : true/false', 'discord-bot-jlg'),
+            __('<strong>show_total</strong> : true/false', 'discord-bot-jlg'),
+            __('<strong>show_title</strong> : true/false', 'discord-bot-jlg'),
+            __('<strong>title</strong> : texte du titre', 'discord-bot-jlg'),
+            __('<strong>hide_labels</strong> : true/false', 'discord-bot-jlg'),
+            __('<strong>hide_icons</strong> : true/false', 'discord-bot-jlg'),
+        );
+
+        $custom_text_items = array(
+            __('<strong>icon_online</strong> : emoji/texte (défaut: 🟢)', 'discord-bot-jlg'),
+            __('<strong>icon_total</strong> : emoji/texte (défaut: 👥)', 'discord-bot-jlg'),
+            __('<strong>label_online</strong> : texte personnalisé', 'discord-bot-jlg'),
+            __('<strong>label_total</strong> : texte personnalisé', 'discord-bot-jlg'),
+        );
+
+        $technical_items = array(
+            __('<strong>refresh</strong> : true/false (auto-actualisation)', 'discord-bot-jlg'),
+            __('<strong>refresh_interval</strong> : secondes (minimum 10 secondes / 10 000 ms)', 'discord-bot-jlg'),
+            __('<strong>demo</strong> : true/false (mode démonstration)', 'discord-bot-jlg'),
+            __('<strong>border_radius</strong> : pixels (coins arrondis)', 'discord-bot-jlg'),
+            __('<strong>gap</strong> : pixels (espace entre éléments)', 'discord-bot-jlg'),
+            __('<strong>padding</strong> : pixels (espacement interne)', 'discord-bot-jlg'),
+        );
+
+        $recommended_configs = array(
+            array(
+                'label' => __('Pour une sidebar :', 'discord-bot-jlg'),
+                'code'  => '[discord_stats layout="vertical" show_discord_icon="true" discord_icon_position="top" compact="true"]',
+            ),
+            array(
+                'label' => __('Pour un header :', 'discord-bot-jlg'),
+                'code'  => '[discord_stats show_discord_icon="true" show_title="true" title="Join us!" align="center" width="100%"]',
+            ),
+            array(
+                'label' => __('Pour un footer :', 'discord-bot-jlg'),
+                'code'  => '[discord_stats theme="dark" show_discord_icon="true" compact="true"]',
+            ),
+            array(
+                'label' => __('Style gaming :', 'discord-bot-jlg'),
+                'code'  => '[discord_stats theme="dark" icon_online="🎮" label_online="Players" show_discord_icon="true"]',
+            ),
+        );
         ?>
         <div style="background: #e8f5e9; padding: 20px; border-radius: 8px;">
-            <h2>📖 Guide d'utilisation</h2>
+            <h2><?php echo esc_html__('📖 Guide d\'utilisation', 'discord-bot-jlg'); ?></h2>
 
-            <h3>Option 1 : Shortcode (avec paramètres)</h3>
-            <p>Copiez ce code dans n'importe quelle page ou article :</p>
+            <h3><?php echo esc_html__('Option 1 : Shortcode (avec paramètres)', 'discord-bot-jlg'); ?></h3>
+            <p><?php echo esc_html__('Copiez ce code dans n\'importe quelle page ou article :', 'discord-bot-jlg'); ?></p>
             <code style="background: white; padding: 10px; display: inline-block; border-radius: 4px;">[discord_stats]</code>
 
-            <h4>Exemples avec paramètres :</h4>
+            <h4><?php echo esc_html__('Exemples avec paramètres :', 'discord-bot-jlg'); ?></h4>
             <pre style="background: white; padding: 15px; border-radius: 4px; overflow-x: auto;">// BASIQUES
 // Layout vertical pour sidebar
 [discord_stats layout="vertical"]
@@ -615,83 +705,70 @@ class Discord_Bot_JLG_Admin {
 // MODE DÉMO (pour tester l'apparence)
 [discord_stats demo="true" show_discord_icon="true" theme="dark" layout="vertical"]</pre>
 
-            <p style="margin-top: 10px;"><em>ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10&nbsp;secondes (10 000&nbsp;ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429.</em></p>
+            <p style="margin-top: 10px;"><em><?php echo wp_kses_post(__('ℹ️ L\'auto-refresh nécessite un intervalle d\'au moins 10&nbsp;secondes (10 000&nbsp;ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429.', 'discord-bot-jlg')); ?></em></p>
 
-            <h4>Tous les paramètres disponibles :</h4>
+            <h4><?php echo esc_html__('Tous les paramètres disponibles :', 'discord-bot-jlg'); ?></h4>
             <div style="background: white; padding: 15px; border-radius: 4px;">
-                <h5>🎨 Apparence & Layout :</h5>
+                <h5><?php echo esc_html__('🎨 Apparence & Layout :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>layout</strong> : horizontal, vertical, compact</li>
-                    <li><strong>theme</strong> : discord, dark, light, minimal</li>
-                    <li><strong>align</strong> : left, center, right</li>
-                    <li><strong>width</strong> : largeur CSS (ex: "300px", "100%")</li>
-                    <li><strong>compact</strong> : true/false (version réduite)</li>
-                    <li><strong>animated</strong> : true/false (animations hover)</li>
-                    <li><strong>class</strong> : classes CSS additionnelles</li>
+                    <?php foreach ($appearance_items as $item) : ?>
+                        <li><?php echo wp_kses($item, array('strong' => array())); ?></li>
+                    <?php endforeach; ?>
                 </ul>
 
-                <h5>🎯 Logo Discord :</h5>
+                <h5><?php echo esc_html__('🎯 Logo Discord :', 'discord-bot-jlg'); ?></h5>
                 <ul>
-                    <li><strong>show_discord_icon</strong> : true/false (afficher le logo officiel)</li>
-                    <li><strong>discord_icon_position</strong> : left, right, top (position du logo)</li>
+                    <?php foreach ($logo_items as $item) : ?>
+                        <li><?php echo wp_kses($item, array('strong' => array())); ?></li>
+                    <?php endforeach; ?>
                 </ul>
 
-                <h5>📊 Données affichées :</h5>
+                <h5><?php echo esc_html__('📊 Données affichées :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>show_online</strong> : true/false</li>
-                    <li><strong>show_total</strong> : true/false</li>
-                    <li><strong>show_title</strong> : true/false</li>
-                    <li><strong>title</strong> : texte du titre</li>
-                    <li><strong>hide_labels</strong> : true/false</li>
-                    <li><strong>hide_icons</strong> : true/false</li>
+                    <?php foreach ($data_items as $item) : ?>
+                        <li><?php echo wp_kses($item, array('strong' => array())); ?></li>
+                    <?php endforeach; ?>
                 </ul>
 
-                <h5>✏️ Personnalisation textes/icônes :</h5>
+                <h5><?php echo esc_html__('✏️ Personnalisation textes/icônes :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>icon_online</strong> : emoji/texte (défaut: 🟢)</li>
-                    <li><strong>icon_total</strong> : emoji/texte (défaut: 👥)</li>
-                    <li><strong>label_online</strong> : texte personnalisé</li>
-                    <li><strong>label_total</strong> : texte personnalisé</li>
+                    <?php foreach ($custom_text_items as $item) : ?>
+                        <li><?php echo wp_kses($item, array('strong' => array())); ?></li>
+                    <?php endforeach; ?>
                 </ul>
 
-                <h5>⚙️ Paramètres techniques :</h5>
+                <h5><?php echo esc_html__('⚙️ Paramètres techniques :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>refresh</strong> : true/false (auto-actualisation)</li>
-                    <li><strong>refresh_interval</strong> : secondes (minimum 10&nbsp;secondes / 10 000&nbsp;ms)</li>
-                    <li><strong>demo</strong> : true/false (mode démonstration)</li>
-                    <li><strong>border_radius</strong> : pixels (coins arrondis)</li>
-                    <li><strong>gap</strong> : pixels (espace entre éléments)</li>
-                    <li><strong>padding</strong> : pixels (espacement interne)</li>
+                    <?php foreach ($technical_items as $item) : ?>
+                        <li><?php echo wp_kses($item, array('strong' => array())); ?></li>
+                    <?php endforeach; ?>
                 </ul>
             </div>
 
-            <h3>Option 2 : Widget</h3>
-            <p>Allez dans <strong>Apparence > Widgets</strong> et ajoutez le widget <strong>"Discord Bot - JLG"</strong> dans votre sidebar</p>
+            <h3><?php echo esc_html__('Option 2 : Widget', 'discord-bot-jlg'); ?></h3>
+            <p>
+                <?php
+                echo wp_kses(
+                    __('Allez dans <strong>Apparence &gt; Widgets</strong> et ajoutez le widget <strong>"Discord Bot - JLG"</strong> dans votre sidebar', 'discord-bot-jlg'),
+                    array('strong' => array())
+                );
+                ?>
+            </p>
 
-            <h3>Option 3 : Code PHP</h3>
-            <p>Pour les développeurs, dans vos templates PHP :</p>
+            <h3><?php echo esc_html__('Option 3 : Code PHP', 'discord-bot-jlg'); ?></h3>
+            <p><?php echo esc_html__('Pour les développeurs, dans vos templates PHP :', 'discord-bot-jlg'); ?></p>
             <code style="background: white; padding: 10px; display: block; border-radius: 4px;">
                 &lt;?php echo do_shortcode('[discord_stats show_discord_icon="true"]'); ?&gt;
             </code>
 
-            <h3>💡 Configurations recommandées</h3>
+            <h3><?php echo esc_html__('💡 Configurations recommandées', 'discord-bot-jlg'); ?></h3>
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 15px;">
-                <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour une sidebar :</strong><br>
-                    <code style="font-size: 12px;">[discord_stats layout="vertical" show_discord_icon="true" discord_icon_position="top" compact="true"]</code>
-                </div>
-                <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour un header :</strong><br>
-                    <code style="font-size: 12px;">[discord_stats show_discord_icon="true" show_title="true" title="Join us!" align="center" width="100%"]</code>
-                </div>
-                <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour un footer :</strong><br>
-                    <code style="font-size: 12px;">[discord_stats theme="dark" show_discord_icon="true" compact="true"]</code>
-                </div>
-                <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Style gaming :</strong><br>
-                    <code style="font-size: 12px;">[discord_stats theme="dark" icon_online="🎮" label_online="Players" show_discord_icon="true"]</code>
-                </div>
+                <?php foreach ($recommended_configs as $config) : ?>
+                    <div style="background: white; padding: 15px; border-radius: 4px;">
+                        <strong><?php echo esc_html($config['label']); ?></strong><br>
+                        <code style="font-size: 12px;"><?php echo esc_html($config['code']); ?></code>
+                    </div>
+                <?php endforeach; ?>
             </div>
         </div>
         <?php
@@ -703,12 +780,12 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_troubleshooting() {
         ?>
         <div style="background: #fff8e1; padding: 20px; border-radius: 8px;">
-            <h2>❓ Dépannage</h2>
+            <h2><?php echo esc_html__('❓ Dépannage', 'discord-bot-jlg'); ?></h2>
             <ul>
-                <li><strong>Erreur de connexion ?</strong> Vérifiez que le bot est bien sur votre serveur</li>
-                <li><strong>Stats à 0 ?</strong> Assurez-vous que le widget est activé dans les paramètres Discord</li>
-                <li><strong>Token invalide ?</strong> Régénérez le token dans le Developer Portal</li>
-                <li><strong>Cache ?</strong> Les stats sont mises à jour toutes les 5 minutes par défaut</li>
+                <li><?php echo wp_kses(__('<strong>Erreur de connexion ?</strong> Vérifiez que le bot est bien sur votre serveur', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+                <li><?php echo wp_kses(__('<strong>Stats à 0 ?</strong> Assurez-vous que le widget est activé dans les paramètres Discord', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+                <li><?php echo wp_kses(__('<strong>Token invalide ?</strong> Régénérez le token dans le Developer Portal', 'discord-bot-jlg'), array('strong' => array())); ?></li>
+                <li><?php echo wp_kses(__('<strong>Cache ?</strong> Les stats sont mises à jour toutes les 5 minutes par défaut', 'discord-bot-jlg'), array('strong' => array())); ?></li>
             </ul>
         </div>
         <?php
@@ -720,10 +797,29 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_footer_note() {
         ?>
         <div style="margin-top: 30px; padding: 15px; background: #f0f0f0; border-radius: 8px; text-align: center;">
-            <p style="margin: 0;">Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse |
-               <a href="https://discord.com/developers/docs/intro" target="_blank">Documentation Discord API</a> |
-               <a href="#" onclick="return false;">Besoin d'aide ?</a>
-            </p>
+            <?php
+            $documentation_link = sprintf(
+                '<a href="%1$s" target="_blank">%2$s</a>',
+                esc_url('https://discord.com/developers/docs/intro'),
+                esc_html__('Documentation Discord API', 'discord-bot-jlg')
+            );
+
+            $help_link = sprintf(
+                '<a href="#" onclick="return false;">%s</a>',
+                esc_html__('Besoin d\'aide ?', 'discord-bot-jlg')
+            );
+
+            printf(
+                '<p style="margin: 0;">%s</p>',
+                wp_kses_post(
+                    sprintf(
+                        __('Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse | %1$s | %2$s', 'discord-bot-jlg'),
+                        $documentation_link,
+                        $help_link
+                    )
+                )
+            );
+            ?>
         </div>
         <?php
     }
@@ -759,7 +855,10 @@ class Discord_Bot_JLG_Admin {
         }
 
         if (!empty($options['demo_mode'])) {
-            echo '<div class="notice notice-info"><p>🎨 Mode démonstration activé - Les données affichées sont fictives</p></div>';
+            printf(
+                '<div class="notice notice-info"><p>%s</p></div>',
+                esc_html__('🎨 Mode démonstration activé - Les données affichées sont fictives', 'discord-bot-jlg')
+            );
             return;
         }
 
@@ -775,16 +874,29 @@ class Discord_Bot_JLG_Admin {
             $online_count = isset($stats['online']) ? (int) $stats['online'] : 0;
             $total_count  = isset($stats['total']) ? (int) $stats['total'] : 0;
 
+            $server_name_display = esc_html($server_name);
+            $online_display     = esc_html(number_format_i18n($online_count));
+            $total_display      = esc_html(number_format_i18n($total_count));
+
             printf(
-                '<div class="notice notice-success"><p>✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres</p></div>',
-                esc_html($server_name),
-                esc_html(number_format_i18n($online_count)),
-                esc_html(number_format_i18n($total_count))
+                '<div class="notice notice-success"><p>%s</p></div>',
+                sprintf(
+                    esc_html__('✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres', 'discord-bot-jlg'),
+                    $server_name_display,
+                    $online_display,
+                    $total_display
+                )
             );
         } elseif (is_array($stats) && !empty($stats['is_demo'])) {
-            echo '<div class="notice notice-warning"><p>⚠️ Pas de configuration Discord détectée. Mode démo actif.</p></div>';
+            printf(
+                '<div class="notice notice-warning"><p>%s</p></div>',
+                esc_html__('⚠️ Pas de configuration Discord détectée. Mode démo actif.', 'discord-bot-jlg')
+            );
         } else {
-            echo '<div class="notice notice-error"><p>❌ Échec de la connexion. Vérifiez vos identifiants.</p></div>';
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html__('❌ Échec de la connexion. Vérifiez vos identifiants.', 'discord-bot-jlg')
+            );
         }
     }
 

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -70,7 +70,7 @@ class Discord_Bot_JLG_API {
         $nonce = isset($_POST['_ajax_nonce']) ? sanitize_text_field(wp_unslash($_POST['_ajax_nonce'])) : '';
 
         if (empty($nonce) || !wp_verify_nonce($nonce, 'refresh_discord_stats')) {
-            wp_send_json_error('Nonce invalide', 403);
+            wp_send_json_error(esc_html__('Nonce invalide', 'discord-bot-jlg'), 403);
         }
 
         $options = get_option($this->option_name);
@@ -79,7 +79,7 @@ class Discord_Bot_JLG_API {
         }
 
         if (!empty($options['demo_mode'])) {
-            wp_send_json_error('Mode démo actif');
+            wp_send_json_error(esc_html__('Mode démo actif', 'discord-bot-jlg'));
         }
 
         $current_action = current_action();
@@ -156,7 +156,7 @@ class Discord_Bot_JLG_API {
 
         delete_transient($rate_limit_key);
 
-        wp_send_json_error('Impossible de récupérer les stats');
+        wp_send_json_error(esc_html__('Impossible de récupérer les stats', 'discord-bot-jlg'));
     }
 
     public function clear_cache() {
@@ -171,10 +171,10 @@ class Discord_Bot_JLG_API {
         $variation = sin($hour * 0.26) * 10;
 
         return array(
-            'online'    => (int) round($base_online + $variation),
-            'total'     => (int) $base_total,
-            'server_name' => 'Serveur Démo',
-            'is_demo'   => true,
+            'online'      => (int) round($base_online + $variation),
+            'total'       => (int) $base_total,
+            'server_name' => __('Serveur Démo', 'discord-bot-jlg'),
+            'is_demo'     => true,
         );
     }
 

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -41,8 +41,8 @@ class Discord_Bot_JLG_Shortcode {
                 'class'                => '',
                 'icon_online'          => '🟢',
                 'icon_total'           => '👥',
-                'label_online'         => 'En ligne',
-                'label_total'          => 'Membres',
+                'label_online'         => __('En ligne', 'discord-bot-jlg'),
+                'label_total'          => __('Membres', 'discord-bot-jlg'),
                 'hide_labels'          => 'false',
                 'hide_icons'           => 'false',
                 'border_radius'        => '8',
@@ -74,7 +74,10 @@ class Discord_Bot_JLG_Shortcode {
         }
 
         if (!is_array($stats)) {
-            return '<div class="discord-stats-error">Impossible de récupérer les stats Discord</div>';
+            return sprintf(
+                '<div class="discord-stats-error">%s</div>',
+                esc_html__('Impossible de récupérer les stats Discord', 'discord-bot-jlg')
+            );
         }
 
         $this->enqueue_assets($options);
@@ -149,7 +152,7 @@ class Discord_Bot_JLG_Shortcode {
         <div <?php echo implode(' ', $attributes); ?>>
 
             <?php if (!empty($stats['is_demo'])): ?>
-            <div class="discord-demo-badge">Mode Démo</div>
+            <div class="discord-demo-badge"><?php echo esc_html__('Mode Démo', 'discord-bot-jlg'); ?></div>
             <?php endif; ?>
 
             <?php if ($show_title): ?>

--- a/discord-bot-jlg/languages/discord-bot-jlg.pot
+++ b/discord-bot-jlg/languages/discord-bot-jlg.pot
@@ -1,0 +1,627 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Discord Bot JLG\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-17 21:42+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: xgettext\n"
+
+#: inc/class-discord-api.php:73
+msgid "Nonce invalide"
+msgstr ""
+
+#: inc/class-discord-api.php:82
+msgid "Mode démo actif"
+msgstr ""
+
+#: inc/class-discord-api.php:109
+#, php-format
+msgid "Veuillez patienter %d secondes avant la prochaine actualisation."
+msgstr ""
+
+#: inc/class-discord-api.php:151
+msgid "Actualisation en cours, veuillez réessayer dans quelques instants."
+msgstr ""
+
+#: inc/class-discord-api.php:159
+msgid "Impossible de récupérer les stats"
+msgstr ""
+
+#: inc/class-discord-api.php:176
+msgid "Serveur Démo"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:44
+msgid "En ligne"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:45
+msgid "Membres"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:79
+msgid "Impossible de récupérer les stats Discord"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:155
+msgid "Mode Démo"
+msgstr ""
+
+#: inc/class-discord-admin.php:21
+msgid "Discord Bot - JLG"
+msgstr ""
+
+#: inc/class-discord-admin.php:22
+msgid "Discord Bot"
+msgstr ""
+
+#: inc/class-discord-admin.php:32 inc/class-discord-admin.php:33
+msgid "Configuration"
+msgstr ""
+
+#: inc/class-discord-admin.php:41 inc/class-discord-admin.php:42
+msgid "Guide & Démo"
+msgstr ""
+
+#: inc/class-discord-admin.php:60
+msgid "Configuration Discord API"
+msgstr ""
+
+#: inc/class-discord-admin.php:67
+msgid "ID du Serveur Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:75
+msgid "Token du Bot Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:83
+msgid "Options d'affichage"
+msgstr ""
+
+#: inc/class-discord-admin.php:90
+msgid "Mode démonstration"
+msgstr ""
+
+#: inc/class-discord-admin.php:98
+msgid "Afficher les membres en ligne"
+msgstr ""
+
+#: inc/class-discord-admin.php:106
+msgid "Afficher le total des membres"
+msgstr ""
+
+#: inc/class-discord-admin.php:114
+msgid "Titre du widget"
+msgstr ""
+
+#: inc/class-discord-admin.php:122
+msgid "Durée du cache (secondes)"
+msgstr ""
+
+#: inc/class-discord-admin.php:130
+msgid "CSS personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:190
+msgid "📚 Guide étape par étape"
+msgstr ""
+
+#: inc/class-discord-admin.php:205
+msgid "Étape 1 : Créer un Bot Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:211
+#, php-format
+msgid ""
+"Rendez-vous sur <a href=\"%1$s\" target=\"_blank\" style=\"color: #5865F2;"
+"\">Discord Developer Portal</a>"
+msgstr ""
+
+#: inc/class-discord-admin.php:224
+msgid "Cliquez sur \"New Application\" en haut à droite"
+msgstr ""
+
+#: inc/class-discord-admin.php:225
+msgid "Donnez un nom à votre application (ex: \"Stats Bot\")"
+msgstr ""
+
+#: inc/class-discord-admin.php:226
+msgid "Dans le menu de gauche, cliquez sur <strong>\"Bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:227
+msgid "Cliquez sur <strong>\"Add Bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:228
+msgid ""
+"Sous \"Token\", cliquez sur <strong>\"Copy\"</strong> pour copier le token "
+"du bot"
+msgstr ""
+
+#: inc/class-discord-admin.php:229
+msgid ""
+"⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez "
+"jamais !"
+msgstr ""
+
+#: inc/class-discord-admin.php:232
+msgid "Étape 2 : Inviter le Bot sur votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:234
+msgid ""
+"Dans le menu de gauche, allez dans <strong>\"OAuth2\"</strong> &gt; "
+"<strong>\"URL Generator\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:235
+msgid "Dans \"Scopes\", cochez <strong>\"bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:236
+msgid "Dans \"Bot Permissions\", sélectionnez :"
+msgstr ""
+
+#: inc/class-discord-admin.php:238
+msgid "✅ View Channels"
+msgstr ""
+
+#: inc/class-discord-admin.php:239
+msgid "✅ Read Messages"
+msgstr ""
+
+#: inc/class-discord-admin.php:240
+msgid "✅ Send Messages (optionnel)"
+msgstr ""
+
+#: inc/class-discord-admin.php:242
+msgid "Copiez l'URL générée en bas de la page"
+msgstr ""
+
+#: inc/class-discord-admin.php:243
+msgid "Ouvrez cette URL dans votre navigateur"
+msgstr ""
+
+#: inc/class-discord-admin.php:244
+msgid ""
+"Sélectionnez votre serveur et cliquez sur <strong>\"Autoriser\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:247
+msgid "Étape 3 : Obtenir l'ID de votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:249
+msgid "Ouvrez Discord (application ou web)"
+msgstr ""
+
+#: inc/class-discord-admin.php:250
+msgid "Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)"
+msgstr ""
+
+#: inc/class-discord-admin.php:251
+msgid ""
+"Dans <strong>\"Avancés\"</strong>, activez <strong>\"Mode développeur\"</"
+"strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:252
+msgid "Retournez sur votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:253
+msgid "Faites un <strong>clic droit sur le nom du serveur</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:254
+msgid "Cliquez sur <strong>\"Copier l'ID\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:257
+msgid "Étape 4 : Activer le Widget (optionnel mais recommandé)"
+msgstr ""
+
+#: inc/class-discord-admin.php:259
+msgid "Dans Discord, allez dans <strong>Paramètres du serveur</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:260
+msgid ""
+"Dans <strong>\"Widget\"</strong>, activez <strong>\"Activer le widget du "
+"serveur\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:261
+msgid "Cela permet une méthode de fallback si le bot a des problèmes"
+msgstr ""
+
+#: inc/class-discord-admin.php:274
+msgid ""
+"<strong>💡 Conseil :</strong> Après avoir rempli les champs ci-dessous, "
+"utilisez le bouton \"Tester la connexion\" pour vérifier que tout "
+"fonctionne !"
+msgstr ""
+
+#: inc/class-discord-admin.php:280
+msgid "Avec logo Discord officiel :"
+msgstr ""
+
+#: inc/class-discord-admin.php:288
+msgid "Logo Discord centré en haut :"
+msgstr ""
+
+#: inc/class-discord-admin.php:302
+msgid "Personnalisez l'affichage des statistiques Discord."
+msgstr ""
+
+#: inc/class-discord-admin.php:312
+msgid "L'ID de votre serveur Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:322
+msgid "Le token de votre bot Discord (gardez-le secret !)"
+msgstr ""
+
+#: inc/class-discord-admin.php:332
+msgid ""
+"Activer le mode démonstration (affiche des données fictives pour tester "
+"l'apparence)"
+msgstr ""
+
+#: inc/class-discord-admin.php:333
+msgid ""
+"🎨 Parfait pour tester les styles et dispositions sans configuration Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:343
+msgid "Afficher le nombre d'utilisateurs en ligne"
+msgstr ""
+
+#: inc/class-discord-admin.php:353
+msgid "Afficher le nombre total de membres"
+msgstr ""
+
+#: inc/class-discord-admin.php:372
+msgid "Minimum 60 secondes, maximum 3600 secondes (1 heure)"
+msgstr ""
+
+#: inc/class-discord-admin.php:380
+msgid "CSS personnalisé pour styliser l'affichage"
+msgstr ""
+
+#: inc/class-discord-admin.php:387
+msgid "🎮 Discord Bot - JLG - Configuration"
+msgstr ""
+
+#: inc/class-discord-admin.php:448
+msgid "🔧 Test de connexion"
+msgstr ""
+
+#: inc/class-discord-admin.php:449
+msgid "Vérifiez que votre configuration fonctionne :"
+msgstr ""
+
+#: inc/class-discord-admin.php:455
+msgid "Tester la connexion"
+msgstr ""
+
+#: inc/class-discord-admin.php:468
+msgid "🚀 Liens rapides"
+msgstr ""
+
+#: inc/class-discord-admin.php:472
+msgid "📖 Guide & Démo"
+msgstr ""
+
+#: inc/class-discord-admin.php:477
+msgid "🔗 Discord Developer Portal"
+msgstr ""
+
+#: inc/class-discord-admin.php:482
+msgid "📐 Gérer les Widgets"
+msgstr ""
+
+#: inc/class-discord-admin.php:496
+msgid "Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse"
+msgstr ""
+
+#: inc/class-discord-admin.php:504
+msgid "📖 Guide & Démonstration"
+msgstr ""
+
+#: inc/class-discord-admin.php:534
+msgid ""
+"<strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode "
+"démo. Vous pouvez les copier-coller directement !"
+msgstr ""
+
+#: inc/class-discord-admin.php:549
+msgid "Standard horizontal :"
+msgstr ""
+
+#: inc/class-discord-admin.php:553
+msgid "Vertical pour sidebar :"
+msgstr ""
+
+#: inc/class-discord-admin.php:558
+msgid "Compact mode sombre :"
+msgstr ""
+
+#: inc/class-discord-admin.php:562
+msgid "Avec titre personnalisé :"
+msgstr ""
+
+#: inc/class-discord-admin.php:566
+msgid "Icônes personnalisées :"
+msgstr ""
+
+#: inc/class-discord-admin.php:570
+msgid "Minimaliste (nombres uniquement) :"
+msgstr ""
+
+#: inc/class-discord-admin.php:576
+msgid "🎨 Prévisualisation en direct"
+msgstr ""
+
+#: inc/class-discord-admin.php:577
+msgid "Testez différentes configurations visuelles :"
+msgstr ""
+
+#: inc/class-discord-admin.php:596
+msgid "<strong>layout</strong> : horizontal, vertical, compact"
+msgstr ""
+
+#: inc/class-discord-admin.php:597
+msgid "<strong>theme</strong> : discord, dark, light, minimal"
+msgstr ""
+
+#: inc/class-discord-admin.php:598
+msgid "<strong>align</strong> : left, center, right"
+msgstr ""
+
+#: inc/class-discord-admin.php:599
+msgid "<strong>width</strong> : largeur CSS (ex: \"300px\", \"100%\")"
+msgstr ""
+
+#: inc/class-discord-admin.php:600
+msgid "<strong>compact</strong> : true/false (version réduite)"
+msgstr ""
+
+#: inc/class-discord-admin.php:601
+msgid "<strong>animated</strong> : true/false (animations hover)"
+msgstr ""
+
+#: inc/class-discord-admin.php:602
+msgid "<strong>class</strong> : classes CSS additionnelles"
+msgstr ""
+
+#: inc/class-discord-admin.php:606
+msgid ""
+"<strong>show_discord_icon</strong> : true/false (afficher le logo officiel)"
+msgstr ""
+
+#: inc/class-discord-admin.php:607
+msgid ""
+"<strong>discord_icon_position</strong> : left, right, top (position du logo)"
+msgstr ""
+
+#: inc/class-discord-admin.php:611
+msgid "<strong>show_online</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:612
+msgid "<strong>show_total</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:613
+msgid "<strong>show_title</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:614
+msgid "<strong>title</strong> : texte du titre"
+msgstr ""
+
+#: inc/class-discord-admin.php:615
+msgid "<strong>hide_labels</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:616
+msgid "<strong>hide_icons</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:620
+msgid "<strong>icon_online</strong> : emoji/texte (défaut: 🟢)"
+msgstr ""
+
+#: inc/class-discord-admin.php:621
+msgid "<strong>icon_total</strong> : emoji/texte (défaut: 👥)"
+msgstr ""
+
+#: inc/class-discord-admin.php:622
+msgid "<strong>label_online</strong> : texte personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:623
+msgid "<strong>label_total</strong> : texte personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:627
+msgid "<strong>refresh</strong> : true/false (auto-actualisation)"
+msgstr ""
+
+#: inc/class-discord-admin.php:628
+msgid ""
+"<strong>refresh_interval</strong> : secondes (minimum 10 secondes / 10 000 "
+"ms)"
+msgstr ""
+
+#: inc/class-discord-admin.php:629
+msgid "<strong>demo</strong> : true/false (mode démonstration)"
+msgstr ""
+
+#: inc/class-discord-admin.php:630
+msgid "<strong>border_radius</strong> : pixels (coins arrondis)"
+msgstr ""
+
+#: inc/class-discord-admin.php:631
+msgid "<strong>gap</strong> : pixels (espace entre éléments)"
+msgstr ""
+
+#: inc/class-discord-admin.php:632
+msgid "<strong>padding</strong> : pixels (espacement interne)"
+msgstr ""
+
+#: inc/class-discord-admin.php:637
+msgid "Pour une sidebar :"
+msgstr ""
+
+#: inc/class-discord-admin.php:641
+msgid "Pour un header :"
+msgstr ""
+
+#: inc/class-discord-admin.php:645
+msgid "Pour un footer :"
+msgstr ""
+
+#: inc/class-discord-admin.php:649
+msgid "Style gaming :"
+msgstr ""
+
+#: inc/class-discord-admin.php:655
+msgid "📖 Guide d'utilisation"
+msgstr ""
+
+#: inc/class-discord-admin.php:657
+msgid "Option 1 : Shortcode (avec paramètres)"
+msgstr ""
+
+#: inc/class-discord-admin.php:658
+msgid "Copiez ce code dans n'importe quelle page ou article :"
+msgstr ""
+
+#: inc/class-discord-admin.php:661
+msgid "Exemples avec paramètres :"
+msgstr ""
+
+#: inc/class-discord-admin.php:708
+msgid ""
+"ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10&nbsp;secondes "
+"(10 000&nbsp;ms). Toute valeur inférieure est automatiquement ajustée pour "
+"éviter les erreurs 429."
+msgstr ""
+
+#: inc/class-discord-admin.php:710
+msgid "Tous les paramètres disponibles :"
+msgstr ""
+
+#: inc/class-discord-admin.php:712
+msgid "🎨 Apparence & Layout :"
+msgstr ""
+
+#: inc/class-discord-admin.php:719
+msgid "🎯 Logo Discord :"
+msgstr ""
+
+#: inc/class-discord-admin.php:726
+msgid "📊 Données affichées :"
+msgstr ""
+
+#: inc/class-discord-admin.php:733
+msgid "✏️ Personnalisation textes/icônes :"
+msgstr ""
+
+#: inc/class-discord-admin.php:740
+msgid "⚙️ Paramètres techniques :"
+msgstr ""
+
+#: inc/class-discord-admin.php:748
+msgid "Option 2 : Widget"
+msgstr ""
+
+#: inc/class-discord-admin.php:752
+msgid ""
+"Allez dans <strong>Apparence &gt; Widgets</strong> et ajoutez le widget "
+"<strong>\"Discord Bot - JLG\"</strong> dans votre sidebar"
+msgstr ""
+
+#: inc/class-discord-admin.php:758
+msgid "Option 3 : Code PHP"
+msgstr ""
+
+#: inc/class-discord-admin.php:759
+msgid "Pour les développeurs, dans vos templates PHP :"
+msgstr ""
+
+#: inc/class-discord-admin.php:764
+msgid "💡 Configurations recommandées"
+msgstr ""
+
+#: inc/class-discord-admin.php:783
+msgid "❓ Dépannage"
+msgstr ""
+
+#: inc/class-discord-admin.php:785
+msgid ""
+"<strong>Erreur de connexion ?</strong> Vérifiez que le bot est bien sur "
+"votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:786
+msgid ""
+"<strong>Stats à 0 ?</strong> Assurez-vous que le widget est activé dans les "
+"paramètres Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:787
+msgid ""
+"<strong>Token invalide ?</strong> Régénérez le token dans le Developer Portal"
+msgstr ""
+
+#: inc/class-discord-admin.php:788
+msgid ""
+"<strong>Cache ?</strong> Les stats sont mises à jour toutes les 5 minutes "
+"par défaut"
+msgstr ""
+
+#: inc/class-discord-admin.php:804
+msgid "Documentation Discord API"
+msgstr ""
+
+#: inc/class-discord-admin.php:809
+msgid "Besoin d'aide ?"
+msgstr ""
+
+#: inc/class-discord-admin.php:816
+#, php-format
+msgid "Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse | %1$s | %2$s"
+msgstr ""
+
+#: inc/class-discord-admin.php:860
+msgid "🎨 Mode démonstration activé - Les données affichées sont fictives"
+msgstr ""
+
+#: inc/class-discord-admin.php:884
+#, php-format
+msgid "✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres"
+msgstr ""
+
+#: inc/class-discord-admin.php:893
+msgid "⚠️ Pas de configuration Discord détectée. Mode démo actif."
+msgstr ""
+
+#: inc/class-discord-admin.php:898
+msgid "❌ Échec de la connexion. Vérifiez vos identifiants."
+msgstr ""


### PR DESCRIPTION
## Summary
- wrap admin menu, settings, guide, and notice strings in Discord Bot JLG with translation helpers using the `discord-bot-jlg` text domain
- translate API error responses and shortcode defaults, keeping appropriate escaping for frontend output
- regenerate the plugin POT catalog for the updated strings

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cb29483f5c832eb30e89a3e5e12fe3