### PR TITLE
Use wp_unique_id for shortcode container id

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -97,7 +97,7 @@ class Discord_Bot_JLG_Shortcode {
 
         $this->enqueue_assets($options);
 
-        $unique_id = 'discord-stats-' . wp_rand(1000, 9999);
+        $unique_id = wp_unique_id('discord-stats-');
 
         $has_total            = !empty($stats['has_total']) && isset($stats['total']) && null !== $stats['total'];
         $total_is_approximate = !empty($stats['total_is_approximate']);


### PR DESCRIPTION
## Summary
- replace shortcode container random ID generation with `wp_unique_id()` to ensure uniqueness without numeric constraint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf18574ad8832e93e0aaf1b113133a