### PR TITLE
Use plugin version constant for asset cache busting

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -16,6 +16,15 @@ if (!defined('ABSPATH')) {
 
 define('DISCORD_BOT_JLG_PLUGIN_PATH', plugin_dir_path(__FILE__));
 define('DISCORD_BOT_JLG_PLUGIN_URL', plugin_dir_url(__FILE__));
+
+$plugin_data = get_file_data(
+    __FILE__,
+    array(
+        'Version' => 'Version',
+    )
+);
+
+define('DISCORD_BOT_JLG_VERSION', !empty($plugin_data['Version']) ? $plugin_data['Version'] : '');
 define('DISCORD_BOT_JLG_OPTION_NAME', 'discord_server_stats_options');
 define('DISCORD_BOT_JLG_CACHE_KEY', 'discord_server_stats_cache');
 define('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION', 300);

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -852,7 +852,7 @@ class Discord_Bot_JLG_Admin {
             'discord-bot-jlg-admin',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg-admin.css',
             array(),
-            '1.0'
+            DISCORD_BOT_JLG_VERSION
         );
     }
 

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -279,21 +279,21 @@ class Discord_Bot_JLG_Shortcode {
             'discord-bot-jlg',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg.css',
             array(),
-            '1.0'
+            DISCORD_BOT_JLG_VERSION
         );
 
         wp_register_style(
             'discord-bot-jlg-inline',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg-inline.css',
             array('discord-bot-jlg'),
-            '1.0'
+            DISCORD_BOT_JLG_VERSION
         );
 
         wp_register_script(
             'discord-bot-jlg-frontend',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/js/discord-bot-jlg.js',
             array(),
-            '1.0',
+            DISCORD_BOT_JLG_VERSION,
             true
         );
 


### PR DESCRIPTION
## Summary
- add a DISCORD_BOT_JLG_VERSION constant derived from the plugin header metadata
- reuse the version constant when registering and enqueuing public and admin assets for consistent cache busting

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ce5fc54d9c832eb340b198e63aee92