### PR TITLE
Internationalize plugin strings

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -21,6 +21,7 @@
     }
 
     function updateStats(container, config, formatter) {
+        var messages = config.messages || {};
         var formData = new FormData();
         formData.append('action', config.action || 'refresh_discord_stats');
         formData.append('_ajax_nonce', config.nonce);
@@ -91,7 +92,8 @@
                 updateStatElement(container, '.discord-total .discord-number', totalValue, formatter);
             })
             .catch(function (error) {
-                console.error('Erreur lors de la mise à jour des statistiques Discord :', error);
+                var errorMessage = messages.updateError || 'Erreur lors de la mise à jour des statistiques Discord :';
+                console.error(errorMessage, error);
 
                 if (container && container.classList) {
                     container.classList.add(ERROR_CLASS);

--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -83,7 +83,10 @@ class DiscordServerStats {
     }
 
     public function activate() {
-        add_option(DISCORD_BOT_JLG_OPTION_NAME, $this->default_options);
+        $defaults = $this->default_options;
+        $defaults['widget_title'] = esc_html__('Discord Server', 'discord-bot-jlg');
+
+        add_option(DISCORD_BOT_JLG_OPTION_NAME, $defaults);
     }
 
     public function deactivate() {

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -34,8 +34,8 @@ class Discord_Bot_JLG_Admin {
         $discord_icon = 'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbD0iI2E0YWFiOCIgZD0iTTIwLjMxNyA0LjM3YTE5LjggMTkuOCAwIDAwLTQuODg1LTEuNTE1LjA3NC4wNzQgMCAwMC0uMDc5LjAzN2MtLjIxLjM3NS0uNDQ0Ljg2NC0uNjA4IDEuMjVhMTguMjcgMTguMjcgMCAwMC01LjQ4NyAwYy0uMTY1LS4zOTctLjQwNC0uODg1LS42MTgtMS4yNWEuMDc3LjA3NyAwIDAwLS4wNzktLjAzN0ExOS43NCAxOS43NCAwIDAwMy42NzcgNC4zN2EuMDcuMDcgMCAwMC0uMDMyLjAyN0MuNTMzIDkuMDQ2LS4zMiAxMy41OC4wOTkgMTguMDU3YS4wOC4wOCAwIDAwLjAzMS4wNTdBMTkuOSAxOS45IDAgMDA2LjA3MyAyMWEuMDc4LjA3OCAwIDAwLjA4NC0uMDI4IDEzLjQgMTMuNCAwIDAwMS4xNTUtMi4xLjA3Ni4wNzYgMCAwMC0uMDQxLS4xMDYgMTMuMSAxMy4xIDAgMDEtMS44NzItLjg5Mi4wNzcuMDc3IDAgMDEtLjAwOC0uMTI4IDE0IDE0IDAgMDAuMzctLjI5Mi4wNzQuMDc0IDAgMDEuMDc3LS4wMWMzLjkyNyAxLjc5MyA4LjE4IDEuNzkzIDEyLjA2IDAgYS4wNzQuMDc0IDAgMDEuMDc4LjAwOS4xMTkuMDk5LjI0Ni4xOTguMzczLjI5MmEuMDc3LjA3NyAwIDAxLS4wMDYuMTI3IDEyLjMgMTIuMyAwIDAxLTEuODczLjg5Mi4wNzcuMDc3IDAgMDAtLjA0MS4xMDdjMy43NDQgMS40MDMgMS4xNTUgMi4xLS4wODQuMDI4YS4wNzguMDc4IDAgMDAxOS45MDItMS45MDMuMDc2LjA3NiAwIDAwLjAzLS4wNTdjLjUzNy00LjU4LS45MDQtOC41NTMtMy44MjMtMTIuMDU3YS4wNi4wNiAwIDAwLS4wMzEtLjAyOHpNOC4wMiAxNS4yNzhjLTEuMTgzIDAtMi4xNTctMS4wODUtMi4xNTctMi40MiAwLTEuMzMzLjk1Ni0yLjQxOSAyLjE1Ny0yLjQxOSAxLjIxIDAgMi4xNzYgMS4wOTYgMi4xNTcgMi40MiAwIDEuMzM0LS45NTYgMi40MTktMi4xNTcgMi40MTl6bTcuOTc1IDBjLTEuMTgzIDAtMi4xNTctMS4wODUtMi4xNTctMi40MiAwLTEuMzMzLjk1NS0yLjQxOSAyLjE1Ny0yLjQxOXMyLjE1NyAxLjA5NiAyLjE1NyAyLjQyYzAgMS4zMzQtLjk1NiAyLjQxOS0yLjE1NyAyLjQxOXoiLz48L3N2Zz4=';
 
         add_menu_page(
-            'Discord Bot - JLG',
-            'Discord Bot',
+            __('Discord Bot - JLG', 'discord-bot-jlg'),
+            __('Discord Bot', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-jlg',
             array($this, 'options_page'),
@@ -45,8 +45,8 @@ class Discord_Bot_JLG_Admin {
 
         add_submenu_page(
             'discord-bot-jlg',
-            'Configuration',
-            'Configuration',
+            __('Configuration', 'discord-bot-jlg'),
+            __('Configuration', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-jlg',
             array($this, 'options_page')
@@ -54,8 +54,8 @@ class Discord_Bot_JLG_Admin {
 
         add_submenu_page(
             'discord-bot-jlg',
-            'Guide & Démo',
-            'Guide & Démo',
+            __('Guide & Démo', 'discord-bot-jlg'),
+            __('Guide & Démo', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-demo',
             array($this, 'demo_page')
@@ -78,14 +78,14 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_section(
             'discord_stats_api_section',
-            'Configuration Discord API',
+            __('Configuration Discord API', 'discord-bot-jlg'),
             array($this, 'api_section_callback'),
             'discord_stats_settings'
         );
 
         add_settings_field(
             'server_id',
-            'ID du Serveur Discord',
+            __('ID du Serveur Discord', 'discord-bot-jlg'),
             array($this, 'server_id_render'),
             'discord_stats_settings',
             'discord_stats_api_section'
@@ -93,7 +93,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'bot_token',
-            'Token du Bot Discord',
+            __('Token du Bot Discord', 'discord-bot-jlg'),
             array($this, 'bot_token_render'),
             'discord_stats_settings',
             'discord_stats_api_section'
@@ -101,14 +101,14 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_section(
             'discord_stats_display_section',
-            'Options d\'affichage',
+            __('Options d\'affichage', 'discord-bot-jlg'),
             array($this, 'display_section_callback'),
             'discord_stats_settings'
         );
 
         add_settings_field(
             'demo_mode',
-            'Mode démonstration',
+            __('Mode démonstration', 'discord-bot-jlg'),
             array($this, 'demo_mode_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -116,7 +116,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'show_online',
-            'Afficher les membres en ligne',
+            __('Afficher les membres en ligne', 'discord-bot-jlg'),
             array($this, 'show_online_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -124,7 +124,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'show_total',
-            'Afficher le total des membres',
+            __('Afficher le total des membres', 'discord-bot-jlg'),
             array($this, 'show_total_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -132,7 +132,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'widget_title',
-            'Titre du widget',
+            __('Titre du widget', 'discord-bot-jlg'),
             array($this, 'widget_title_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -140,7 +140,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'cache_duration',
-            'Durée du cache (secondes)',
+            __('Durée du cache (secondes)', 'discord-bot-jlg'),
             array($this, 'cache_duration_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -148,7 +148,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'custom_css',
-            'CSS personnalisé',
+            __('CSS personnalisé', 'discord-bot-jlg'),
             array($this, 'custom_css_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -220,7 +220,7 @@ class Discord_Bot_JLG_Admin {
     public function api_section_callback() {
         ?>
         <div style="background: #f0f4ff; padding: 20px; border-radius: 8px; margin: 20px 0;">
-            <h3 style="margin-top: 0;">📚 Guide étape par étape</h3>
+            <h3 style="margin-top: 0;"><?php esc_html_e('📚 Guide étape par étape', 'discord-bot-jlg'); ?></h3>
             <?php
             $this->render_api_steps();
             $this->render_api_previews();
@@ -234,47 +234,57 @@ class Discord_Bot_JLG_Admin {
      */
     private function render_api_steps() {
         ?>
-        <h4>Étape 1 : Créer un Bot Discord</h4>
+        <h4><?php esc_html_e('Étape 1 : Créer un Bot Discord', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Rendez-vous sur <a href="https://discord.com/developers/applications" target="_blank" style="color: #5865F2;">Discord Developer Portal</a></li>
-            <li>Cliquez sur <strong>"New Application"</strong> en haut à droite</li>
-            <li>Donnez un nom à votre application (ex: "Stats Bot")</li>
-            <li>Dans le menu de gauche, cliquez sur <strong>"Bot"</strong></li>
-            <li>Cliquez sur <strong>"Add Bot"</strong></li>
-            <li>Sous "Token", cliquez sur <strong>"Copy"</strong> pour copier le token du bot</li>
-            <li>⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez jamais !</li>
+            <li>
+                <?php
+                echo wp_kses_post(
+                    sprintf(
+                        /* translators: %s: Discord developer portal URL. */
+                        __('Rendez-vous sur <a href="%s" target="_blank" style="color: #5865F2;">Discord Developer Portal</a>', 'discord-bot-jlg'),
+                        'https://discord.com/developers/applications'
+                    )
+                );
+                ?>
+            </li>
+            <li><?php echo wp_kses_post(__('Cliquez sur <strong>"New Application"</strong> en haut à droite', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Donnez un nom à votre application (ex : "Stats Bot")', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans le menu de gauche, cliquez sur <strong>"Bot"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Cliquez sur <strong>"Add Bot"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Sous "Token", cliquez sur <strong>"Copy"</strong> pour copier le token du bot', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez jamais !', 'discord-bot-jlg')); ?></li>
         </ol>
 
-        <h4>Étape 2 : Inviter le Bot sur votre serveur</h4>
+        <h4><?php esc_html_e('Étape 2 : Inviter le Bot sur votre serveur', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Dans le menu de gauche, allez dans <strong>"OAuth2"</strong> > <strong>"URL Generator"</strong></li>
-            <li>Dans "Scopes", cochez <strong>"bot"</strong></li>
-            <li>Dans "Bot Permissions", sélectionnez :</li>
+            <li><?php echo wp_kses_post(__('Dans le menu de gauche, allez dans <strong>"OAuth2"</strong> &gt; <strong>"URL Generator"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans "Scopes", cochez <strong>"bot"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans "Bot Permissions", sélectionnez :', 'discord-bot-jlg')); ?></li>
                 <ul>
-                    <li>✅ View Channels</li>
-                    <li>✅ Read Messages</li>
-                    <li>✅ Send Messages (optionnel)</li>
+                    <li><?php esc_html_e('✅ View Channels', 'discord-bot-jlg'); ?></li>
+                    <li><?php esc_html_e('✅ Read Messages', 'discord-bot-jlg'); ?></li>
+                    <li><?php esc_html_e('✅ Send Messages (optionnel)', 'discord-bot-jlg'); ?></li>
                 </ul>
-            <li>Copiez l'URL générée en bas de la page</li>
-            <li>Ouvrez cette URL dans votre navigateur</li>
-            <li>Sélectionnez votre serveur et cliquez sur <strong>"Autoriser"</strong></li>
+            <li><?php esc_html_e("Copiez l'URL générée en bas de la page", 'discord-bot-jlg'); ?></li>
+            <li><?php esc_html_e('Ouvrez cette URL dans votre navigateur', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Sélectionnez votre serveur et cliquez sur <strong>"Autoriser"</strong>', 'discord-bot-jlg')); ?></li>
         </ol>
 
-        <h4>Étape 3 : Obtenir l'ID de votre serveur</h4>
+        <h4><?php esc_html_e('Étape 3 : Obtenir l\'ID de votre serveur', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Ouvrez Discord (application ou web)</li>
-            <li>Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)</li>
-            <li>Dans <strong>"Avancés"</strong>, activez <strong>"Mode développeur"</strong></li>
-            <li>Retournez sur votre serveur</li>
-            <li>Faites un <strong>clic droit sur le nom du serveur</strong></li>
-            <li>Cliquez sur <strong>"Copier l'ID"</strong></li>
+            <li><?php esc_html_e('Ouvrez Discord (application ou web)', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans <strong>"Avancés"</strong>, activez <strong>"Mode développeur"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php esc_html_e('Retournez sur votre serveur', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Faites un <strong>clic droit sur le nom du serveur</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Cliquez sur <strong>"Copier l\'ID"</strong>', 'discord-bot-jlg')); ?></li>
         </ol>
 
-        <h4>Étape 4 : Activer le Widget (optionnel mais recommandé)</h4>
+        <h4><?php esc_html_e('Étape 4 : Activer le Widget (optionnel mais recommandé)', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Dans Discord, allez dans <strong>Paramètres du serveur</strong></li>
-            <li>Dans <strong>"Widget"</strong>, activez <strong>"Activer le widget du serveur"</strong></li>
-            <li>Cela permet une méthode de fallback si le bot a des problèmes</li>
+            <li><?php echo wp_kses_post(__('Dans Discord, allez dans <strong>Paramètres du serveur</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans <strong>"Widget"</strong>, activez <strong>"Activer le widget du serveur"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php esc_html_e('Cela permet une méthode de fallback si le bot a des problèmes', 'discord-bot-jlg'); ?></li>
         </ol>
         <?php
     }
@@ -285,10 +295,19 @@ class Discord_Bot_JLG_Admin {
     private function render_api_previews() {
         ?>
         <div style="background: #fff3cd; padding: 10px; border-radius: 4px; margin-top: 15px;">
-            <strong>💡 Conseil :</strong> Après avoir rempli les champs ci-dessous, utilisez le bouton "Tester la connexion" pour vérifier que tout fonctionne !
+            <?php
+            echo wp_kses_post(
+                sprintf(
+                    /* translators: %s: Button label. */
+                    __('%1$s Après avoir rempli les champs ci-dessous, utilisez le bouton "%2$s" pour vérifier que tout fonctionne !', 'discord-bot-jlg'),
+                    '<strong>💡 ' . esc_html__('Conseil :', 'discord-bot-jlg') . '</strong>',
+                    esc_html__('Tester la connexion', 'discord-bot-jlg')
+                )
+            );
+            ?>
             <?php
             $this->render_preview_block(
-                'Avec logo Discord officiel :',
+                __('Avec logo Discord officiel :', 'discord-bot-jlg'),
                 '[discord_stats demo="true" show_discord_icon="true" discord_icon_position="left"]',
                 array(
                     'container_style' => 'margin: 20px 0;',
@@ -296,7 +315,7 @@ class Discord_Bot_JLG_Admin {
             );
 
             $this->render_preview_block(
-                'Logo Discord centré en haut :',
+                __('Logo Discord centré en haut :', 'discord-bot-jlg'),
                 '[discord_stats demo="true" show_discord_icon="true" discord_icon_position="top" align="center" theme="dark"]',
                 array(
                     'container_style' => 'margin: 20px 0;',
@@ -313,7 +332,7 @@ class Discord_Bot_JLG_Admin {
      * @return void
      */
     public function display_section_callback() {
-        echo '<p>Personnalisez l\'affichage des statistiques Discord.</p>';
+        printf('<p>%s</p>', esc_html__('Personnalisez l\'affichage des statistiques Discord.', 'discord-bot-jlg'));
     }
 
     /**
@@ -327,7 +346,7 @@ class Discord_Bot_JLG_Admin {
         <input type="text" name="<?php echo esc_attr($this->option_name); ?>[server_id]"
                value="<?php echo esc_attr(isset($options['server_id']) ? $options['server_id'] : ''); ?>"
                class="regular-text" />
-        <p class="description">L'ID de votre serveur Discord</p>
+        <p class="description"><?php esc_html_e("L'ID de votre serveur Discord", 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -342,7 +361,7 @@ class Discord_Bot_JLG_Admin {
         <input type="password" name="<?php echo esc_attr($this->option_name); ?>[bot_token]"
                value="<?php echo esc_attr(isset($options['bot_token']) ? $options['bot_token'] : ''); ?>"
                class="regular-text" />
-        <p class="description">Le token de votre bot Discord (gardez-le secret !)</p>
+        <p class="description"><?php esc_html_e('Le token de votre bot Discord (gardez-le secret !)', 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -357,8 +376,8 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[demo_mode]"
                value="1" <?php checked($demo_mode, 1); ?> />
-        <label>Activer le mode démonstration (affiche des données fictives pour tester l'apparence)</label>
-        <p class="description">🎨 Parfait pour tester les styles et dispositions sans configuration Discord</p>
+        <label><?php esc_html_e("Activer le mode démonstration (affiche des données fictives pour tester l'apparence)", 'discord-bot-jlg'); ?></label>
+        <p class="description"><?php esc_html_e('🎨 Parfait pour tester les styles et dispositions sans configuration Discord', 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -373,7 +392,7 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_online]"
                value="1" <?php checked($value, 1); ?> />
-        <label>Afficher le nombre d'utilisateurs en ligne</label>
+        <label><?php esc_html_e("Afficher le nombre d'utilisateurs en ligne", 'discord-bot-jlg'); ?></label>
         <?php
     }
 
@@ -388,7 +407,7 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_total]"
                value="1" <?php checked($value, 1); ?> />
-        <label>Afficher le nombre total de membres</label>
+        <label><?php esc_html_e('Afficher le nombre total de membres', 'discord-bot-jlg'); ?></label>
         <?php
     }
 
@@ -417,7 +436,7 @@ class Discord_Bot_JLG_Admin {
         <input type="number" name="<?php echo esc_attr($this->option_name); ?>[cache_duration]"
                value="<?php echo esc_attr(isset($options['cache_duration']) ? $options['cache_duration'] : ''); ?>"
                min="60" max="3600" class="small-text" />
-        <p class="description">Minimum 60 secondes, maximum 3600 secondes (1 heure)</p>
+        <p class="description"><?php esc_html_e('Minimum 60 secondes, maximum 3600 secondes (1 heure)', 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -430,7 +449,7 @@ class Discord_Bot_JLG_Admin {
         $options = get_option($this->option_name);
         ?>
         <textarea name="<?php echo esc_attr($this->option_name); ?>[custom_css]" rows="5" cols="50"><?php echo esc_textarea(isset($options['custom_css']) ? $options['custom_css'] : ''); ?></textarea>
-        <p class="description">CSS personnalisé pour styliser l'affichage</p>
+        <p class="description"><?php esc_html_e("CSS personnalisé pour styliser l'affichage", 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -442,7 +461,7 @@ class Discord_Bot_JLG_Admin {
     public function options_page() {
         ?>
         <div class="wrap">
-            <h1>🎮 Discord Bot - JLG - Configuration</h1>
+            <h1><?php esc_html_e('🎮 Discord Bot - JLG - Configuration', 'discord-bot-jlg'); ?></h1>
             <?php $this->handle_test_connection_request(); ?>
 
             <div style="display: flex; gap: 20px; margin-top: 20px;">
@@ -503,14 +522,14 @@ class Discord_Bot_JLG_Admin {
     private function render_connection_test_panel() {
         ?>
         <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
-            <h3 style="margin-top: 0;">🔧 Test de connexion</h3>
-            <p>Vérifiez que votre configuration fonctionne :</p>
+            <h3 style="margin-top: 0;"><?php esc_html_e('🔧 Test de connexion', 'discord-bot-jlg'); ?></h3>
+            <p><?php esc_html_e('Vérifiez que votre configuration fonctionne :', 'discord-bot-jlg'); ?></p>
             <form method="get" action="<?php echo esc_url(admin_url('admin.php')); ?>">
                 <input type="hidden" name="page" value="discord-bot-jlg" />
                 <input type="hidden" name="test_connection" value="1" />
                 <?php wp_nonce_field('discord_test_connection'); ?>
                 <p>
-                    <button type="submit" class="button button-secondary" style="width: 100%;">Tester la connexion</button>
+                    <button type="submit" class="button button-secondary" style="width: 100%;"><?php esc_html_e('Tester la connexion', 'discord-bot-jlg'); ?></button>
                 </p>
             </form>
         </div>
@@ -523,21 +542,21 @@ class Discord_Bot_JLG_Admin {
     private function render_quick_links_panel() {
         ?>
         <div style="background: #e8f5e9; padding: 20px; border-radius: 8px;">
-            <h3 style="margin-top: 0;">🚀 Liens rapides</h3>
+            <h3 style="margin-top: 0;"><?php esc_html_e('🚀 Liens rapides', 'discord-bot-jlg'); ?></h3>
             <ul style="list-style: none; padding: 0;">
                 <li style="margin-bottom: 10px;">
                     <a href="<?php echo esc_url(admin_url('admin.php?page=discord-bot-demo')); ?>" class="button button-primary" style="width: 100%;">
-                        📖 Guide & Démo
+                        <?php esc_html_e('📖 Guide & Démo', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
                 <li style="margin-bottom: 10px;">
                     <a href="https://discord.com/developers/applications" target="_blank" class="button" style="width: 100%;">
-                        🔗 Discord Developer Portal
+                        <?php esc_html_e('🔗 Discord Developer Portal', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
                 <li>
                     <a href="<?php echo esc_url(admin_url('widgets.php')); ?>" class="button" style="width: 100%;">
-                        📐 Gérer les Widgets
+                        <?php esc_html_e('📐 Gérer les Widgets', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
             </ul>
@@ -551,7 +570,7 @@ class Discord_Bot_JLG_Admin {
     private function render_admin_footer_note() {
         ?>
         <div style="margin-top: 30px; padding: 15px; background: #f0f0f0; border-radius: 8px; text-align: center;">
-            <p style="margin: 0;">Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse</p>
+            <p style="margin: 0;"><?php esc_html_e('Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse', 'discord-bot-jlg'); ?></p>
         </div>
         <?php
     }
@@ -564,7 +583,7 @@ class Discord_Bot_JLG_Admin {
     public function demo_page() {
         ?>
         <div class="wrap">
-            <h1>📖 Guide & Démonstration</h1>
+            <h1><?php esc_html_e('📖 Guide & Démonstration', 'discord-bot-jlg'); ?></h1>
             <?php $this->render_demo_intro_notice(); ?>
 
             <hr style="margin: 30px 0;">
@@ -591,7 +610,13 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_intro_notice() {
         ?>
         <div style="background: #fff3cd; padding: 10px 20px; border-radius: 8px; margin: 20px 0;">
-            <p><strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode démo. Vous pouvez les copier-coller directement !</p>
+            <p>
+                <?php
+                echo wp_kses_post(
+                    __('<strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode démo. Vous pouvez les copier-coller directement !', 'discord-bot-jlg')
+                );
+                ?>
+            </p>
         </div>
         <?php
     }
@@ -602,35 +627,35 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_previews() {
         $previews = array(
             array(
-                'title' => 'Standard horizontal :',
+                'title' => __('Standard horizontal :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true"]',
             ),
             array(
-                'title' => 'Vertical pour sidebar :',
+                'title' => __('Vertical pour sidebar :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" layout="vertical" theme="minimal"]',
                 'inner_wrapper_style' => 'max-width: 300px;',
             ),
             array(
-                'title' => 'Compact mode sombre :',
+                'title' => __('Compact mode sombre :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" compact="true" theme="dark"]',
             ),
             array(
-                'title' => 'Avec titre personnalisé :',
+                'title' => __('Avec titre personnalisé :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" show_title="true" title="🎮 Notre Communauté Gaming" align="center"]',
             ),
             array(
-                'title' => 'Icônes personnalisées :',
+                'title' => __('Icônes personnalisées :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" icon_online="🔥" label_online="Actifs" icon_total="⚔️" label_total="Guerriers"]',
             ),
             array(
-                'title' => 'Minimaliste (nombres uniquement) :',
+                'title' => __('Minimaliste (nombres uniquement) :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" hide_labels="true" hide_icons="true" theme="minimal"]',
             ),
         );
         ?>
         <div style="background: #e3f2fd; padding: 20px; border-radius: 8px;">
-            <h2>🎨 Prévisualisation en direct</h2>
-            <p>Testez différentes configurations visuelles :</p>
+            <h2><?php esc_html_e('🎨 Prévisualisation en direct', 'discord-bot-jlg'); ?></h2>
+            <p><?php esc_html_e('Testez différentes configurations visuelles :', 'discord-bot-jlg'); ?></p>
             <?php
             foreach ($previews as $preview) {
                 $options = array('container_style' => 'margin: 20px 0;');
@@ -650,134 +675,90 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_guide_section() {
         ?>
         <div style="background: #e8f5e9; padding: 20px; border-radius: 8px;">
-            <h2>📖 Guide d'utilisation</h2>
+            <h2><?php esc_html_e("📖 Guide d'utilisation", 'discord-bot-jlg'); ?></h2>
 
-            <h3>Option 1 : Shortcode (avec paramètres)</h3>
-            <p>Copiez ce code dans n'importe quelle page ou article :</p>
+            <h3><?php esc_html_e('Option 1 : Shortcode (avec paramètres)', 'discord-bot-jlg'); ?></h3>
+            <p><?php esc_html_e("Copiez ce code dans n'importe quelle page ou article :", 'discord-bot-jlg'); ?></p>
             <code style="background: white; padding: 10px; display: inline-block; border-radius: 4px;">[discord_stats]</code>
 
-            <h4>Exemples avec paramètres :</h4>
-            <pre style="background: white; padding: 15px; border-radius: 4px; overflow-x: auto;">// BASIQUES
-// Layout vertical pour sidebar
-[discord_stats layout="vertical"]
+            <h4><?php esc_html_e('Exemples avec paramètres :', 'discord-bot-jlg'); ?></h4>
+            <pre style="background: white; padding: 15px; border-radius: 4px; overflow-x: auto;"><?php echo esc_html__("// BASIQUES\n// Layout vertical pour sidebar\n[discord_stats layout=\"vertical\"]\n\n// Compact avec titre\n[discord_stats compact=\"true\" show_title=\"true\" title=\"Rejoignez-nous !\"]\n\n// Theme sombre centré\n[discord_stats theme=\"dark\" align=\"center\"]\n\n// AVEC LOGO DISCORD\n// Logo à gauche (classique)\n[discord_stats show_discord_icon=\"true\"]\n\n// Logo à droite avec thème sombre\n[discord_stats show_discord_icon=\"true\" discord_icon_position=\"right\" theme=\"dark\"]\n\n// Logo centré en haut (parfait pour widgets)\n[discord_stats show_discord_icon=\"true\" discord_icon_position=\"top\" align=\"center\"]\n\n// PERSONNALISATION AVANCÉE\n// Bannière complète pour header\n[discord_stats show_discord_icon=\"true\" show_title=\"true\" title=\"🎮 Rejoignez notre Discord !\" width=\"100%\" align=\"center\" theme=\"discord\"]\n\n// Sidebar élégante avec logo\n[discord_stats layout=\"vertical\" show_discord_icon=\"true\" discord_icon_position=\"top\" theme=\"minimal\" compact=\"true\"]\n\n// Gaming style avec icônes custom\n[discord_stats show_discord_icon=\"true\" icon_online=\"🎮\" label_online=\"Joueurs actifs\" icon_total=\"⚔️\" label_total=\"Guerriers\" theme=\"dark\"]\n\n// Minimaliste avec logo seul\n[discord_stats hide_labels=\"true\" hide_icons=\"true\" show_discord_icon=\"true\" discord_icon_position=\"top\" align=\"center\" theme=\"minimal\"]\n\n// Footer discret\n[discord_stats compact=\"true\" show_discord_icon=\"true\" discord_icon_position=\"left\" theme=\"light\"]\n\n// FONCTIONNALITÉS SPÉCIALES\n// Auto-refresh toutes les 30 secondes (minimum 10 secondes)\n[discord_stats refresh=\"true\" refresh_interval=\"30\" show_discord_icon=\"true\"]\n\n// Afficher seulement les membres en ligne avec logo\n[discord_stats show_online=\"true\" show_total=\"false\" show_discord_icon=\"true\"]\n\n// MODE DÉMO (pour tester l'apparence)\n[discord_stats demo=\"true\" show_discord_icon=\"true\" theme=\"dark\" layout=\"vertical\"]", 'discord-bot-jlg'); ?></pre>
 
-// Compact avec titre
-[discord_stats compact="true" show_title="true" title="Rejoignez-nous !"]
+            <p style="margin-top: 10px;"><em><?php esc_html_e("ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10 secondes (10 000 ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429.", 'discord-bot-jlg'); ?></em></p>
 
-// Theme sombre centré
-[discord_stats theme="dark" align="center"]
-
-// AVEC LOGO DISCORD
-// Logo à gauche (classique)
-[discord_stats show_discord_icon="true"]
-
-// Logo à droite avec thème sombre
-[discord_stats show_discord_icon="true" discord_icon_position="right" theme="dark"]
-
-// Logo centré en haut (parfait pour widgets)
-[discord_stats show_discord_icon="true" discord_icon_position="top" align="center"]
-
-// PERSONNALISATION AVANCÉE
-// Bannière complète pour header
-[discord_stats show_discord_icon="true" show_title="true" title="🎮 Rejoignez notre Discord !" width="100%" align="center" theme="discord"]
-
-// Sidebar élégante avec logo
-[discord_stats layout="vertical" show_discord_icon="true" discord_icon_position="top" theme="minimal" compact="true"]
-
-// Gaming style avec icônes custom
-[discord_stats show_discord_icon="true" icon_online="🎮" label_online="Joueurs actifs" icon_total="⚔️" label_total="Guerriers" theme="dark"]
-
-// Minimaliste avec logo seul
-[discord_stats hide_labels="true" hide_icons="true" show_discord_icon="true" discord_icon_position="top" align="center" theme="minimal"]
-
-// Footer discret
-[discord_stats compact="true" show_discord_icon="true" discord_icon_position="left" theme="light"]
-
-// FONCTIONNALITÉS SPÉCIALES
-// Auto-refresh toutes les 30 secondes (minimum 10 secondes)
-[discord_stats refresh="true" refresh_interval="30" show_discord_icon="true"]
-
-// Afficher seulement les membres en ligne avec logo
-[discord_stats show_online="true" show_total="false" show_discord_icon="true"]
-
-// MODE DÉMO (pour tester l'apparence)
-[discord_stats demo="true" show_discord_icon="true" theme="dark" layout="vertical"]</pre>
-
-            <p style="margin-top: 10px;"><em>ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10&nbsp;secondes (10 000&nbsp;ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429.</em></p>
-
-            <h4>Tous les paramètres disponibles :</h4>
+            <h4><?php esc_html_e('Tous les paramètres disponibles :', 'discord-bot-jlg'); ?></h4>
             <div style="background: white; padding: 15px; border-radius: 4px;">
-                <h5>🎨 Apparence & Layout :</h5>
+                <h5><?php esc_html_e('🎨 Apparence & Layout :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>layout</strong> : horizontal, vertical, compact</li>
-                    <li><strong>theme</strong> : discord, dark, light, minimal</li>
-                    <li><strong>align</strong> : left, center, right</li>
-                    <li><strong>width</strong> : largeur CSS (ex: "300px", "100%")</li>
-                    <li><strong>compact</strong> : true/false (version réduite)</li>
-                    <li><strong>animated</strong> : true/false (animations hover)</li>
-                    <li><strong>class</strong> : classes CSS additionnelles</li>
+                    <li><?php echo wp_kses_post(__('<strong>layout</strong> : horizontal, vertical, compact', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>theme</strong> : discord, dark, light, minimal', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>align</strong> : left, center, right', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>width</strong> : largeur CSS (ex : "300px", "100%")', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>compact</strong> : true/false (version réduite)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>animated</strong> : true/false (animations hover)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>class</strong> : classes CSS additionnelles', 'discord-bot-jlg')); ?></li>
                 </ul>
 
-                <h5>🎯 Logo Discord :</h5>
+                <h5><?php esc_html_e('🎯 Logo Discord :', 'discord-bot-jlg'); ?></h5>
                 <ul>
-                    <li><strong>show_discord_icon</strong> : true/false (afficher le logo officiel)</li>
-                    <li><strong>discord_icon_position</strong> : left, right, top (position du logo)</li>
+                    <li><?php echo wp_kses_post(__('<strong>show_discord_icon</strong> : true/false (afficher le logo officiel)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>discord_icon_position</strong> : left, right, top (position du logo)', 'discord-bot-jlg')); ?></li>
                 </ul>
 
-                <h5>📊 Données affichées :</h5>
+                <h5><?php esc_html_e('📊 Données affichées :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>show_online</strong> : true/false</li>
-                    <li><strong>show_total</strong> : true/false</li>
-                    <li><strong>show_title</strong> : true/false</li>
-                    <li><strong>title</strong> : texte du titre</li>
-                    <li><strong>hide_labels</strong> : true/false</li>
-                    <li><strong>hide_icons</strong> : true/false</li>
+                    <li><?php echo wp_kses_post(__('<strong>show_online</strong> : true/false', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>show_total</strong> : true/false', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>show_title</strong> : true/false', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>title</strong> : texte du titre', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>hide_labels</strong> : true/false', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>hide_icons</strong> : true/false', 'discord-bot-jlg')); ?></li>
                 </ul>
 
-                <h5>✏️ Personnalisation textes/icônes :</h5>
+                <h5><?php esc_html_e('✏️ Personnalisation textes/icônes :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>icon_online</strong> : emoji/texte (défaut: 🟢)</li>
-                    <li><strong>icon_total</strong> : emoji/texte (défaut: 👥)</li>
-                    <li><strong>label_online</strong> : texte personnalisé</li>
-                    <li><strong>label_total</strong> : texte personnalisé</li>
+                    <li><?php echo wp_kses_post(__('<strong>icon_online</strong> : emoji/texte (défaut : 🟢)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>icon_total</strong> : emoji/texte (défaut : 👥)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>label_online</strong> : texte personnalisé', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>label_total</strong> : texte personnalisé', 'discord-bot-jlg')); ?></li>
                 </ul>
 
-                <h5>⚙️ Paramètres techniques :</h5>
+                <h5><?php esc_html_e('⚙️ Paramètres techniques :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>refresh</strong> : true/false (auto-actualisation)</li>
-                    <li><strong>refresh_interval</strong> : secondes (minimum 10&nbsp;secondes / 10 000&nbsp;ms)</li>
-                    <li><strong>demo</strong> : true/false (mode démonstration)</li>
-                    <li><strong>border_radius</strong> : pixels (coins arrondis)</li>
-                    <li><strong>gap</strong> : pixels (espace entre éléments)</li>
-                    <li><strong>padding</strong> : pixels (espacement interne)</li>
+                    <li><?php echo wp_kses_post(__('<strong>refresh</strong> : true/false (auto-actualisation)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>refresh_interval</strong> : secondes (minimum 10 secondes / 10 000 ms)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>demo</strong> : true/false (mode démonstration)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>border_radius</strong> : pixels (coins arrondis)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>gap</strong> : pixels (espace entre éléments)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>padding</strong> : pixels (espacement interne)', 'discord-bot-jlg')); ?></li>
                 </ul>
             </div>
 
-            <h3>Option 2 : Widget</h3>
-            <p>Allez dans <strong>Apparence > Widgets</strong> et ajoutez le widget <strong>"Discord Bot - JLG"</strong> dans votre sidebar</p>
+            <h3><?php esc_html_e('Option 2 : Widget', 'discord-bot-jlg'); ?></h3>
+            <p><?php echo wp_kses_post(__('Allez dans <strong>Apparence &gt; Widgets</strong> et ajoutez le widget <strong>"Discord Bot - JLG"</strong> dans votre sidebar', 'discord-bot-jlg')); ?></p>
 
-            <h3>Option 3 : Code PHP</h3>
-            <p>Pour les développeurs, dans vos templates PHP :</p>
+            <h3><?php esc_html_e('Option 3 : Code PHP', 'discord-bot-jlg'); ?></h3>
+            <p><?php esc_html_e('Pour les développeurs, dans vos templates PHP :', 'discord-bot-jlg'); ?></p>
             <code style="background: white; padding: 10px; display: block; border-radius: 4px;">
                 &lt;?php echo do_shortcode('[discord_stats show_discord_icon="true"]'); ?&gt;
             </code>
 
-            <h3>💡 Configurations recommandées</h3>
+            <h3><?php esc_html_e('💡 Configurations recommandées', 'discord-bot-jlg'); ?></h3>
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 15px;">
                 <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour une sidebar :</strong><br>
+                    <strong><?php esc_html_e('Pour une sidebar :', 'discord-bot-jlg'); ?></strong><br>
                     <code style="font-size: 12px;">[discord_stats layout="vertical" show_discord_icon="true" discord_icon_position="top" compact="true"]</code>
                 </div>
                 <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour un header :</strong><br>
+                    <strong><?php esc_html_e('Pour un header :', 'discord-bot-jlg'); ?></strong><br>
                     <code style="font-size: 12px;">[discord_stats show_discord_icon="true" show_title="true" title="Join us!" align="center" width="100%"]</code>
                 </div>
                 <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour un footer :</strong><br>
+                    <strong><?php esc_html_e('Pour un footer :', 'discord-bot-jlg'); ?></strong><br>
                     <code style="font-size: 12px;">[discord_stats theme="dark" show_discord_icon="true" compact="true"]</code>
                 </div>
                 <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Style gaming :</strong><br>
+                    <strong><?php esc_html_e('Style gaming :', 'discord-bot-jlg'); ?></strong><br>
                     <code style="font-size: 12px;">[discord_stats theme="dark" icon_online="🎮" label_online="Players" show_discord_icon="true"]</code>
                 </div>
             </div>
@@ -791,12 +772,12 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_troubleshooting() {
         ?>
         <div style="background: #fff8e1; padding: 20px; border-radius: 8px;">
-            <h2>❓ Dépannage</h2>
+            <h2><?php esc_html_e('❓ Dépannage', 'discord-bot-jlg'); ?></h2>
             <ul>
-                <li><strong>Erreur de connexion ?</strong> Vérifiez que le bot est bien sur votre serveur</li>
-                <li><strong>Stats à 0 ?</strong> Assurez-vous que le widget est activé dans les paramètres Discord</li>
-                <li><strong>Token invalide ?</strong> Régénérez le token dans le Developer Portal</li>
-                <li><strong>Cache ?</strong> Les stats sont mises à jour toutes les 5 minutes par défaut</li>
+                <li><?php echo wp_kses_post(__('<strong>Erreur de connexion&nbsp;?</strong> Vérifiez que le bot est bien sur votre serveur', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('<strong>Stats à 0&nbsp;?</strong> Assurez-vous que le widget est activé dans les paramètres Discord', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('<strong>Token invalide&nbsp;?</strong> Régénérez le token dans le Developer Portal', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('<strong>Cache&nbsp;?</strong> Les stats sont mises à jour toutes les 5 minutes par défaut', 'discord-bot-jlg')); ?></li>
             </ul>
         </div>
         <?php
@@ -808,9 +789,18 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_footer_note() {
         ?>
         <div style="margin-top: 30px; padding: 15px; background: #f0f0f0; border-radius: 8px; text-align: center;">
-            <p style="margin: 0;">Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse |
-               <a href="https://discord.com/developers/docs/intro" target="_blank">Documentation Discord API</a> |
-               <a href="#" onclick="return false;">Besoin d'aide ?</a>
+            <p style="margin: 0;">
+                <?php
+                echo wp_kses_post(
+                    sprintf(
+                        /* translators: 1: Plugin credits. 2: Documentation link. 3: Help link. */
+                        __('%1$s | %2$s | %3$s', 'discord-bot-jlg'),
+                        esc_html__('Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse', 'discord-bot-jlg'),
+                        '<a href="https://discord.com/developers/docs/intro" target="_blank">' . esc_html__('Documentation Discord API', 'discord-bot-jlg') . '</a>',
+                        '<a href="#" onclick="return false;">' . esc_html__("Besoin d'aide ?", 'discord-bot-jlg') . '</a>'
+                    )
+                );
+                ?>
             </p>
         </div>
         <?php
@@ -859,7 +849,10 @@ class Discord_Bot_JLG_Admin {
         }
 
         if (!empty($options['demo_mode'])) {
-            echo '<div class="notice notice-info"><p>🎨 Mode démonstration activé - Les données affichées sont fictives</p></div>';
+            printf(
+                '<div class="notice notice-info"><p>%s</p></div>',
+                esc_html__('🎨 Mode démonstration activé - Les données affichées sont fictives', 'discord-bot-jlg')
+            );
             return;
         }
 
@@ -881,16 +874,28 @@ class Discord_Bot_JLG_Admin {
                 $total_display = esc_html__('Total indisponible', 'discord-bot-jlg');
             }
 
-            printf(
-                '<div class="notice notice-success"><p>✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres</p></div>',
-                esc_html($server_name),
-                esc_html(number_format_i18n($online_count)),
-                $total_display
+            echo wp_kses_post(
+                sprintf(
+                    '<div class="notice notice-success"><p>%s</p></div>',
+                    sprintf(
+                        /* translators: 1: Server name, 2: Online members, 3: Total members. */
+                        esc_html__('✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres', 'discord-bot-jlg'),
+                        esc_html($server_name),
+                        esc_html(number_format_i18n($online_count)),
+                        $total_display
+                    )
+                )
             );
         } elseif (is_array($stats) && !empty($stats['is_demo'])) {
-            echo '<div class="notice notice-warning"><p>⚠️ Pas de configuration Discord détectée. Mode démo actif.</p></div>';
+            printf(
+                '<div class="notice notice-warning"><p>%s</p></div>',
+                esc_html__('⚠️ Pas de configuration Discord détectée. Mode démo actif.', 'discord-bot-jlg')
+            );
         } else {
-            echo '<div class="notice notice-error"><p>❌ Échec de la connexion. Vérifiez vos identifiants.</p></div>';
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html__('❌ Échec de la connexion. Vérifiez vos identifiants.', 'discord-bot-jlg')
+            );
         }
     }
 

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -156,7 +156,7 @@ class Discord_Bot_JLG_API {
                 );
             }
 
-            wp_send_json_error('Nonce invalide', 403);
+            wp_send_json_error(esc_html__('Nonce invalide', 'discord-bot-jlg'), 403);
         }
 
         $options = get_option($this->option_name);
@@ -165,7 +165,7 @@ class Discord_Bot_JLG_API {
         }
 
         if (!empty($options['demo_mode'])) {
-            wp_send_json_error('Mode démo actif');
+            wp_send_json_error(esc_html__('Mode démo actif', 'discord-bot-jlg'));
         }
 
         $rate_limit_key = $this->cache_key . '_refresh_lock';
@@ -246,7 +246,7 @@ class Discord_Bot_JLG_API {
 
         delete_transient($rate_limit_key);
 
-        wp_send_json_error('Impossible de récupérer les stats');
+        wp_send_json_error(esc_html__('Impossible de récupérer les stats', 'discord-bot-jlg'));
     }
 
     /**
@@ -273,7 +273,7 @@ class Discord_Bot_JLG_API {
         return array(
             'online'               => (int) round($base_online + $variation),
             'total'                => (int) $base_total,
-            'server_name'          => 'Serveur Démo',
+            'server_name'          => esc_html__('Serveur Démo', 'discord-bot-jlg'),
             'is_demo'              => true,
             'has_total'            => true,
             'total_is_approximate' => false,

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -59,8 +59,8 @@ class Discord_Bot_JLG_Shortcode {
                 'class'                => '',
                 'icon_online'          => '🟢',
                 'icon_total'           => '👥',
-                'label_online'         => 'En ligne',
-                'label_total'          => 'Membres',
+                'label_online'         => esc_html__('En ligne', 'discord-bot-jlg'),
+                'label_total'          => esc_html__('Membres', 'discord-bot-jlg'),
                 'hide_labels'          => false,
                 'hide_icons'           => false,
                 'border_radius'        => '8',
@@ -92,7 +92,10 @@ class Discord_Bot_JLG_Shortcode {
         }
 
         if (!is_array($stats)) {
-            return '<div class="discord-stats-error">Impossible de récupérer les stats Discord</div>';
+            return sprintf(
+                '<div class="discord-stats-error">%s</div>',
+                esc_html__('Impossible de récupérer les stats Discord', 'discord-bot-jlg')
+            );
         }
 
         $this->enqueue_assets($options);
@@ -174,7 +177,7 @@ class Discord_Bot_JLG_Shortcode {
         <div <?php echo implode(' ', $attributes); ?>>
 
             <?php if (!empty($stats['is_demo'])): ?>
-            <div class="discord-demo-badge">Mode Démo</div>
+            <div class="discord-demo-badge"><?php esc_html_e('Mode Démo', 'discord-bot-jlg'); ?></div>
             <?php endif; ?>
 
             <?php if ($show_title): ?>
@@ -310,6 +313,9 @@ class Discord_Bot_JLG_Shortcode {
                 'minRefreshInterval' => defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
                     ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
                     : 10,
+                'messages' => array(
+                    'updateError' => __('Erreur lors de la mise à jour des statistiques Discord :', 'discord-bot-jlg'),
+                ),
             )
         );
 

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -16,8 +16,8 @@ class Discord_Stats_Widget extends WP_Widget {
     public function __construct() {
         parent::__construct(
             'discord_stats_widget',
-            'Discord Bot - JLG',
-            array('description' => 'Affiche les statistiques de votre serveur Discord')
+            __('Discord Bot - JLG', 'discord-bot-jlg'),
+            array('description' => esc_html__('Affiche les statistiques de votre serveur Discord', 'discord-bot-jlg'))
         );
     }
 
@@ -25,7 +25,7 @@ class Discord_Stats_Widget extends WP_Widget {
         echo $args['before_widget'];
 
         $options = get_option(DISCORD_BOT_JLG_OPTION_NAME);
-        $title   = !empty($options['widget_title']) ? $options['widget_title'] : 'Discord Server';
+        $title   = !empty($options['widget_title']) ? $options['widget_title'] : esc_html__('Discord Server', 'discord-bot-jlg');
 
         if (!empty($title)) {
             echo $args['before_title'] . apply_filters('widget_title', $title) . $args['after_title'];
@@ -39,7 +39,15 @@ class Discord_Stats_Widget extends WP_Widget {
     public function form($instance) {
         ?>
         <p>
-            Configurez les options dans le menu principal <a href="<?php echo esc_url(admin_url('admin.php?page=discord-bot-jlg')); ?>">Discord Bot</a>
+            <?php
+            echo wp_kses_post(
+                sprintf(
+                    /* translators: %s: Admin menu label. */
+                    __('Configurez les options dans le menu principal <a href="%s">Discord Bot</a>', 'discord-bot-jlg'),
+                    esc_url(admin_url('admin.php?page=discord-bot-jlg'))
+                )
+            );
+            ?>
         </p>
         <?php
     }

--- a/discord-bot-jlg/languages/discord-bot-jlg.pot
+++ b/discord-bot-jlg/languages/discord-bot-jlg.pot
@@ -1,0 +1,721 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the discord-bot-jlg package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: discord-bot-jlg\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-19 19:49+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: discord-bot-jlg.php:55 inc/class-discord-widget.php:28
+msgid "Discord Server"
+msgstr ""
+
+#: inc/class-discord-admin.php:37 inc/class-discord-widget.php:19
+msgid "Discord Bot - JLG"
+msgstr ""
+
+#: inc/class-discord-admin.php:38
+msgid "Discord Bot"
+msgstr ""
+
+#: inc/class-discord-admin.php:48 inc/class-discord-admin.php:49
+msgid "Configuration"
+msgstr ""
+
+#: inc/class-discord-admin.php:57 inc/class-discord-admin.php:58
+msgid "Guide & Démo"
+msgstr ""
+
+#: inc/class-discord-admin.php:81
+msgid "Configuration Discord API"
+msgstr ""
+
+#: inc/class-discord-admin.php:88
+msgid "ID du Serveur Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:96
+msgid "Token du Bot Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:104
+msgid "Options d'affichage"
+msgstr ""
+
+#: inc/class-discord-admin.php:111
+msgid "Mode démonstration"
+msgstr ""
+
+#: inc/class-discord-admin.php:119
+msgid "Afficher les membres en ligne"
+msgstr ""
+
+#: inc/class-discord-admin.php:127
+msgid "Afficher le total des membres"
+msgstr ""
+
+#: inc/class-discord-admin.php:135
+msgid "Titre du widget"
+msgstr ""
+
+#: inc/class-discord-admin.php:143
+msgid "Durée du cache (secondes)"
+msgstr ""
+
+#: inc/class-discord-admin.php:151
+msgid "CSS personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:223
+msgid "📚 Guide étape par étape"
+msgstr ""
+
+#: inc/class-discord-admin.php:237
+msgid "Étape 1 : Créer un Bot Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:244
+#, php-format
+msgid ""
+"Rendez-vous sur <a href=\"%s\" target=\"_blank\" style=\"color: #5865F2;"
+"\">Discord Developer Portal</a>"
+msgstr ""
+
+#: inc/class-discord-admin.php:250
+msgid "Cliquez sur <strong>\"New Application\"</strong> en haut à droite"
+msgstr ""
+
+#: inc/class-discord-admin.php:251
+msgid "Donnez un nom à votre application (ex : \"Stats Bot\")"
+msgstr ""
+
+#: inc/class-discord-admin.php:252
+msgid "Dans le menu de gauche, cliquez sur <strong>\"Bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:253
+msgid "Cliquez sur <strong>\"Add Bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:254
+msgid ""
+"Sous \"Token\", cliquez sur <strong>\"Copy\"</strong> pour copier le token "
+"du bot"
+msgstr ""
+
+#: inc/class-discord-admin.php:255
+msgid ""
+"⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez "
+"jamais !"
+msgstr ""
+
+#: inc/class-discord-admin.php:258
+msgid "Étape 2 : Inviter le Bot sur votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:260
+msgid ""
+"Dans le menu de gauche, allez dans <strong>\"OAuth2\"</strong> &gt; "
+"<strong>\"URL Generator\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:261
+msgid "Dans \"Scopes\", cochez <strong>\"bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:262
+msgid "Dans \"Bot Permissions\", sélectionnez :"
+msgstr ""
+
+#: inc/class-discord-admin.php:264
+msgid "✅ View Channels"
+msgstr ""
+
+#: inc/class-discord-admin.php:265
+msgid "✅ Read Messages"
+msgstr ""
+
+#: inc/class-discord-admin.php:266
+msgid "✅ Send Messages (optionnel)"
+msgstr ""
+
+#: inc/class-discord-admin.php:268
+msgid "Copiez l'URL générée en bas de la page"
+msgstr ""
+
+#: inc/class-discord-admin.php:269
+msgid "Ouvrez cette URL dans votre navigateur"
+msgstr ""
+
+#: inc/class-discord-admin.php:270
+msgid ""
+"Sélectionnez votre serveur et cliquez sur <strong>\"Autoriser\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:273
+msgid "Étape 3 : Obtenir l'ID de votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:275
+msgid "Ouvrez Discord (application ou web)"
+msgstr ""
+
+#: inc/class-discord-admin.php:276
+msgid "Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)"
+msgstr ""
+
+#: inc/class-discord-admin.php:277
+msgid ""
+"Dans <strong>\"Avancés\"</strong>, activez <strong>\"Mode développeur\"</"
+"strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:278
+msgid "Retournez sur votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:279
+msgid "Faites un <strong>clic droit sur le nom du serveur</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:280
+msgid "Cliquez sur <strong>\"Copier l'ID\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:283
+msgid "Étape 4 : Activer le Widget (optionnel mais recommandé)"
+msgstr ""
+
+#: inc/class-discord-admin.php:285
+msgid "Dans Discord, allez dans <strong>Paramètres du serveur</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:286
+msgid ""
+"Dans <strong>\"Widget\"</strong>, activez <strong>\"Activer le widget du "
+"serveur\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:287
+msgid "Cela permet une méthode de fallback si le bot a des problèmes"
+msgstr ""
+
+#: inc/class-discord-admin.php:302
+#, php-format
+msgid ""
+"%1$s Après avoir rempli les champs ci-dessous, utilisez le bouton \"%2$s\" "
+"pour vérifier que tout fonctionne !"
+msgstr ""
+
+#: inc/class-discord-admin.php:303
+msgid "Conseil :"
+msgstr ""
+
+#: inc/class-discord-admin.php:304 inc/class-discord-admin.php:532
+msgid "Tester la connexion"
+msgstr ""
+
+#: inc/class-discord-admin.php:310
+msgid "Avec logo Discord officiel :"
+msgstr ""
+
+#: inc/class-discord-admin.php:318
+msgid "Logo Discord centré en haut :"
+msgstr ""
+
+#: inc/class-discord-admin.php:335
+msgid "Personnalisez l'affichage des statistiques Discord."
+msgstr ""
+
+#: inc/class-discord-admin.php:349
+msgid "L'ID de votre serveur Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:364
+msgid "Le token de votre bot Discord (gardez-le secret !)"
+msgstr ""
+
+#: inc/class-discord-admin.php:379
+msgid ""
+"Activer le mode démonstration (affiche des données fictives pour tester "
+"l'apparence)"
+msgstr ""
+
+#: inc/class-discord-admin.php:380
+msgid ""
+"🎨 Parfait pour tester les styles et dispositions sans configuration Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:395
+msgid "Afficher le nombre d'utilisateurs en ligne"
+msgstr ""
+
+#: inc/class-discord-admin.php:410
+msgid "Afficher le nombre total de membres"
+msgstr ""
+
+#: inc/class-discord-admin.php:439
+msgid "Minimum 60 secondes, maximum 3600 secondes (1 heure)"
+msgstr ""
+
+#: inc/class-discord-admin.php:452
+msgid "CSS personnalisé pour styliser l'affichage"
+msgstr ""
+
+#: inc/class-discord-admin.php:464
+msgid "🎮 Discord Bot - JLG - Configuration"
+msgstr ""
+
+#: inc/class-discord-admin.php:525
+msgid "🔧 Test de connexion"
+msgstr ""
+
+#: inc/class-discord-admin.php:526
+msgid "Vérifiez que votre configuration fonctionne :"
+msgstr ""
+
+#: inc/class-discord-admin.php:545
+msgid "🚀 Liens rapides"
+msgstr ""
+
+#: inc/class-discord-admin.php:549
+msgid "📖 Guide & Démo"
+msgstr ""
+
+#: inc/class-discord-admin.php:554
+msgid "🔗 Discord Developer Portal"
+msgstr ""
+
+#: inc/class-discord-admin.php:559
+msgid "📐 Gérer les Widgets"
+msgstr ""
+
+#: inc/class-discord-admin.php:573 inc/class-discord-admin.php:798
+msgid "Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse"
+msgstr ""
+
+#: inc/class-discord-admin.php:586
+msgid "📖 Guide & Démonstration"
+msgstr ""
+
+#: inc/class-discord-admin.php:616
+msgid ""
+"<strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode "
+"démo. Vous pouvez les copier-coller directement !"
+msgstr ""
+
+#: inc/class-discord-admin.php:630
+msgid "Standard horizontal :"
+msgstr ""
+
+#: inc/class-discord-admin.php:634
+msgid "Vertical pour sidebar :"
+msgstr ""
+
+#: inc/class-discord-admin.php:639
+msgid "Compact mode sombre :"
+msgstr ""
+
+#: inc/class-discord-admin.php:643
+msgid "Avec titre personnalisé :"
+msgstr ""
+
+#: inc/class-discord-admin.php:647
+msgid "Icônes personnalisées :"
+msgstr ""
+
+#: inc/class-discord-admin.php:651
+msgid "Minimaliste (nombres uniquement) :"
+msgstr ""
+
+#: inc/class-discord-admin.php:657
+msgid "🎨 Prévisualisation en direct"
+msgstr ""
+
+#: inc/class-discord-admin.php:658
+msgid "Testez différentes configurations visuelles :"
+msgstr ""
+
+#: inc/class-discord-admin.php:678
+msgid "📖 Guide d'utilisation"
+msgstr ""
+
+#: inc/class-discord-admin.php:680
+msgid "Option 1 : Shortcode (avec paramètres)"
+msgstr ""
+
+#: inc/class-discord-admin.php:681
+msgid "Copiez ce code dans n'importe quelle page ou article :"
+msgstr ""
+
+#: inc/class-discord-admin.php:684
+msgid "Exemples avec paramètres :"
+msgstr ""
+
+#: inc/class-discord-admin.php:685
+msgid ""
+"// BASIQUES\n"
+"// Layout vertical pour sidebar\n"
+"[discord_stats layout=\"vertical\"]\n"
+"\n"
+"// Compact avec titre\n"
+"[discord_stats compact=\"true\" show_title=\"true\" title=\"Rejoignez-nous !"
+"\"]\n"
+"\n"
+"// Theme sombre centré\n"
+"[discord_stats theme=\"dark\" align=\"center\"]\n"
+"\n"
+"// AVEC LOGO DISCORD\n"
+"// Logo à gauche (classique)\n"
+"[discord_stats show_discord_icon=\"true\"]\n"
+"\n"
+"// Logo à droite avec thème sombre\n"
+"[discord_stats show_discord_icon=\"true\" discord_icon_position=\"right\" "
+"theme=\"dark\"]\n"
+"\n"
+"// Logo centré en haut (parfait pour widgets)\n"
+"[discord_stats show_discord_icon=\"true\" discord_icon_position=\"top\" "
+"align=\"center\"]\n"
+"\n"
+"// PERSONNALISATION AVANCÉE\n"
+"// Bannière complète pour header\n"
+"[discord_stats show_discord_icon=\"true\" show_title=\"true\" title=\"🎮 "
+"Rejoignez notre Discord !\" width=\"100%\" align=\"center\" "
+"theme=\"discord\"]\n"
+"\n"
+"// Sidebar élégante avec logo\n"
+"[discord_stats layout=\"vertical\" show_discord_icon=\"true\" "
+"discord_icon_position=\"top\" theme=\"minimal\" compact=\"true\"]\n"
+"\n"
+"// Gaming style avec icônes custom\n"
+"[discord_stats show_discord_icon=\"true\" icon_online=\"🎮\" "
+"label_online=\"Joueurs actifs\" icon_total=\"⚔️\" label_total=\"Guerriers\" "
+"theme=\"dark\"]\n"
+"\n"
+"// Minimaliste avec logo seul\n"
+"[discord_stats hide_labels=\"true\" hide_icons=\"true\" "
+"show_discord_icon=\"true\" discord_icon_position=\"top\" align=\"center\" "
+"theme=\"minimal\"]\n"
+"\n"
+"// Footer discret\n"
+"[discord_stats compact=\"true\" show_discord_icon=\"true\" "
+"discord_icon_position=\"left\" theme=\"light\"]\n"
+"\n"
+"// FONCTIONNALITÉS SPÉCIALES\n"
+"// Auto-refresh toutes les 30 secondes (minimum 10 secondes)\n"
+"[discord_stats refresh=\"true\" refresh_interval=\"30\" "
+"show_discord_icon=\"true\"]\n"
+"\n"
+"// Afficher seulement les membres en ligne avec logo\n"
+"[discord_stats show_online=\"true\" show_total=\"false\" "
+"show_discord_icon=\"true\"]\n"
+"\n"
+"// MODE DÉMO (pour tester l'apparence)\n"
+"[discord_stats demo=\"true\" show_discord_icon=\"true\" theme=\"dark\" "
+"layout=\"vertical\"]"
+msgstr ""
+
+#: inc/class-discord-admin.php:687
+msgid ""
+"ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10 secondes (10 000 ms). "
+"Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs "
+"429."
+msgstr ""
+
+#: inc/class-discord-admin.php:689
+msgid "Tous les paramètres disponibles :"
+msgstr ""
+
+#: inc/class-discord-admin.php:691
+msgid "🎨 Apparence & Layout :"
+msgstr ""
+
+#: inc/class-discord-admin.php:693
+msgid "<strong>layout</strong> : horizontal, vertical, compact"
+msgstr ""
+
+#: inc/class-discord-admin.php:694
+msgid "<strong>theme</strong> : discord, dark, light, minimal"
+msgstr ""
+
+#: inc/class-discord-admin.php:695
+msgid "<strong>align</strong> : left, center, right"
+msgstr ""
+
+#: inc/class-discord-admin.php:696
+msgid "<strong>width</strong> : largeur CSS (ex : \"300px\", \"100%\")"
+msgstr ""
+
+#: inc/class-discord-admin.php:697
+msgid "<strong>compact</strong> : true/false (version réduite)"
+msgstr ""
+
+#: inc/class-discord-admin.php:698
+msgid "<strong>animated</strong> : true/false (animations hover)"
+msgstr ""
+
+#: inc/class-discord-admin.php:699
+msgid "<strong>class</strong> : classes CSS additionnelles"
+msgstr ""
+
+#: inc/class-discord-admin.php:702
+msgid "🎯 Logo Discord :"
+msgstr ""
+
+#: inc/class-discord-admin.php:704
+msgid ""
+"<strong>show_discord_icon</strong> : true/false (afficher le logo officiel)"
+msgstr ""
+
+#: inc/class-discord-admin.php:705
+msgid ""
+"<strong>discord_icon_position</strong> : left, right, top (position du logo)"
+msgstr ""
+
+#: inc/class-discord-admin.php:708
+msgid "📊 Données affichées :"
+msgstr ""
+
+#: inc/class-discord-admin.php:710
+msgid "<strong>show_online</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:711
+msgid "<strong>show_total</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:712
+msgid "<strong>show_title</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:713
+msgid "<strong>title</strong> : texte du titre"
+msgstr ""
+
+#: inc/class-discord-admin.php:714
+msgid "<strong>hide_labels</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:715
+msgid "<strong>hide_icons</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:718
+msgid "✏️ Personnalisation textes/icônes :"
+msgstr ""
+
+#: inc/class-discord-admin.php:720
+msgid "<strong>icon_online</strong> : emoji/texte (défaut : 🟢)"
+msgstr ""
+
+#: inc/class-discord-admin.php:721
+msgid "<strong>icon_total</strong> : emoji/texte (défaut : 👥)"
+msgstr ""
+
+#: inc/class-discord-admin.php:722
+msgid "<strong>label_online</strong> : texte personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:723
+msgid "<strong>label_total</strong> : texte personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:726
+msgid "⚙️ Paramètres techniques :"
+msgstr ""
+
+#: inc/class-discord-admin.php:728
+msgid "<strong>refresh</strong> : true/false (auto-actualisation)"
+msgstr ""
+
+#: inc/class-discord-admin.php:729
+msgid ""
+"<strong>refresh_interval</strong> : secondes (minimum 10 secondes / "
+"10 000 ms)"
+msgstr ""
+
+#: inc/class-discord-admin.php:730
+msgid "<strong>demo</strong> : true/false (mode démonstration)"
+msgstr ""
+
+#: inc/class-discord-admin.php:731
+msgid "<strong>border_radius</strong> : pixels (coins arrondis)"
+msgstr ""
+
+#: inc/class-discord-admin.php:732
+msgid "<strong>gap</strong> : pixels (espace entre éléments)"
+msgstr ""
+
+#: inc/class-discord-admin.php:733
+msgid "<strong>padding</strong> : pixels (espacement interne)"
+msgstr ""
+
+#: inc/class-discord-admin.php:737
+msgid "Option 2 : Widget"
+msgstr ""
+
+#: inc/class-discord-admin.php:738
+msgid ""
+"Allez dans <strong>Apparence &gt; Widgets</strong> et ajoutez le widget "
+"<strong>\"Discord Bot - JLG\"</strong> dans votre sidebar"
+msgstr ""
+
+#: inc/class-discord-admin.php:740
+msgid "Option 3 : Code PHP"
+msgstr ""
+
+#: inc/class-discord-admin.php:741
+msgid "Pour les développeurs, dans vos templates PHP :"
+msgstr ""
+
+#: inc/class-discord-admin.php:746
+msgid "💡 Configurations recommandées"
+msgstr ""
+
+#: inc/class-discord-admin.php:749
+msgid "Pour une sidebar :"
+msgstr ""
+
+#: inc/class-discord-admin.php:753
+msgid "Pour un header :"
+msgstr ""
+
+#: inc/class-discord-admin.php:757
+msgid "Pour un footer :"
+msgstr ""
+
+#: inc/class-discord-admin.php:761
+msgid "Style gaming :"
+msgstr ""
+
+#: inc/class-discord-admin.php:775
+msgid "❓ Dépannage"
+msgstr ""
+
+#: inc/class-discord-admin.php:777
+msgid ""
+"<strong>Erreur de connexion&nbsp;?</strong> Vérifiez que le bot est bien sur "
+"votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:778
+msgid ""
+"<strong>Stats à 0&nbsp;?</strong> Assurez-vous que le widget est activé dans "
+"les paramètres Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:779
+msgid ""
+"<strong>Token invalide&nbsp;?</strong> Régénérez le token dans le Developer "
+"Portal"
+msgstr ""
+
+#: inc/class-discord-admin.php:780
+msgid ""
+"<strong>Cache&nbsp;?</strong> Les stats sont mises à jour toutes les 5 "
+"minutes par défaut"
+msgstr ""
+
+#: inc/class-discord-admin.php:797
+#, php-format
+msgid "%1$s | %2$s | %3$s"
+msgstr ""
+
+#: inc/class-discord-admin.php:799
+msgid "Documentation Discord API"
+msgstr ""
+
+#: inc/class-discord-admin.php:800
+msgid "Besoin d'aide ?"
+msgstr ""
+
+#: inc/class-discord-admin.php:854
+msgid "🎨 Mode démonstration activé - Les données affichées sont fictives"
+msgstr ""
+
+#: inc/class-discord-admin.php:874 inc/class-discord-shortcode.php:238
+#: inc/class-discord-shortcode.php:240
+msgid "Total indisponible"
+msgstr ""
+
+#: inc/class-discord-admin.php:882
+#, php-format
+msgid "✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres"
+msgstr ""
+
+#: inc/class-discord-admin.php:892
+msgid "⚠️ Pas de configuration Discord détectée. Mode démo actif."
+msgstr ""
+
+#: inc/class-discord-admin.php:897
+msgid "❌ Échec de la connexion. Vérifiez vos identifiants."
+msgstr ""
+
+#: inc/class-discord-api.php:159
+msgid "Nonce invalide"
+msgstr ""
+
+#: inc/class-discord-api.php:168
+msgid "Mode démo actif"
+msgstr ""
+
+#: inc/class-discord-api.php:193
+#, php-format
+msgid "Veuillez patienter %d secondes avant la prochaine actualisation."
+msgstr ""
+
+#: inc/class-discord-api.php:241
+msgid "Actualisation en cours, veuillez réessayer dans quelques instants."
+msgstr ""
+
+#: inc/class-discord-api.php:249
+msgid "Impossible de récupérer les stats"
+msgstr ""
+
+#: inc/class-discord-api.php:276
+msgid "Serveur Démo"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:62
+msgid "En ligne"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:63
+msgid "Membres"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:97
+msgid "Impossible de récupérer les stats Discord"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:180
+msgid "Mode Démo"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:226
+msgid "approx."
+msgstr ""
+
+#: inc/class-discord-shortcode.php:317
+msgid "Erreur lors de la mise à jour des statistiques Discord :"
+msgstr ""
+
+#: inc/class-discord-widget.php:20
+msgid "Affiche les statistiques de votre serveur Discord"
+msgstr ""
+
+#: inc/class-discord-widget.php:46
+#, php-format
+msgid ""
+"Configurez les options dans le menu principal <a href=\"%s\">Discord Bot</a>"
+msgstr ""


### PR DESCRIPTION
## Summary
- localize the admin menus, settings fields, helper content, and status messages using WordPress i18n helpers
- translate default shortcode/widget labels, API responses, and expose frontend error messaging for localization
- regenerate the POT catalog with the new translatable strings

## Testing
- php -l inc/class-discord-admin.php
- php -l inc/class-discord-shortcode.php
- php -l inc/class-discord-widget.php
- php -l inc/class-discord-api.php
- php -l discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb27eab80832eac8e0595b5e87ea3