### PR TITLE
Adjust rate limit lock timing

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -122,15 +122,13 @@ class Discord_Bot_JLG_API {
             $rate_limit_window = self::MIN_PUBLIC_REFRESH_INTERVAL;
         }
 
-        $should_update_rate_limit = false;
+        $refresh_requires_remote_call = false;
 
         if (true === $is_public_request) {
             $cached_stats = get_transient($this->cache_key);
             if (is_array($cached_stats) && empty($cached_stats['is_demo'])) {
                 wp_send_json_success($cached_stats);
             }
-
-            $should_update_rate_limit = true;
 
             $last_refresh = get_transient($rate_limit_key);
             if (false !== $last_refresh) {
@@ -153,6 +151,7 @@ class Discord_Bot_JLG_API {
                 }
             }
 
+            $refresh_requires_remote_call = true;
         }
 
         $stats = $this->get_stats(
@@ -161,10 +160,16 @@ class Discord_Bot_JLG_API {
             )
         );
 
+        if (
+            true === $is_public_request
+            && true === $refresh_requires_remote_call
+            && is_array($stats)
+            && empty($stats['is_demo'])
+        ) {
+            set_transient($rate_limit_key, time(), $rate_limit_window);
+        }
+
         if (is_array($stats) && empty($stats['is_demo'])) {
-            if (true === $is_public_request && !empty($should_update_rate_limit)) {
-                set_transient($rate_limit_key, time(), $rate_limit_window);
-            }
             wp_send_json_success($stats);
         }
 


### PR DESCRIPTION
## Summary
- ensure public AJAX refresh only updates the rate-limit lock when a fresh Discord fetch occurs
- avoid extending the lock for cached fallbacks after failures so retries remain immediate

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cc50ae3180832eb58dbc64a45d19ee