### PR TITLE
Remove duplicate version constant definition

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -23,15 +23,6 @@ if (!defined('DISCORD_BOT_JLG_VERSION')) {
 
 define('DISCORD_BOT_JLG_PLUGIN_PATH', plugin_dir_path(__FILE__));
 define('DISCORD_BOT_JLG_PLUGIN_URL', plugin_dir_url(__FILE__));
-
-$plugin_data = get_file_data(
-    __FILE__,
-    array(
-        'Version' => 'Version',
-    )
-);
-
-define('DISCORD_BOT_JLG_VERSION', !empty($plugin_data['Version']) ? $plugin_data['Version'] : '');
 define('DISCORD_BOT_JLG_OPTION_NAME', 'discord_server_stats_options');
 define('DISCORD_BOT_JLG_CACHE_KEY', 'discord_server_stats_cache');
 define('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION', 300);


### PR DESCRIPTION
## Summary
- remove the redundant retrieval of plugin metadata and duplicate DISCORD_BOT_JLG_VERSION definition
- keep the plugin path and URL constants available for subsequent requires and asset usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce6c99d97c832eadaf3cf6a7f37421