### PR TITLE
Priorise le total du widget pour le cache Discord

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -99,14 +99,14 @@ class Discord_Bot_JLG_API {
                     $has_total         = false;
                     $total_approximate = false;
 
-                    if (!empty($bot_stats['has_total'])) {
-                        $total             = $bot_stats['total'];
-                        $has_total         = true;
-                        $total_approximate = !empty($bot_stats['total_is_approximate']);
-                    } elseif (!empty($widget_stats['has_total'])) {
+                    if (!empty($widget_stats['has_total'])) {
                         $total             = $widget_stats['total'];
                         $has_total         = true;
                         $total_approximate = !empty($widget_stats['total_is_approximate']);
+                    } elseif (!empty($bot_stats['has_total'])) {
+                        $total             = $bot_stats['total'];
+                        $has_total         = true;
+                        $total_approximate = !empty($bot_stats['total_is_approximate']);
                     }
 
                     $stats = array(
@@ -395,7 +395,8 @@ class Discord_Bot_JLG_API {
             'total'                => (int) $data['approximate_member_count'],
             'server_name'          => isset($data['name']) ? $data['name'] : '',
             'has_total'            => true,
-            'total_is_approximate' => false,
+            // Discord renvoie uniquement un total approximatif via approximate_member_count.
+            'total_is_approximate' => true,
         );
     }
 


### PR DESCRIPTION
## Summary
- marque les totaux remontés par le bot comme approximatifs car l'API ne fournit qu'`approximate_member_count`
- privilégie les totaux du widget lors de la fusion des statistiques et ne bascule sur ceux du bot qu'en dernier recours tout en propageant l'indicateur d'approximation

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68ce743b7168832ea575357dd02c4473