### PR TITLE
Allow cache duration down to public refresh minimum

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -202,7 +202,10 @@ class Discord_Bot_JLG_Admin {
 
         if (isset($input['cache_duration'])) {
             $cache_duration               = absint($input['cache_duration']);
-            $sanitized['cache_duration'] = max(60, min(3600, $cache_duration));
+            $sanitized['cache_duration'] = max(
+                Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                min(3600, $cache_duration)
+            );
         }
 
         if (isset($input['custom_css'])) {
@@ -425,8 +428,10 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="number" name="<?php echo esc_attr($this->option_name); ?>[cache_duration]"
                value="<?php echo esc_attr(isset($options['cache_duration']) ? $options['cache_duration'] : ''); ?>"
-               min="60" max="3600" class="small-text" />
-        <p class="description">Minimum 60 secondes, maximum 3600 secondes (1 heure)</p>
+               min="<?php echo esc_attr(Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL); ?>" max="3600" class="small-text" />
+        <p class="description">
+            Minimum <?php echo esc_html(Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL); ?> secondes, maximum 3600 secondes (1 heure)
+        </p>
         <?php
     }
 

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -460,7 +460,10 @@ class Discord_Bot_JLG_API {
     private function get_cache_duration($options) {
         if (isset($options['cache_duration'])) {
             $duration = (int) $options['cache_duration'];
-            if ($duration >= 60 && $duration <= 3600) {
+            if (
+                $duration >= self::MIN_PUBLIC_REFRESH_INTERVAL
+                && $duration <= 3600
+            ) {
                 return $duration;
             }
         }


### PR DESCRIPTION
## Summary
- lower the cache duration validation to the public refresh minimum so 10s intervals are accepted
- update admin sanitization and form field to match the new minimum and dynamic help text

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cfcee52db0832e95f46cd28137a65e