### PR TITLE
Handle widget totals without rejecting member_count equality

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -282,17 +282,19 @@ class Discord_Bot_JLG_API {
         $online = (int) $data['presence_count'];
 
         $total = null;
+        $total_comes_from_fallback = false;
 
         if (isset($data['member_count'])) {
             $total = (int) $data['member_count'];
         } elseif (isset($data['members']) && is_array($data['members'])) {
             // The widget exposes the list of displayed members (usually online ones) but not the full roster.
             $total = count($data['members']);
+            $total_comes_from_fallback = true;
         }
 
         $server_name = isset($data['name']) ? $data['name'] : '';
 
-        if (null === $total || $total === $online) {
+        if (null === $total || true === $total_comes_from_fallback) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- track whether widget totals come from the fallback member list
- keep widget statistics whenever member_count is provided, even if it matches presence_count, while still rejecting fallback totals

## Testing
- php <<'PHP'
<?php
define('ABSPATH', __DIR__);
require "discord-bot-jlg/inc/class-discord-api.php";

function wp_safe_remote_get($url, $args = array()) {
    global $mock_response;
    return $mock_response;
}

function is_wp_error($thing) {
    return false;
}

function wp_remote_retrieve_response_code($response) {
    return isset($response["response"]["code"]) ? $response["response"]["code"] : 0;
}

function wp_remote_retrieve_body($response) {
    return isset($response["body"]) ? $response["body"] : '';
}

$api = new Discord_Bot_JLG_API('opt', 'cache');
$ref = new ReflectionMethod('Discord_Bot_JLG_API', 'get_stats_from_widget');
$ref->setAccessible(true);

global $mock_response;
$mock_response = array(
    'response' => array('code' => 200),
    'body'      => json_encode(array(
        'presence_count' => 42,
        'member_count'   => 42,
        'name'           => 'Test Guild',
    )),
);

$result = $ref->invoke($api, array('server_id' => '123'));
var_export($result);
echo "\n";

$mock_response = array(
    'response' => array('code' => 200),
    'body'      => json_encode(array(
        'presence_count' => 10,
        'members'        => array_fill(0, 5, array('id' => 1)),
        'name'           => 'Fallback Guild',
    )),
);

$result = $ref->invoke($api, array('server_id' => '123'));
var_export($result);
echo "\n";
PHP

------
https://chatgpt.com/codex/tasks/task_e_68cc6e5c2628832eb09a30080a8a715e