### PR TITLE
Distinguish forced demo from fallback demo

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -195,7 +195,9 @@
         }
 
         Array.prototype.forEach.call(containers, function (container) {
-            if (container.dataset.demo === 'true') {
+            var isForcedDemo = container.dataset.demo === 'true' && container.dataset.fallbackDemo !== 'true';
+
+            if (isForcedDemo) {
                 return;
             }
 

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -40,7 +40,7 @@ class Discord_Bot_JLG_API {
      *     @type bool $bypass_cache Si vrai, ignore la valeur mise en cache et interroge l'API directement.
      * }
      *
-     * @return array Statistiques du serveur (clés `online`, `total`, `server_name`, éventuellement `is_demo`).
+     * @return array Statistiques du serveur (clés `online`, `total`, `server_name`, `is_demo`, éventuellement `fallback_demo`).
      */
     public function get_stats($args = array()) {
         $args = wp_parse_args(
@@ -52,7 +52,7 @@ class Discord_Bot_JLG_API {
         );
 
         if (true === $args['force_demo']) {
-            return $this->get_demo_stats();
+            return $this->get_demo_stats(false);
         }
 
         $options = get_option($this->option_name);
@@ -61,7 +61,7 @@ class Discord_Bot_JLG_API {
         }
 
         if (!empty($options['demo_mode'])) {
-            return $this->get_demo_stats();
+            return $this->get_demo_stats(false);
         }
 
         if (false === $args['bypass_cache']) {
@@ -72,7 +72,7 @@ class Discord_Bot_JLG_API {
         }
 
         if (empty($options['server_id'])) {
-            return $this->get_demo_stats();
+            return $this->get_demo_stats(true);
         }
 
         $stats = false;
@@ -129,7 +129,7 @@ class Discord_Bot_JLG_API {
         }
 
         if (false === $this->has_usable_stats($stats)) {
-            return $this->get_demo_stats();
+            return $this->get_demo_stats(true);
         }
 
         set_transient($this->cache_key, $stats, $this->get_cache_duration($options));
@@ -276,9 +276,11 @@ class Discord_Bot_JLG_API {
     /**
      * Génère des statistiques fictives pour la démonstration ou en cas d'absence de configuration.
      *
-     * @return array Statistiques de démonstration comprenant les clés `online`, `total`, `server_name` et `is_demo`.
+     * @param bool $is_fallback Indique si ces statistiques sont utilisées faute de données réelles.
+     *
+     * @return array Statistiques de démonstration comprenant les clés `online`, `total`, `server_name`, `is_demo` et `fallback_demo`.
      */
-    public function get_demo_stats() {
+    public function get_demo_stats($is_fallback = false) {
         $base_online = 42;
         $base_total  = 256;
 
@@ -290,6 +292,7 @@ class Discord_Bot_JLG_API {
             'total'                => (int) $base_total,
             'server_name'          => 'Serveur Démo',
             'is_demo'              => true,
+            'fallback_demo'        => (bool) $is_fallback,
             'has_total'            => true,
             'total_is_approximate' => false,
         );

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -99,6 +99,10 @@ class Discord_Bot_JLG_Shortcode {
 
         $unique_id = wp_unique_id('discord-stats-');
 
+        $is_demo          = !empty($stats['is_demo']);
+        $is_fallback_demo = !empty($stats['fallback_demo']);
+        $is_forced_demo   = $is_demo && !$is_fallback_demo;
+
         $has_total            = !empty($stats['has_total']) && isset($stats['total']) && null !== $stats['total'];
         $total_is_approximate = !empty($stats['total_is_approximate']);
 
@@ -117,7 +121,7 @@ class Discord_Bot_JLG_Shortcode {
             $container_classes[] = 'discord-animated';
         }
 
-        if (!empty($stats['is_demo'])) {
+        if ($is_demo) {
             $container_classes[] = 'discord-demo-mode';
         }
 
@@ -147,7 +151,8 @@ class Discord_Bot_JLG_Shortcode {
         $attributes = array(
             sprintf('id="%s"', esc_attr($unique_id)),
             sprintf('class="%s"', esc_attr(implode(' ', $container_classes))),
-            sprintf('data-demo="%s"', esc_attr(!empty($stats['is_demo']) ? 'true' : 'false')),
+            sprintf('data-demo="%s"', esc_attr($is_forced_demo ? 'true' : 'false')),
+            sprintf('data-fallback-demo="%s"', esc_attr($is_fallback_demo ? 'true' : 'false')),
         );
 
         if (!empty($style_declarations)) {
@@ -159,7 +164,7 @@ class Discord_Bot_JLG_Shortcode {
             ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
             : 10;
 
-        if ($refresh && empty($stats['is_demo'])) {
+        if ($refresh && (!$is_demo || $is_fallback_demo)) {
             $refresh_interval = max($min_refresh_interval, intval($atts['refresh_interval']));
         }
 


### PR DESCRIPTION
## Summary
- differentiate fallback demo data returned by the API from explicitly forced demo mode
- propagate the fallback indicator to the shortcode markup so only real forced demos set the data-demo flag and keep refresh timing for fallbacks
- adjust the front-end auto-refresh logic to skip updates only for true forced demos

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cf3a0a4ef4832eb291da38c0cf75af