### PR TITLE
Support bot token constant override

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Accédez à la page **Discord Bot** dans l’administration pour :
 - Définir la durée du cache des statistiques ;
 - Ajouter du CSS personnalisé.
 
+### Définir le token via une constante
+
+Il est possible de forcer l'utilisation d'un token spécifique en définissant la constante `DISCORD_BOT_JLG_TOKEN` dans votre fichier `wp-config.php` ou dans un plugin mu. Lorsque cette constante est présente (et non vide), elle est utilisée à la place de la valeur enregistrée dans l'administration et le champ correspondant devient en lecture seule.
+
 ## Utilisation
 ### Shortcode
 ```

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -338,11 +338,20 @@ class Discord_Bot_JLG_Admin {
      */
     public function bot_token_render() {
         $options = get_option($this->option_name);
+        $constant_overridden = (defined('DISCORD_BOT_JLG_TOKEN') && '' !== DISCORD_BOT_JLG_TOKEN);
         ?>
         <input type="password" name="<?php echo esc_attr($this->option_name); ?>[bot_token]"
                value="<?php echo esc_attr(isset($options['bot_token']) ? $options['bot_token'] : ''); ?>"
-               class="regular-text" />
-        <p class="description">Le token de votre bot Discord (gardez-le secret !)</p>
+               class="regular-text" <?php echo $constant_overridden ? 'readonly' : ''; ?> />
+        <p class="description">
+            <?php
+            if ($constant_overridden) {
+                echo 'Le token est actuellement défini via la constante <code>DISCORD_BOT_JLG_TOKEN</code> et remplace cette valeur.';
+            } else {
+                echo 'Le token de votre bot Discord (gardez-le secret !).';
+            }
+            ?>
+        </p>
         <?php
     }
 

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -85,9 +85,10 @@ class Discord_Bot_JLG_API {
 
         $widget_incomplete = $this->stats_need_completion($widget_stats);
 
-        $bot_stats = false;
+        $bot_stats  = false;
+        $bot_token = $this->get_bot_token($options);
 
-        if (!empty($options['bot_token'])) {
+        if (!empty($bot_token)) {
             $bot_stats = $this->get_stats_from_bot($options);
 
             if (is_array($bot_stats)) {
@@ -345,7 +346,9 @@ class Discord_Bot_JLG_API {
     }
 
     private function get_stats_from_bot($options) {
-        if (empty($options['bot_token'])) {
+        $bot_token = $this->get_bot_token($options);
+
+        if (empty($bot_token)) {
             return false;
         }
 
@@ -356,7 +359,7 @@ class Discord_Bot_JLG_API {
             array(
                 'timeout' => 10,
                 'headers' => array(
-                    'Authorization' => 'Bot ' . $options['bot_token'],
+                    'Authorization' => 'Bot ' . $bot_token,
                     'User-Agent'    => 'WordPress Discord Stats Plugin',
                 ),
             )
@@ -420,6 +423,14 @@ class Discord_Bot_JLG_API {
         }
 
         return false;
+    }
+
+    private function get_bot_token($options) {
+        if (defined('DISCORD_BOT_JLG_TOKEN') && '' !== DISCORD_BOT_JLG_TOKEN) {
+            return DISCORD_BOT_JLG_TOKEN;
+        }
+
+        return isset($options['bot_token']) ? $options['bot_token'] : '';
     }
 
     private function get_cache_duration($options) {


### PR DESCRIPTION
## Summary
- add a helper to consistently read the bot token from the constant or option
- prevent empty Authorization headers and reuse the helper inside the API client
- inform administrators about the constant override and document the behaviour

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb280775c832eaa551e5bbac37b39