### PR TITLE
Handle dynamic Discord total availability

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -76,10 +76,11 @@
                     return;
                 }
 
+                var hasTotalInfo = data.data && typeof data.data.has_total !== 'undefined';
                 var onlineValue = typeof data.data.online === 'number' ? data.data.online : null;
                 var totalValue = typeof data.data.total === 'number' ? data.data.total : null;
 
-                if (onlineValue === null && totalValue === null) {
+                if (onlineValue === null && totalValue === null && !hasTotalInfo) {
                     return;
                 }
 
@@ -88,7 +89,71 @@
                 }
 
                 updateStatElement(container, '.discord-online .discord-number', onlineValue, formatter);
-                updateStatElement(container, '.discord-total .discord-number', totalValue, formatter);
+
+                var totalElement = container.querySelector('.discord-total');
+                if (totalElement) {
+                    var placeholder = totalElement.dataset && totalElement.dataset.placeholder ? totalElement.dataset.placeholder : '—';
+                    var totalLabel = totalElement.dataset && totalElement.dataset.labelTotal ? totalElement.dataset.labelTotal : '';
+                    var totalUnavailableLabel = totalElement.dataset && totalElement.dataset.labelUnavailable ? totalElement.dataset.labelUnavailable : totalLabel;
+                    var approxLabel = totalElement.dataset && totalElement.dataset.labelApprox ? totalElement.dataset.labelApprox : '';
+                    var labelTextElement = totalElement.querySelector('.discord-label-text');
+                    var labelExtraElement = totalElement.querySelector('.discord-label-extra');
+                    var indicatorElement = totalElement.querySelector('.discord-approx-indicator');
+                    var numberElement = totalElement.querySelector('.discord-number');
+                    var hasTotal = !!(data.data && data.data.has_total) && totalValue !== null;
+                    var isApproximate = !!(data.data && data.data.total_is_approximate) && hasTotal;
+
+                    if (container && container.classList) {
+                        container.classList.toggle('discord-total-missing', !hasTotal);
+                    }
+
+                    if (!hasTotal) {
+                        totalElement.classList.add('discord-total-unavailable');
+                        totalElement.classList.remove('discord-total-approximate');
+
+                        if (numberElement) {
+                            numberElement.textContent = placeholder;
+                            numberElement.style.transform = 'scale(1)';
+                        }
+
+                        if (labelTextElement) {
+                            labelTextElement.textContent = totalUnavailableLabel;
+                        }
+
+                        if (labelExtraElement) {
+                            labelExtraElement.textContent = '';
+                        }
+
+                        if (indicatorElement) {
+                            indicatorElement.hidden = true;
+                        }
+
+                        if (totalElement.dataset) {
+                            delete totalElement.dataset.value;
+                        }
+                    } else {
+                        totalElement.classList.remove('discord-total-unavailable');
+                        totalElement.classList.toggle('discord-total-approximate', isApproximate);
+
+                        updateStatElement(container, '.discord-total .discord-number', totalValue, formatter);
+
+                        if (labelTextElement) {
+                            labelTextElement.textContent = totalLabel;
+                        }
+
+                        if (labelExtraElement) {
+                            labelExtraElement.textContent = isApproximate ? approxLabel : '';
+                        }
+
+                        if (indicatorElement) {
+                            indicatorElement.hidden = !isApproximate;
+                        }
+
+                        if (totalElement.dataset) {
+                            totalElement.dataset.value = totalValue;
+                        }
+                    }
+                }
             })
             .catch(function (error) {
                 console.error('Erreur lors de la mise à jour des statistiques Discord :', error);

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -207,35 +207,40 @@ class Discord_Bot_JLG_Shortcode {
                     </div>
                     <?php endif; ?>
 
-                    <?php if ($show_total && $has_total) : ?>
-                    <div class="discord-stat discord-total<?php echo $total_is_approximate ? ' discord-total-approximate' : ''; ?>" data-value="<?php echo esc_attr((int) $stats['total']); ?>">
+                    <?php if ($show_total) : ?>
+                    <?php
+                    $total_classes = array('discord-stat', 'discord-total');
+                    if ($has_total) {
+                        if ($total_is_approximate) {
+                            $total_classes[] = 'discord-total-approximate';
+                        }
+                    } else {
+                        $total_classes[] = 'discord-total-unavailable';
+                    }
+
+                    $label_unavailable = __('Total indisponible', 'discord-bot-jlg');
+                    $label_classes    = array('discord-label');
+                    if ($hide_labels) {
+                        $label_classes[] = 'screen-reader-text';
+                    }
+                    ?>
+                    <div class="<?php echo esc_attr(implode(' ', $total_classes)); ?>"
+                        <?php if ($has_total): ?>
+                        data-value="<?php echo esc_attr((int) $stats['total']); ?>"
+                        <?php endif; ?>
+                        data-label-total="<?php echo esc_attr($atts['label_total']); ?>"
+                        data-label-unavailable="<?php echo esc_attr($label_unavailable); ?>"
+                        data-label-approx="<?php echo esc_attr__('approx.', 'discord-bot-jlg'); ?>"
+                        data-placeholder="<?php echo esc_attr('—'); ?>">
                         <?php if (!$hide_icons): ?>
                         <span class="discord-icon"><?php echo esc_html($atts['icon_total']); ?></span>
                         <?php endif; ?>
-                        <span class="discord-number"><?php echo esc_html(number_format_i18n((int) $stats['total'])); ?></span>
-                        <?php if ($total_is_approximate): ?>
-                        <span class="discord-approx-indicator" aria-hidden="true">≈</span>
-                        <?php endif; ?>
-                        <?php if (!$hide_labels): ?>
-                        <span class="discord-label">
-                            <?php echo esc_html($atts['label_total']); ?>
-                            <?php if ($total_is_approximate): ?>
-                            <span class="screen-reader-text"><?php esc_html_e('approx.', 'discord-bot-jlg'); ?></span>
-                            <?php endif; ?>
+                        <span class="discord-number"><?php echo $has_total ? esc_html(number_format_i18n((int) $stats['total'])) : '&mdash;'; ?></span>
+                        <span class="discord-approx-indicator" aria-hidden="true"<?php echo $total_is_approximate ? '' : ' hidden'; ?>>≈</span>
+                        <span class="<?php echo esc_attr(implode(' ', $label_classes)); ?>">
+                            <span class="discord-label-text"><?php echo esc_html($has_total ? $atts['label_total'] : $label_unavailable); ?></span>
+                            <span class="discord-label-extra screen-reader-text"><?php echo $total_is_approximate ? esc_html__('approx.', 'discord-bot-jlg') : ''; ?></span>
                         </span>
-                        <?php endif; ?>
-                    </div>
-                    <?php elseif ($show_total): ?>
-                    <div class="discord-stat discord-total discord-total-unavailable">
-                        <?php if (!$hide_icons): ?>
-                        <span class="discord-icon"><?php echo esc_html($atts['icon_total']); ?></span>
-                        <?php endif; ?>
-                        <span class="discord-number">&mdash;</span>
-                        <?php if (!$hide_labels): ?>
-                        <span class="discord-label"><?php esc_html_e('Total indisponible', 'discord-bot-jlg'); ?></span>
-                        <?php else: ?>
-                        <span class="screen-reader-text"><?php esc_html_e('Total indisponible', 'discord-bot-jlg'); ?></span>
-                        <?php endif; ?>
                     </div>
                     <?php endif; ?>
                 </div>


### PR DESCRIPTION
## Summary
- expose translation labels, placeholder metadata and a persistent approximate indicator on the total stat markup
- update the frontend refresh logic to toggle totals, labels and indicators based on has_total and total_is_approximate responses

## Testing
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68ce74332e98832ea028d4d0bbf2edf9