### PR TITLE
Use plugin version constant for asset cache busting

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -14,6 +14,11 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+if (!defined('DISCORD_BOT_JLG_VERSION')) {
+    $plugin_data = get_file_data(__FILE__, array('Version' => 'Version'));
+    define('DISCORD_BOT_JLG_VERSION', !empty($plugin_data['Version']) ? $plugin_data['Version'] : '');
+}
+
 define('DISCORD_BOT_JLG_PLUGIN_PATH', plugin_dir_path(__FILE__));
 define('DISCORD_BOT_JLG_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('DISCORD_BOT_JLG_OPTION_NAME', 'discord_server_stats_options');

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -852,7 +852,7 @@ class Discord_Bot_JLG_Admin {
             'discord-bot-jlg-admin',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg-admin.css',
             array(),
-            '1.0'
+            DISCORD_BOT_JLG_VERSION
         );
     }
 

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -279,21 +279,21 @@ class Discord_Bot_JLG_Shortcode {
             'discord-bot-jlg',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg.css',
             array(),
-            '1.0'
+            DISCORD_BOT_JLG_VERSION
         );
 
         wp_register_style(
             'discord-bot-jlg-inline',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg-inline.css',
             array('discord-bot-jlg'),
-            '1.0'
+            DISCORD_BOT_JLG_VERSION
         );
 
         wp_register_script(
             'discord-bot-jlg-frontend',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/js/discord-bot-jlg.js',
             array(),
-            '1.0',
+            DISCORD_BOT_JLG_VERSION,
             true
         );
 


### PR DESCRIPTION
## Summary
- add a `DISCORD_BOT_JLG_VERSION` constant sourced from the plugin header metadata
- use the plugin version when registering public styles/scripts for consistent cache busting
- reuse the same version constant for the admin stylesheet enqueue

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc942e54c832eac6620f8784d34c5