### PR TITLE
Improve widget stats fallback

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -280,8 +280,8 @@ class Discord_Bot_JLG_API {
             }
         }
 
-        if (null === $total || $total < $online) {
-            $total = $online;
+        if (null === $total || $total === $online) {
+            return false;
         }
 
         return array(


### PR DESCRIPTION
## Summary
- ensure widget stats fallback to the bot API when the widget does not expose a reliable member total
- merge the bot-provided totals into widget data when available instead of returning potentially incorrect counts

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cc50ae848c832e95f09b746f4b76c5