### PR TITLE
Use plugin header version constant

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -15,8 +15,12 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('DISCORD_BOT_JLG_VERSION')) {
-    $plugin_data = get_file_data(__FILE__, array('Version' => 'Version'));
-    define('DISCORD_BOT_JLG_VERSION', !empty($plugin_data['Version']) ? $plugin_data['Version'] : '');
+    $plugin_data    = get_file_data(__FILE__, array('Version' => 'Version'));
+    $plugin_version = isset($plugin_data['Version']) && '' !== $plugin_data['Version']
+        ? $plugin_data['Version']
+        : '1.0';
+
+    define('DISCORD_BOT_JLG_VERSION', $plugin_version);
 }
 
 define('DISCORD_BOT_JLG_PLUGIN_PATH', plugin_dir_path(__FILE__));


### PR DESCRIPTION
## Summary
- derive the `DISCORD_BOT_JLG_VERSION` constant from the plugin header using `get_file_data`
- ensure a sane fallback version string when the header is missing

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68ce666ccec4832e8696073457f4cc55