### PR TITLE
Handle expired nonce for public stats refresh

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -39,6 +39,22 @@
                 }
 
                 if (!data.success) {
+                    if (data.data && data.data.nonce_expired) {
+                        if (data.data.new_nonce) {
+                            config.nonce = data.data.new_nonce;
+                        }
+
+                        if (container && container.classList) {
+                            container.classList.remove(ERROR_CLASS);
+                        }
+
+                        // Les caches frontaux peuvent invalider les requêtes POST :
+                        // en cas de nonce expiré on relance immédiatement avec le nouveau jeton.
+                        updateStats(container, config, formatter);
+
+                        return;
+                    }
+
                     if (data.data && data.data.message) {
                         console.warn(data.data.message);
                     } else if (typeof data.data === 'string') {


### PR DESCRIPTION
## Summary
- return a structured error with a refreshed nonce when the public stats AJAX call is made with an expired nonce
- refresh the frontend nonce and retry stats loading when the backend reports an expired nonce
- document the cache-related retry in the JavaScript handler

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cda8d6d564832ea5fd49d74134b220