### PR TITLE
Adjust rate limit lock handling

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -125,7 +125,6 @@ class Discord_Bot_JLG_API {
         if (true === $is_public_request) {
             $cached_stats = get_transient($this->cache_key);
             if (is_array($cached_stats) && empty($cached_stats['is_demo'])) {
-                set_transient($rate_limit_key, time(), $rate_limit_window);
                 wp_send_json_success($cached_stats);
             }
 
@@ -168,7 +167,6 @@ class Discord_Bot_JLG_API {
         if (true === $is_public_request) {
             $cached_stats = get_transient($this->cache_key);
             if (is_array($cached_stats) && empty($cached_stats['is_demo'])) {
-                set_transient($rate_limit_key, time(), $rate_limit_window);
                 wp_send_json_success($cached_stats);
             }
 


### PR DESCRIPTION
## Summary
- stop refreshing the public refresh lock when serving cached statistics
- only update the lock when a public request actually refreshes Discord data
- avoid extending the lock when falling back to cached data after an error

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cc494df0b0832e9ccada532b32dd18