### PR TITLE
Use plugin version constant in admin footers

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -560,7 +560,7 @@ class Discord_Bot_JLG_Admin {
     private function render_admin_footer_note() {
         ?>
         <div style="margin-top: 30px; padding: 15px; background: #f0f0f0; border-radius: 8px; text-align: center;">
-            <p style="margin: 0;">Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse</p>
+            <p style="margin: 0;"><?php printf('Discord Bot - JLG v%s | Développé par Jérôme Le Gousse', esc_html(DISCORD_BOT_JLG_VERSION)); ?></p>
         </div>
         <?php
     }
@@ -817,7 +817,7 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_footer_note() {
         ?>
         <div style="margin-top: 30px; padding: 15px; background: #f0f0f0; border-radius: 8px; text-align: center;">
-            <p style="margin: 0;">Discord Bot - JLG v1.0 | Développé par Jérôme Le Gousse |
+            <p style="margin: 0;"><?php printf('Discord Bot - JLG v%s | Développé par Jérôme Le Gousse |', esc_html(DISCORD_BOT_JLG_VERSION)); ?>
                <a href="https://discord.com/developers/docs/intro" target="_blank">Documentation Discord API</a> |
                <a href="#" onclick="return false;">Besoin d'aide ?</a>
             </p>


### PR DESCRIPTION
## Summary
- use `DISCORD_BOT_JLG_VERSION` constant when rendering admin footer note
- use `DISCORD_BOT_JLG_VERSION` constant when rendering demo footer note

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce9bf26294832ea0af7568f7dc1e07