### PR TITLE
Fix admin stylesheet loading for demo page

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -853,7 +853,7 @@ class Discord_Bot_JLG_Admin {
     public function enqueue_admin_styles($hook_suffix) {
         $allowed_ids = array(
             'toplevel_page_discord-bot-jlg',
-            'discord-bot_page_discord-bot-demo',
+            'discord-bot-jlg_page_discord-bot-demo',
         );
 
         if (function_exists('get_current_screen')) {


### PR DESCRIPTION
## Summary
- update the allowed admin page identifier so the Guide & Démo screen matches the actual submenu hook
- ensure the Discord Bot admin stylesheet loads on the demo page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0531de524832ea80166c25b69eeb3