### PR TITLE
Limit bot calls when widget stats complete

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -87,8 +87,9 @@ class Discord_Bot_JLG_API {
 
         $bot_stats  = false;
         $bot_token = $this->get_bot_token($options);
+        $should_call_bot = (!empty($bot_token) && ($widget_incomplete || empty($widget_stats)));
 
-        if (!empty($bot_token)) {
+        if ($should_call_bot) {
             $bot_stats = $this->get_stats_from_bot($options);
 
             if (is_array($bot_stats)) {


### PR DESCRIPTION
## Summary
- call the Discord bot API only when widget data is missing or incomplete
- keep the merging logic so bot data still fills in gaps when required

## Testing
- php /tmp/test_bot_calls.php

------
https://chatgpt.com/codex/tasks/task_e_68cff99de148832e843b492b153d8136