### PR TITLE
Allow shortcode preview data attributes

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -960,10 +960,14 @@ class Discord_Bot_JLG_Admin {
         $div_attributes = array_merge(
             $div_attributes,
             array(
-                'style'       => true,
-                'data-demo'   => true,
-                'data-refresh'=> true,
-                'data-value'  => true,
+                'style'                 => true,
+                'data-demo'             => true,
+                'data-refresh'          => true,
+                'data-value'            => true,
+                'data-label-total'      => true,
+                'data-label-unavailable'=> true,
+                'data-label-approx'     => true,
+                'data-placeholder'      => true,
             )
         );
         $allowed_tags['div'] = $div_attributes;


### PR DESCRIPTION
## Summary
- allow shortcode preview HTML to expose all data-* attributes needed by the refresh logic

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cf229b68c0832ead6a4f6211d0c68a