### PR TITLE
Adjust rate limiting lock handling

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -122,12 +122,15 @@ class Discord_Bot_JLG_API {
             $rate_limit_window = self::MIN_PUBLIC_REFRESH_INTERVAL;
         }
 
+        $should_update_rate_limit = false;
+
         if (true === $is_public_request) {
             $cached_stats = get_transient($this->cache_key);
             if (is_array($cached_stats) && empty($cached_stats['is_demo'])) {
-                set_transient($rate_limit_key, time(), $rate_limit_window);
                 wp_send_json_success($cached_stats);
             }
+
+            $should_update_rate_limit = true;
 
             $last_refresh = get_transient($rate_limit_key);
             if (false !== $last_refresh) {
@@ -159,7 +162,7 @@ class Discord_Bot_JLG_API {
         );
 
         if (is_array($stats) && empty($stats['is_demo'])) {
-            if (true === $is_public_request) {
+            if (true === $is_public_request && !empty($should_update_rate_limit)) {
                 set_transient($rate_limit_key, time(), $rate_limit_window);
             }
             wp_send_json_success($stats);
@@ -168,7 +171,6 @@ class Discord_Bot_JLG_API {
         if (true === $is_public_request) {
             $cached_stats = get_transient($this->cache_key);
             if (is_array($cached_stats) && empty($cached_stats['is_demo'])) {
-                set_transient($rate_limit_key, time(), $rate_limit_window);
                 wp_send_json_success($cached_stats);
             }
 


### PR DESCRIPTION
## Summary
- avoid refreshing the public refresh lock when serving cached statistics
- only set the rate limit lock after a successful API fetch and leave it untouched on fallback cache paths

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4b15629c832eb75c8342a1effa9e