### PR TITLE
Improve widget stats fallback

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -260,17 +260,32 @@ class Discord_Bot_JLG_API {
             $total = count($data['members']);
         }
 
-        if (null === $total) {
-            // Public widget payload lacks the total member count; fall back to online users to keep data usable.
-            $total = $online;
-        } elseif ($total < $online) {
+        $server_name = isset($data['name']) ? $data['name'] : '';
+
+        if (null === $total || $total === $online) {
+            $bot_stats = $this->get_stats_from_bot($options);
+
+            if (false === $bot_stats || !is_array($bot_stats)) {
+                return false;
+            }
+
+            if (isset($bot_stats['total'])) {
+                $total = (int) $bot_stats['total'];
+            }
+
+            if (empty($server_name) && !empty($bot_stats['server_name'])) {
+                $server_name = $bot_stats['server_name'];
+            }
+        }
+
+        if (null === $total || $total < $online) {
             $total = $online;
         }
 
         return array(
             'online'      => $online,
             'total'       => $total,
-            'server_name' => isset($data['name']) ? $data['name'] : '',
+            'server_name' => $server_name,
         );
     }
 


### PR DESCRIPTION
## Summary
- request bot statistics when the widget payload lacks a member count so totals stay accurate
- keep the widget online count while reusing the best available server name and ensuring totals are not below online users

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cc494eb2c4832e90ceeef149586fac