### PR TITLE
Ensure Discord shortcode styles print in admin footer

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -276,6 +276,7 @@ class Discord_Bot_JLG_Shortcode {
 
         if (!self::$footer_hook_added) {
             add_action('wp_footer', array($this, 'print_late_styles'), 1);
+            add_action('admin_print_footer_scripts', array($this, 'print_late_styles'), 1);
             self::$footer_hook_added = true;
         }
     }


### PR DESCRIPTION
## Summary
- hook the shortcode late-style printer into the admin footer so previews share frontend styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf411c6304832ea6e2eac03ca8c52f