### PR TITLE
Require explicit admin force_refresh to bypass stats cache

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -209,9 +209,19 @@ class Discord_Bot_JLG_API {
             $refresh_requires_remote_call = true;
         }
 
+        $force_refresh = false;
+
+        if (
+            false === $is_public_request
+            && isset($_POST['force_refresh'])
+            && current_user_can('manage_options')
+        ) {
+            $force_refresh = wp_validate_boolean(wp_unslash($_POST['force_refresh']));
+        }
+
         $stats = $this->get_stats(
             array(
-                'bypass_cache' => (false === $is_public_request),
+                'bypass_cache' => $force_refresh,
             )
         );
 


### PR DESCRIPTION
## Summary
- keep public and authenticated AJAX refreshes on the cached stats by default
- only allow bypassing the cache when a `force_refresh` flag is provided by an admin-capable requester

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8f419a18832ea132a37406bf1e2b