### PR TITLE
Handle partial widget stats

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -300,11 +300,16 @@ class Discord_Bot_JLG_API {
             return false;
         }
 
-        if (false === isset($data['presence_count'])) {
+        $has_presence_count = isset($data['presence_count']);
+        $has_members_list   = isset($data['members']) && is_array($data['members']);
+
+        if (false === $has_presence_count && false === $has_members_list) {
             return false;
         }
 
-        $online = (int) $data['presence_count'];
+        $online = $has_presence_count
+            ? (int) $data['presence_count']
+            : (int) count($data['members']);
 
         $server_name = isset($data['name']) ? $data['name'] : '';
 
@@ -319,10 +324,10 @@ class Discord_Bot_JLG_API {
         if (isset($data['member_count'])) {
             $stats['total']     = (int) $data['member_count'];
             $stats['has_total'] = true;
-        } elseif (isset($data['members']) && is_array($data['members'])) {
+        } elseif ($has_members_list) {
             // The widget exposes the list of displayed members (usually online ones) but not the full roster.
-            $stats['total']                = (int) count($data['members']);
-            $stats['has_total']            = true;
+            $stats['total']                = null;
+            $stats['has_total']            = false;
             $stats['total_is_approximate'] = true;
         } else {
             $stats['total_is_approximate'] = true;

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -225,6 +225,18 @@ class Discord_Bot_JLG_Shortcode {
                         </span>
                         <?php endif; ?>
                     </div>
+                    <?php elseif ($show_total): ?>
+                    <div class="discord-stat discord-total discord-total-unavailable">
+                        <?php if (!$hide_icons): ?>
+                        <span class="discord-icon"><?php echo esc_html($atts['icon_total']); ?></span>
+                        <?php endif; ?>
+                        <span class="discord-number">&mdash;</span>
+                        <?php if (!$hide_labels): ?>
+                        <span class="discord-label"><?php esc_html_e('Total indisponible', 'discord-bot-jlg'); ?></span>
+                        <?php else: ?>
+                        <span class="screen-reader-text"><?php esc_html_e('Total indisponible', 'discord-bot-jlg'); ?></span>
+                        <?php endif; ?>
+                    </div>
                     <?php endif; ?>
                 </div>
 


### PR DESCRIPTION
## Summary
- allow widget stats to be used even when the Discord widget only exposes the member list, keeping the presence count and flagging missing totals
- adjust the public shortcode to hide the total count and show a notice when the widget cannot provide a reliable total

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php
- php /tmp/test_shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cd759ed198832ebc6d693860768601