### PR TITLE
Ensure front stats refresh keeps cache unless explicitly forced

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -209,19 +209,23 @@ class Discord_Bot_JLG_API {
             $refresh_requires_remote_call = true;
         }
 
-        $force_refresh = false;
+        $bypass_cache = false;
 
-        if (
-            false === $is_public_request
-            && isset($_POST['force_refresh'])
-            && current_user_can('manage_options')
-        ) {
+        if (isset($_POST['force_refresh'])) {
             $force_refresh = wp_validate_boolean(wp_unslash($_POST['force_refresh']));
+
+            if (
+                true === $force_refresh
+                && false === $is_public_request
+                && current_user_can('manage_options')
+            ) {
+                $bypass_cache = true;
+            }
         }
 
         $stats = $this->get_stats(
             array(
-                'bypass_cache' => $force_refresh,
+                'bypass_cache' => $bypass_cache,
             )
         );
 


### PR DESCRIPTION
## Summary
- keep Discord stats cache in place for frontend AJAX refreshes unless an administrator explicitly requests a force refresh
- only allow cache bypass when a `force_refresh` flag is provided by an administrator with the proper capability

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68ce904aec84832eb75e5e8c6affc3ca