### PR TITLE
Handle fallback demo refresh responses

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -230,6 +230,12 @@ class Discord_Bot_JLG_API {
             )
         );
 
+        $is_fallback_demo = (
+            is_array($stats)
+            && !empty($stats['is_demo'])
+            && !empty($stats['fallback_demo'])
+        );
+
         if (
             true === $is_public_request
             && true === $refresh_requires_remote_call
@@ -237,6 +243,11 @@ class Discord_Bot_JLG_API {
             && empty($stats['is_demo'])
         ) {
             set_transient($rate_limit_key, time(), $rate_limit_window);
+        }
+
+        if (true === $is_fallback_demo) {
+            delete_transient($rate_limit_key);
+            wp_send_json_success($stats);
         }
 
         if (is_array($stats) && empty($stats['is_demo'])) {


### PR DESCRIPTION
## Summary
- return JSON success when fallback demo stats are provided by get_stats to keep the demo display active
- clear refresh rate limit lock for fallback demo responses so periodic retries can continue

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cfeb89ef00832e82e97563a1db91ba