### PR TITLE
Log Discord API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Un widget « Discord Bot - JLG » est disponible via le menu « Widgets ».
 ## Fonctionnalités
 - Affichage du nombre de membres en ligne et du total ;
 - Mise en cache des statistiques ;
+- Journalisation des erreurs de communication avec l'API Discord (accessible via `WP_DEBUG_LOG`) ;
 - Page de démonstration intégrée.
 
 ## Désinstallation

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -294,10 +294,13 @@ class Discord_Bot_JLG_API {
         );
 
         if (is_wp_error($response)) {
+            error_log('Discord API error (widget): ' . $response->get_error_message());
             return false;
         }
 
-        if (200 !== (int) wp_remote_retrieve_response_code($response)) {
+        $response_code = (int) wp_remote_retrieve_response_code($response);
+        if (200 !== $response_code) {
+            error_log('Discord API error (widget): HTTP ' . $response_code);
             return false;
         }
 
@@ -363,10 +366,13 @@ class Discord_Bot_JLG_API {
         );
 
         if (is_wp_error($response)) {
+            error_log('Discord API error (bot): ' . $response->get_error_message());
             return false;
         }
 
-        if (200 !== (int) wp_remote_retrieve_response_code($response)) {
+        $response_code = (int) wp_remote_retrieve_response_code($response);
+        if (200 !== $response_code) {
+            error_log('Discord API error (bot): HTTP ' . $response_code);
             return false;
         }
 


### PR DESCRIPTION
## Summary
- log Discord widget API errors to the PHP error log for easier debugging
- log Discord bot API errors, including unexpected HTTP status codes, without exposing secrets
- document the availability of these diagnostic messages in the README

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb281b54c832ebd0acf7bccab07ac