### PR TITLE
Define plugin version constant for asset cache busting

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -15,8 +15,10 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('DISCORD_BOT_JLG_VERSION')) {
-    $plugin_data = get_file_data(__FILE__, array('Version' => 'Version'));
-    define('DISCORD_BOT_JLG_VERSION', !empty($plugin_data['Version']) ? $plugin_data['Version'] : '');
+    $plugin_data    = get_file_data(__FILE__, array('Version' => 'Version'));
+    $plugin_version = !empty($plugin_data['Version']) ? $plugin_data['Version'] : '1.0';
+
+    define('DISCORD_BOT_JLG_VERSION', $plugin_version);
 }
 
 define('DISCORD_BOT_JLG_PLUGIN_PATH', plugin_dir_path(__FILE__));


### PR DESCRIPTION
## Summary
- ensure the plugin version constant falls back to the header version for cache-busting needs

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68ce64ce9784832eb7846ea146891e0d