### PR TITLE
Handle fallback demo stats as successful refresh

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -239,6 +239,18 @@ class Discord_Bot_JLG_API {
             set_transient($rate_limit_key, time(), $rate_limit_window);
         }
 
+        if (
+            is_array($stats)
+            && !empty($stats['is_demo'])
+            && !empty($stats['fallback_demo'])
+        ) {
+            if (true === $is_public_request) {
+                delete_transient($rate_limit_key);
+            }
+
+            wp_send_json_success($stats);
+        }
+
         if (is_array($stats) && empty($stats['is_demo'])) {
             wp_send_json_success($stats);
         }


### PR DESCRIPTION
## Summary
- treat fallback demo responses from get_stats() as successful AJAX refreshes so demo data remains displayed
- clear any refresh rate limit lock when returning fallback demo data and preserve fallback_demo flag in JSON responses

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68cfef1ea7cc832eafdad9a90d72d0ee