### PR TITLE
Localize admin strings and update translation template

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -36,8 +36,8 @@ class Discord_Bot_JLG_Admin {
         $discord_icon = 'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbD0iI2E0YWFiOCIgZD0iTTIwLjMxNyA0LjM3YTE5LjggMTkuOCAwIDAwLTQuODg1LTEuNTE1LjA3NC4wNzQgMCAwMC0uMDc5LjAzN2MtLjIxLjM3NS0uNDQ0Ljg2NC0uNjA4IDEuMjVhMTguMjcgMTguMjcgMCAwMC01LjQ4NyAwYy0uMTY1LS4zOTctLjQwNC0uODg1LS42MTgtMS4yNWEuMDc3LjA3NyAwIDAwLS4wNzktLjAzN0ExOS43NCAxOS43NCAwIDAwMy42NzcgNC4zN2EuMDcuMDcgMCAwMC0uMDMyLjAyN0MuNTMzIDkuMDQ2LS4zMiAxMy41OC4wOTkgMTguMDU3YS4wOC4wOCAwIDAwLjAzMS4wNTdBMTkuOSAxOS45IDAgMDA2LjA3MyAyMWEuMDc4LjA3OCAwIDAwLjA4NC0uMDI4IDEzLjQgMTMuNCAwIDAwMS4xNTUtMi4xLjA3Ni4wNzYgMCAwMC0uMDQxLS4xMDYgMTMuMSAxMy4xIDAgMDEtMS44NzItLjg5Mi4wNzcuMDc3IDAgMDEtLjAwOC0uMTI4IDE0IDE0IDAgMDAuMzctLjI5Mi4wNzQuMDc0IDAgMDEuMDc3LS4wMWMzLjkyNyAxLjc5MyA4LjE4IDEuNzkzIDEyLjA2IDAgYS4wNzQuMDc0IDAgMDEuMDc4LjAwOS4xMTkuMDk5LjI0Ni4xOTguMzczLjI5MmEuMDc3LjA3NyAwIDAxLS4wMDYuMTI3IDEyLjMgMTIuMyAwIDAxLTEuODczLjg5Mi4wNzcuMDc3IDAgMDAtLjA0MS4xMDdjMy43NDQgMS40MDMgMS4xNTUgMi4xLS4wODQuMDI4YS4wNzguMDc4IDAgMDAxOS45MDItMS45MDMuMDc2LjA3NiAwIDAwLjAzLS4wNTdjLjUzNy00LjU4LS45MDQtOC41NTMtMy44MjMtMTIuMDU3YS4wNi4wNiAwIDAwLS4wMzEtLjAyOHpNOC4wMiAxNS4yNzhjLTEuMTgzIDAtMi4xNTctMS4wODUtMi4xNTctMi40MiAwLTEuMzMzLjk1Ni0yLjQxOSAyLjE1Ny0yLjQxOSAxLjIxIDAgMi4xNzYgMS4wOTYgMi4xNTcgMi40MiAwIDEuMzM0LS45NTYgMi40MTktMi4xNTcgMi40MTl6bTcuOTc1IDBjLTEuMTgzIDAtMi4xNTctMS4wODUtMi4xNTctMi40MiAwLTEuMzMzLjk1NS0yLjQxOSAyLjE1Ny0yLjQxOXMyLjE1NyAxLjA5NiAyLjE1NyAyLjQyYzAgMS4zMzQtLjk1NiAyLjQxOS0yLjE1NyAyLjQxOXoiLz48L3N2Zz4=';
 
         add_menu_page(
-            'Discord Bot - JLG',
-            'Discord Bot',
+            __('Discord Bot - JLG', 'discord-bot-jlg'),
+            __('Discord Bot', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-jlg',
             array($this, 'options_page'),
@@ -47,8 +47,8 @@ class Discord_Bot_JLG_Admin {
 
         add_submenu_page(
             'discord-bot-jlg',
-            'Configuration',
-            'Configuration',
+            __('Configuration', 'discord-bot-jlg'),
+            __('Configuration', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-jlg',
             array($this, 'options_page')
@@ -56,8 +56,8 @@ class Discord_Bot_JLG_Admin {
 
         $this->demo_page_hook_suffix = add_submenu_page(
             'discord-bot-jlg',
-            'Guide & Démo',
-            'Guide & Démo',
+            __('Guide & Démo', 'discord-bot-jlg'),
+            __('Guide & Démo', 'discord-bot-jlg'),
             'manage_options',
             'discord-bot-demo',
             array($this, 'demo_page')
@@ -80,14 +80,14 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_section(
             'discord_stats_api_section',
-            'Configuration Discord API',
+            __('Configuration Discord API', 'discord-bot-jlg'),
             array($this, 'api_section_callback'),
             'discord_stats_settings'
         );
 
         add_settings_field(
             'server_id',
-            'ID du Serveur Discord',
+            __('ID du Serveur Discord', 'discord-bot-jlg'),
             array($this, 'server_id_render'),
             'discord_stats_settings',
             'discord_stats_api_section'
@@ -95,7 +95,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'bot_token',
-            'Token du Bot Discord',
+            __('Token du Bot Discord', 'discord-bot-jlg'),
             array($this, 'bot_token_render'),
             'discord_stats_settings',
             'discord_stats_api_section'
@@ -103,14 +103,14 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_section(
             'discord_stats_display_section',
-            'Options d\'affichage',
+            esc_html__('Options d\'affichage', 'discord-bot-jlg'),
             array($this, 'display_section_callback'),
             'discord_stats_settings'
         );
 
         add_settings_field(
             'demo_mode',
-            'Mode démonstration',
+            __('Mode démonstration', 'discord-bot-jlg'),
             array($this, 'demo_mode_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -118,7 +118,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'show_online',
-            'Afficher les membres en ligne',
+            __('Afficher les membres en ligne', 'discord-bot-jlg'),
             array($this, 'show_online_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -126,7 +126,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'show_total',
-            'Afficher le total des membres',
+            __('Afficher le total des membres', 'discord-bot-jlg'),
             array($this, 'show_total_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -134,7 +134,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'widget_title',
-            'Titre du widget',
+            __('Titre du widget', 'discord-bot-jlg'),
             array($this, 'widget_title_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -142,7 +142,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'cache_duration',
-            'Durée du cache (secondes)',
+            __('Durée du cache (secondes)', 'discord-bot-jlg'),
             array($this, 'cache_duration_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -150,7 +150,7 @@ class Discord_Bot_JLG_Admin {
 
         add_settings_field(
             'custom_css',
-            'CSS personnalisé',
+            __('CSS personnalisé', 'discord-bot-jlg'),
             array($this, 'custom_css_render'),
             'discord_stats_settings',
             'discord_stats_display_section'
@@ -225,7 +225,7 @@ class Discord_Bot_JLG_Admin {
     public function api_section_callback() {
         ?>
         <div style="background: #f0f4ff; padding: 20px; border-radius: 8px; margin: 20px 0;">
-            <h3 style="margin-top: 0;">📚 Guide étape par étape</h3>
+            <h3 style="margin-top: 0;"><?php esc_html_e('📚 Guide étape par étape', 'discord-bot-jlg'); ?></h3>
             <?php
             $this->render_api_steps();
             $this->render_api_previews();
@@ -239,47 +239,60 @@ class Discord_Bot_JLG_Admin {
      */
     private function render_api_steps() {
         ?>
-        <h4>Étape 1 : Créer un Bot Discord</h4>
+        <h4><?php esc_html_e('Étape 1 : Créer un Bot Discord', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Rendez-vous sur <a href="https://discord.com/developers/applications" target="_blank" rel="noopener noreferrer" style="color: #5865F2;">Discord Developer Portal</a></li>
-            <li>Cliquez sur <strong>"New Application"</strong> en haut à droite</li>
-            <li>Donnez un nom à votre application (ex: "Stats Bot")</li>
-            <li>Dans le menu de gauche, cliquez sur <strong>"Bot"</strong></li>
-            <li>Cliquez sur <strong>"Add Bot"</strong></li>
-            <li>Sous "Token", cliquez sur <strong>"Copy"</strong> pour copier le token du bot</li>
-            <li>⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez jamais !</li>
+            <li>
+                <?php
+                printf(
+                    wp_kses_post(
+                        /* translators: %1$s: URL to the Discord Developer Portal. */
+                        __(
+                            'Rendez-vous sur <a href="%1$s" target="_blank" rel="noopener noreferrer" style="color: #5865F2;">Discord Developer Portal</a>',
+                            'discord-bot-jlg'
+                        )
+                    ),
+                    esc_url('https://discord.com/developers/applications')
+                );
+                ?>
+            </li>
+            <li><?php echo wp_kses_post(__('Cliquez sur <strong>"New Application"</strong> en haut à droite', 'discord-bot-jlg')); ?></li>
+            <li><?php esc_html_e('Donnez un nom à votre application (ex: "Stats Bot")', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Dans le menu de gauche, cliquez sur <strong>"Bot"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Cliquez sur <strong>"Add Bot"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Sous "Token", cliquez sur <strong>"Copy"</strong> pour copier le token du bot', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez jamais !', 'discord-bot-jlg')); ?></li>
         </ol>
 
-        <h4>Étape 2 : Inviter le Bot sur votre serveur</h4>
+        <h4><?php esc_html_e('Étape 2 : Inviter le Bot sur votre serveur', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Dans le menu de gauche, allez dans <strong>"OAuth2"</strong> > <strong>"URL Generator"</strong></li>
-            <li>Dans "Scopes", cochez <strong>"bot"</strong></li>
-            <li>Dans "Bot Permissions", sélectionnez :</li>
+            <li><?php echo wp_kses_post(__('Dans le menu de gauche, allez dans <strong>"OAuth2"</strong> &gt; <strong>"URL Generator"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans "Scopes", cochez <strong>"bot"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans "Bot Permissions", sélectionnez :', 'discord-bot-jlg')); ?></li>
                 <ul>
-                    <li>✅ View Channels</li>
-                    <li>✅ Read Messages</li>
-                    <li>✅ Send Messages (optionnel)</li>
+                    <li><?php esc_html_e('✅ View Channels', 'discord-bot-jlg'); ?></li>
+                    <li><?php esc_html_e('✅ Read Messages', 'discord-bot-jlg'); ?></li>
+                    <li><?php esc_html_e('✅ Send Messages (optionnel)', 'discord-bot-jlg'); ?></li>
                 </ul>
-            <li>Copiez l'URL générée en bas de la page</li>
-            <li>Ouvrez cette URL dans votre navigateur</li>
-            <li>Sélectionnez votre serveur et cliquez sur <strong>"Autoriser"</strong></li>
+            <li><?php esc_html_e('Copiez l\'URL générée en bas de la page', 'discord-bot-jlg'); ?></li>
+            <li><?php esc_html_e('Ouvrez cette URL dans votre navigateur', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Sélectionnez votre serveur et cliquez sur <strong>"Autoriser"</strong>', 'discord-bot-jlg')); ?></li>
         </ol>
 
-        <h4>Étape 3 : Obtenir l'ID de votre serveur</h4>
+        <h4><?php esc_html_e('Étape 3 : Obtenir l\'ID de votre serveur', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Ouvrez Discord (application ou web)</li>
-            <li>Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)</li>
-            <li>Dans <strong>"Avancés"</strong>, activez <strong>"Mode développeur"</strong></li>
-            <li>Retournez sur votre serveur</li>
-            <li>Faites un <strong>clic droit sur le nom du serveur</strong></li>
-            <li>Cliquez sur <strong>"Copier l'ID"</strong></li>
+            <li><?php esc_html_e('Ouvrez Discord (application ou web)', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans <strong>"Avancés"</strong>, activez <strong>"Mode développeur"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php esc_html_e('Retournez sur votre serveur', 'discord-bot-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Faites un <strong>clic droit sur le nom du serveur</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Cliquez sur <strong>"Copier l\'ID"</strong>', 'discord-bot-jlg')); ?></li>
         </ol>
 
-        <h4>Étape 4 : Activer le Widget (optionnel mais recommandé)</h4>
+        <h4><?php esc_html_e('Étape 4 : Activer le Widget (optionnel mais recommandé)', 'discord-bot-jlg'); ?></h4>
         <ol>
-            <li>Dans Discord, allez dans <strong>Paramètres du serveur</strong></li>
-            <li>Dans <strong>"Widget"</strong>, activez <strong>"Activer le widget du serveur"</strong></li>
-            <li>Cela permet une méthode de fallback si le bot a des problèmes</li>
+            <li><?php echo wp_kses_post(__('Dans Discord, allez dans <strong>Paramètres du serveur</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans <strong>"Widget"</strong>, activez <strong>"Activer le widget du serveur"</strong>', 'discord-bot-jlg')); ?></li>
+            <li><?php esc_html_e('Cela permet une méthode de fallback si le bot a des problèmes', 'discord-bot-jlg'); ?></li>
         </ol>
         <?php
     }
@@ -290,10 +303,10 @@ class Discord_Bot_JLG_Admin {
     private function render_api_previews() {
         ?>
         <div style="background: #fff3cd; padding: 10px; border-radius: 4px; margin-top: 15px;">
-            <strong>💡 Conseil :</strong> Après avoir rempli les champs ci-dessous, utilisez le bouton "Tester la connexion" pour vérifier que tout fonctionne !
+            <?php echo wp_kses_post(__('<strong>💡 Conseil :</strong> Après avoir rempli les champs ci-dessous, utilisez le bouton "Tester la connexion" pour vérifier que tout fonctionne !', 'discord-bot-jlg')); ?>
             <?php
             $this->render_preview_block(
-                'Avec logo Discord officiel :',
+                __('Avec logo Discord officiel :', 'discord-bot-jlg'),
                 '[discord_stats demo="true" show_discord_icon="true" discord_icon_position="left"]',
                 array(
                     'container_style' => 'margin: 20px 0;',
@@ -301,7 +314,7 @@ class Discord_Bot_JLG_Admin {
             );
 
             $this->render_preview_block(
-                'Logo Discord centré en haut :',
+                __('Logo Discord centré en haut :', 'discord-bot-jlg'),
                 '[discord_stats demo="true" show_discord_icon="true" discord_icon_position="top" align="center" theme="dark"]',
                 array(
                     'container_style' => 'margin: 20px 0;',
@@ -318,7 +331,7 @@ class Discord_Bot_JLG_Admin {
      * @return void
      */
     public function display_section_callback() {
-        echo '<p>Personnalisez l\'affichage des statistiques Discord.</p>';
+        printf('<p>%s</p>', esc_html__('Personnalisez l\'affichage des statistiques Discord.', 'discord-bot-jlg'));
     }
 
     /**
@@ -332,7 +345,7 @@ class Discord_Bot_JLG_Admin {
         <input type="text" name="<?php echo esc_attr($this->option_name); ?>[server_id]"
                value="<?php echo esc_attr(isset($options['server_id']) ? $options['server_id'] : ''); ?>"
                class="regular-text" />
-        <p class="description">L'ID de votre serveur Discord</p>
+        <p class="description"><?php esc_html_e('L\'ID de votre serveur Discord', 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -351,9 +364,9 @@ class Discord_Bot_JLG_Admin {
         <p class="description">
             <?php
             if ($constant_overridden) {
-                echo 'Le token est actuellement défini via la constante <code>DISCORD_BOT_JLG_TOKEN</code> et remplace cette valeur.';
+                echo wp_kses_post(__('Le token est actuellement défini via la constante <code>DISCORD_BOT_JLG_TOKEN</code> et remplace cette valeur.', 'discord-bot-jlg'));
             } else {
-                echo 'Le token de votre bot Discord (gardez-le secret !).';
+                echo esc_html__('Le token de votre bot Discord (gardez-le secret !).', 'discord-bot-jlg');
             }
             ?>
         </p>
@@ -371,8 +384,8 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[demo_mode]"
                value="1" <?php checked($demo_mode, 1); ?> />
-        <label>Activer le mode démonstration (affiche des données fictives pour tester l'apparence)</label>
-        <p class="description">🎨 Parfait pour tester les styles et dispositions sans configuration Discord</p>
+        <label><?php esc_html_e('Activer le mode démonstration (affiche des données fictives pour tester l\'apparence)', 'discord-bot-jlg'); ?></label>
+        <p class="description"><?php esc_html_e('🎨 Parfait pour tester les styles et dispositions sans configuration Discord', 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -387,7 +400,7 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_online]"
                value="1" <?php checked($value, 1); ?> />
-        <label>Afficher le nombre d'utilisateurs en ligne</label>
+        <label><?php esc_html_e('Afficher le nombre d\'utilisateurs en ligne', 'discord-bot-jlg'); ?></label>
         <?php
     }
 
@@ -402,7 +415,7 @@ class Discord_Bot_JLG_Admin {
         ?>
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_total]"
                value="1" <?php checked($value, 1); ?> />
-        <label>Afficher le nombre total de membres</label>
+        <label><?php esc_html_e('Afficher le nombre total de membres', 'discord-bot-jlg'); ?></label>
         <?php
     }
 
@@ -432,7 +445,14 @@ class Discord_Bot_JLG_Admin {
                value="<?php echo esc_attr(isset($options['cache_duration']) ? $options['cache_duration'] : ''); ?>"
                min="<?php echo esc_attr(Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL); ?>" max="3600" class="small-text" />
         <p class="description">
-            Minimum <?php echo esc_html(Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL); ?> secondes, maximum 3600 secondes (1 heure)
+            <?php
+            printf(
+                /* translators: 1: minimum cache duration in seconds, 2: maximum cache duration in seconds. */
+                esc_html__('Minimum %1$s secondes, maximum %2$s secondes (1 heure)', 'discord-bot-jlg'),
+                esc_html(Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL),
+                esc_html(number_format_i18n(3600))
+            );
+            ?>
         </p>
         <?php
     }
@@ -446,7 +466,7 @@ class Discord_Bot_JLG_Admin {
         $options = get_option($this->option_name);
         ?>
         <textarea name="<?php echo esc_attr($this->option_name); ?>[custom_css]" rows="5" cols="50"><?php echo esc_textarea(isset($options['custom_css']) ? $options['custom_css'] : ''); ?></textarea>
-        <p class="description">CSS personnalisé pour styliser l'affichage</p>
+        <p class="description"><?php esc_html_e('CSS personnalisé pour styliser l\'affichage', 'discord-bot-jlg'); ?></p>
         <?php
     }
 
@@ -458,7 +478,7 @@ class Discord_Bot_JLG_Admin {
     public function options_page() {
         ?>
         <div class="wrap">
-            <h1>🎮 Discord Bot - JLG - Configuration</h1>
+            <h1><?php esc_html_e('🎮 Discord Bot - JLG - Configuration', 'discord-bot-jlg'); ?></h1>
             <?php $this->handle_test_connection_request(); ?>
 
             <div style="display: flex; gap: 20px; margin-top: 20px;">
@@ -519,14 +539,14 @@ class Discord_Bot_JLG_Admin {
     private function render_connection_test_panel() {
         ?>
         <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
-            <h3 style="margin-top: 0;">🔧 Test de connexion</h3>
-            <p>Vérifiez que votre configuration fonctionne :</p>
+            <h3 style="margin-top: 0;"><?php esc_html_e('🔧 Test de connexion', 'discord-bot-jlg'); ?></h3>
+            <p><?php esc_html_e('Vérifiez que votre configuration fonctionne :', 'discord-bot-jlg'); ?></p>
             <form method="get" action="<?php echo esc_url(admin_url('admin.php')); ?>">
                 <input type="hidden" name="page" value="discord-bot-jlg" />
                 <input type="hidden" name="test_connection" value="1" />
                 <?php wp_nonce_field('discord_test_connection'); ?>
                 <p>
-                    <button type="submit" class="button button-secondary" style="width: 100%;">Tester la connexion</button>
+                    <button type="submit" class="button button-secondary" style="width: 100%;"><?php esc_html_e('Tester la connexion', 'discord-bot-jlg'); ?></button>
                 </p>
             </form>
         </div>
@@ -539,21 +559,21 @@ class Discord_Bot_JLG_Admin {
     private function render_quick_links_panel() {
         ?>
         <div style="background: #e8f5e9; padding: 20px; border-radius: 8px;">
-            <h3 style="margin-top: 0;">🚀 Liens rapides</h3>
+            <h3 style="margin-top: 0;"><?php esc_html_e('🚀 Liens rapides', 'discord-bot-jlg'); ?></h3>
             <ul style="list-style: none; padding: 0;">
                 <li style="margin-bottom: 10px;">
                     <a href="<?php echo esc_url(admin_url('admin.php?page=discord-bot-demo')); ?>" class="button button-primary" style="width: 100%;">
-                        📖 Guide & Démo
+                        <?php esc_html_e('📖 Guide & Démo', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
                 <li style="margin-bottom: 10px;">
                     <a href="https://discord.com/developers/applications" target="_blank" rel="noopener noreferrer" class="button" style="width: 100%;">
-                        🔗 Discord Developer Portal
+                        <?php esc_html_e('🔗 Discord Developer Portal', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
                 <li>
                     <a href="<?php echo esc_url(admin_url('widgets.php')); ?>" class="button" style="width: 100%;">
-                        📐 Gérer les Widgets
+                        <?php esc_html_e('📐 Gérer les Widgets', 'discord-bot-jlg'); ?>
                     </a>
                 </li>
             </ul>
@@ -569,9 +589,15 @@ class Discord_Bot_JLG_Admin {
         <div style="margin-top: 30px; padding: 15px; background: #f0f0f0; border-radius: 8px; text-align: center;">
             <p style="margin: 0;">
                 <?php
+                $version_label = sprintf(
+                    /* translators: %s: plugin version. */
+                    __('Discord Bot - JLG v%s', 'discord-bot-jlg'),
+                    DISCORD_BOT_JLG_VERSION
+                );
                 printf(
-                    '%s | Développé par Jérôme Le Gousse',
-                    esc_html(sprintf('Discord Bot - JLG v%s', DISCORD_BOT_JLG_VERSION))
+                    /* translators: %1$s: plugin version label. */
+                    esc_html__('%1$s | Développé par Jérôme Le Gousse', 'discord-bot-jlg'),
+                    esc_html($version_label)
                 );
                 ?>
             </p>
@@ -587,7 +613,7 @@ class Discord_Bot_JLG_Admin {
     public function demo_page() {
         ?>
         <div class="wrap">
-            <h1>📖 Guide & Démonstration</h1>
+            <h1><?php esc_html_e('📖 Guide & Démonstration', 'discord-bot-jlg'); ?></h1>
             <?php $this->render_demo_intro_notice(); ?>
 
             <hr style="margin: 30px 0;">
@@ -614,7 +640,7 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_intro_notice() {
         ?>
         <div style="background: #fff3cd; padding: 10px 20px; border-radius: 8px; margin: 20px 0;">
-            <p><strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode démo. Vous pouvez les copier-coller directement !</p>
+            <p><?php echo wp_kses_post(__('<strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode démo. Vous pouvez les copier-coller directement !', 'discord-bot-jlg')); ?></p>
         </div>
         <?php
     }
@@ -625,35 +651,35 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_previews() {
         $previews = array(
             array(
-                'title' => 'Standard horizontal :',
+                'title' => __('Standard horizontal :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true"]',
             ),
             array(
-                'title' => 'Vertical pour sidebar :',
+                'title' => __('Vertical pour sidebar :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" layout="vertical" theme="minimal"]',
                 'inner_wrapper_style' => 'max-width: 300px;',
             ),
             array(
-                'title' => 'Compact mode sombre :',
+                'title' => __('Compact mode sombre :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" compact="true" theme="dark"]',
             ),
             array(
-                'title' => 'Avec titre personnalisé :',
+                'title' => __('Avec titre personnalisé :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" show_title="true" title="🎮 Notre Communauté Gaming" align="center"]',
             ),
             array(
-                'title' => 'Icônes personnalisées :',
+                'title' => __('Icônes personnalisées :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" icon_online="🔥" label_online="Actifs" icon_total="⚔️" label_total="Guerriers"]',
             ),
             array(
-                'title' => 'Minimaliste (nombres uniquement) :',
+                'title' => __('Minimaliste (nombres uniquement) :', 'discord-bot-jlg'),
                 'shortcode' => '[discord_stats demo="true" hide_labels="true" hide_icons="true" theme="minimal"]',
             ),
         );
         ?>
         <div style="background: #e3f2fd; padding: 20px; border-radius: 8px;">
-            <h2>🎨 Prévisualisation en direct</h2>
-            <p>Testez différentes configurations visuelles :</p>
+            <h2><?php esc_html_e('🎨 Prévisualisation en direct', 'discord-bot-jlg'); ?></h2>
+            <p><?php esc_html_e('Testez différentes configurations visuelles :', 'discord-bot-jlg'); ?></p>
             <?php
             foreach ($previews as $preview) {
                 $options = array('container_style' => 'margin: 20px 0;');
@@ -673,135 +699,91 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_guide_section() {
         ?>
         <div style="background: #e8f5e9; padding: 20px; border-radius: 8px;">
-            <h2>📖 Guide d'utilisation</h2>
+            <h2><?php esc_html_e('📖 Guide d\'utilisation', 'discord-bot-jlg'); ?></h2>
 
-            <h3>Option 1 : Shortcode (avec paramètres)</h3>
-            <p>Copiez ce code dans n'importe quelle page ou article :</p>
-            <code style="background: white; padding: 10px; display: inline-block; border-radius: 4px;">[discord_stats]</code>
+            <h3><?php esc_html_e('Option 1 : Shortcode (avec paramètres)', 'discord-bot-jlg'); ?></h3>
+            <p><?php esc_html_e('Copiez ce code dans n\'importe quelle page ou article :', 'discord-bot-jlg'); ?></p>
+            <code style="background: white; padding: 10px; display: inline-block; border-radius: 4px;"><?php echo esc_html__('[discord_stats]', 'discord-bot-jlg'); ?></code>
 
-            <h4>Exemples avec paramètres :</h4>
-            <pre style="background: white; padding: 15px; border-radius: 4px; overflow-x: auto;">// BASIQUES
-// Layout vertical pour sidebar
-[discord_stats layout="vertical"]
+            <h4><?php esc_html_e('Exemples avec paramètres :', 'discord-bot-jlg'); ?></h4>
+            <pre style="background: white; padding: 15px; border-radius: 4px; overflow-x: auto;"><?php echo esc_html__("// BASIQUES\n// Layout vertical pour sidebar\n[discord_stats layout=\"vertical\"]\n\n// Compact avec titre\n[discord_stats compact=\"true\" show_title=\"true\" title=\"Rejoignez-nous !\"]\n\n// Theme sombre centré\n[discord_stats theme=\"dark\" align=\"center\"]\n\n// AVEC LOGO DISCORD\n// Logo à gauche (classique)\n[discord_stats show_discord_icon=\"true\"]\n\n// Logo à droite avec thème sombre\n[discord_stats show_discord_icon=\"true\" discord_icon_position=\"right\" theme=\"dark\"]\n\n// Logo centré en haut (parfait pour widgets)\n[discord_stats show_discord_icon=\"true\" discord_icon_position=\"top\" align=\"center\"]\n\n// PERSONNALISATION AVANCÉE\n// Bannière complète pour header\n[discord_stats show_discord_icon=\"true\" show_title=\"true\" title=\"🎮 Rejoignez notre Discord !\" width=\"100%\" align=\"center\" theme=\"discord\"]\n\n// Sidebar élégante avec logo\n[discord_stats layout=\"vertical\" show_discord_icon=\"true\" discord_icon_position=\"top\" theme=\"minimal\" compact=\"true\"]\n\n// Gaming style avec icônes custom\n[discord_stats show_discord_icon=\"true\" icon_online=\"🎮\" label_online=\"Joueurs actifs\" icon_total=\"⚔️\" label_total=\"Guerriers\" theme=\"dark\"]\n\n// Minimaliste avec logo seul\n[discord_stats hide_labels=\"true\" hide_icons=\"true\" show_discord_icon=\"true\" discord_icon_position=\"top\" align=\"center\" theme=\"minimal\"]\n\n// Footer discret\n[discord_stats compact=\"true\" show_discord_icon=\"true\" discord_icon_position=\"left\" theme=\"light\"]\n\n// FONCTIONNALITÉS SPÉCIALES\n// Auto-refresh toutes les 30 secondes (minimum 10 secondes)\n[discord_stats refresh=\"true\" refresh_interval=\"30\" show_discord_icon=\"true\"]\n\n// Afficher seulement les membres en ligne avec logo\n[discord_stats show_online=\"true\" show_total=\"false\" show_discord_icon=\"true\"]\n\n// MODE DÉMO (pour tester l'apparence)\n[discord_stats demo=\"true\" show_discord_icon=\"true\" theme=\"dark\" layout=\"vertical\"]", 'discord-bot-jlg'); ?></pre>
 
-// Compact avec titre
-[discord_stats compact="true" show_title="true" title="Rejoignez-nous !"]
+            <p style="margin-top: 10px;"><em><?php echo esc_html__('ℹ️ L\'auto-refresh nécessite un intervalle d\'au moins 10 secondes (10 000 ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429.', 'discord-bot-jlg'); ?></em></p>
 
-// Theme sombre centré
-[discord_stats theme="dark" align="center"]
-
-// AVEC LOGO DISCORD
-// Logo à gauche (classique)
-[discord_stats show_discord_icon="true"]
-
-// Logo à droite avec thème sombre
-[discord_stats show_discord_icon="true" discord_icon_position="right" theme="dark"]
-
-// Logo centré en haut (parfait pour widgets)
-[discord_stats show_discord_icon="true" discord_icon_position="top" align="center"]
-
-// PERSONNALISATION AVANCÉE
-// Bannière complète pour header
-[discord_stats show_discord_icon="true" show_title="true" title="🎮 Rejoignez notre Discord !" width="100%" align="center" theme="discord"]
-
-// Sidebar élégante avec logo
-[discord_stats layout="vertical" show_discord_icon="true" discord_icon_position="top" theme="minimal" compact="true"]
-
-// Gaming style avec icônes custom
-[discord_stats show_discord_icon="true" icon_online="🎮" label_online="Joueurs actifs" icon_total="⚔️" label_total="Guerriers" theme="dark"]
-
-// Minimaliste avec logo seul
-[discord_stats hide_labels="true" hide_icons="true" show_discord_icon="true" discord_icon_position="top" align="center" theme="minimal"]
-
-// Footer discret
-[discord_stats compact="true" show_discord_icon="true" discord_icon_position="left" theme="light"]
-
-// FONCTIONNALITÉS SPÉCIALES
-// Auto-refresh toutes les 30 secondes (minimum 10 secondes)
-[discord_stats refresh="true" refresh_interval="30" show_discord_icon="true"]
-
-// Afficher seulement les membres en ligne avec logo
-[discord_stats show_online="true" show_total="false" show_discord_icon="true"]
-
-// MODE DÉMO (pour tester l'apparence)
-[discord_stats demo="true" show_discord_icon="true" theme="dark" layout="vertical"]</pre>
-
-            <p style="margin-top: 10px;"><em>ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10&nbsp;secondes (10 000&nbsp;ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429.</em></p>
-
-            <h4>Tous les paramètres disponibles :</h4>
+            <h4><?php esc_html_e('Tous les paramètres disponibles :', 'discord-bot-jlg'); ?></h4>
             <div style="background: white; padding: 15px; border-radius: 4px;">
-                <h5>🎨 Apparence & Layout :</h5>
+                <h5><?php esc_html_e('🎨 Apparence & Layout :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>layout</strong> : horizontal, vertical, compact</li>
-                    <li><strong>theme</strong> : discord, dark, light, minimal</li>
-                    <li><strong>align</strong> : left, center, right</li>
-                    <li><strong>width</strong> : largeur CSS (ex: "300px", "100%")</li>
-                    <li><strong>compact</strong> : true/false (version réduite)</li>
-                    <li><strong>animated</strong> : true/false (animations hover)</li>
-                    <li><strong>class</strong> : classes CSS additionnelles</li>
+                    <li><?php echo wp_kses_post(__('<strong>layout</strong> : horizontal, vertical, compact', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>theme</strong> : discord, dark, light, minimal', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>align</strong> : left, center, right', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>width</strong> : largeur CSS (ex: "300px", "100%")', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>compact</strong> : true/false (version réduite)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>animated</strong> : true/false (animations hover)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>class</strong> : classes CSS additionnelles', 'discord-bot-jlg')); ?></li>
                 </ul>
 
-                <h5>🎯 Logo Discord :</h5>
+                <h5><?php esc_html_e('🎯 Logo Discord :', 'discord-bot-jlg'); ?></h5>
                 <ul>
-                    <li><strong>show_discord_icon</strong> : true/false (afficher le logo officiel)</li>
-                    <li><strong>discord_icon_position</strong> : left, right, top (position du logo)</li>
+                    <li><?php echo wp_kses_post(__('<strong>show_discord_icon</strong> : true/false (afficher le logo officiel)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>discord_icon_position</strong> : left, right, top (position du logo)', 'discord-bot-jlg')); ?></li>
                 </ul>
 
-                <h5>📊 Données affichées :</h5>
+                <h5><?php esc_html_e('📊 Données affichées :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>show_online</strong> : true/false</li>
-                    <li><strong>show_total</strong> : true/false</li>
-                    <li><strong>show_title</strong> : true/false</li>
-                    <li><strong>title</strong> : texte du titre</li>
-                    <li><strong>hide_labels</strong> : true/false</li>
-                    <li><strong>hide_icons</strong> : true/false</li>
+                    <li><?php echo wp_kses_post(__('<strong>show_online</strong> : true/false', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>show_total</strong> : true/false', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>show_title</strong> : true/false', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>title</strong> : texte du titre', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>hide_labels</strong> : true/false', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>hide_icons</strong> : true/false', 'discord-bot-jlg')); ?></li>
                 </ul>
 
-                <h5>✏️ Personnalisation textes/icônes :</h5>
+                <h5><?php esc_html_e('✏️ Personnalisation textes/icônes :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>icon_online</strong> : emoji/texte (défaut: 🟢)</li>
-                    <li><strong>icon_total</strong> : emoji/texte (défaut: 👥)</li>
-                    <li><strong>label_online</strong> : texte personnalisé</li>
-                    <li><strong>label_total</strong> : texte personnalisé</li>
+                    <li><?php echo wp_kses_post(__('<strong>icon_online</strong> : emoji/texte (défaut: 🟢)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>icon_total</strong> : emoji/texte (défaut: 👥)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>label_online</strong> : texte personnalisé', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>label_total</strong> : texte personnalisé', 'discord-bot-jlg')); ?></li>
                 </ul>
 
-                <h5>⚙️ Paramètres techniques :</h5>
+                <h5><?php esc_html_e('⚙️ Paramètres techniques :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
-                    <li><strong>refresh</strong> : true/false (auto-actualisation)</li>
-                    <li><strong>refresh_interval</strong> : secondes (minimum 10&nbsp;secondes / 10 000&nbsp;ms)</li>
-                    <li><strong>demo</strong> : true/false (mode démonstration)</li>
-                    <li><strong>border_radius</strong> : pixels (coins arrondis)</li>
-                    <li><strong>gap</strong> : pixels (espace entre éléments)</li>
-                    <li><strong>padding</strong> : pixels (espacement interne)</li>
+                    <li><?php echo wp_kses_post(__('<strong>refresh</strong> : true/false (auto-actualisation)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>refresh_interval</strong> : secondes (minimum 10&nbsp;secondes / 10 000&nbsp;ms)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>demo</strong> : true/false (mode démonstration)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>border_radius</strong> : pixels (coins arrondis)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>gap</strong> : pixels (espace entre éléments)', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>padding</strong> : pixels (espacement interne)', 'discord-bot-jlg')); ?></li>
                 </ul>
             </div>
 
-            <h3>Option 2 : Widget</h3>
-            <p>Allez dans <strong>Apparence > Widgets</strong> et ajoutez le widget <strong>"Discord Bot - JLG"</strong> dans votre sidebar</p>
+            <h3><?php esc_html_e('Option 2 : Widget', 'discord-bot-jlg'); ?></h3>
+            <p><?php echo wp_kses_post(__('Allez dans <strong>Apparence &gt; Widgets</strong> et ajoutez le widget <strong>"Discord Bot - JLG"</strong> dans votre sidebar', 'discord-bot-jlg')); ?></p>
 
-            <h3>Option 3 : Code PHP</h3>
-            <p>Pour les développeurs, dans vos templates PHP :</p>
+            <h3><?php esc_html_e('Option 3 : Code PHP', 'discord-bot-jlg'); ?></h3>
+            <p><?php esc_html_e('Pour les développeurs, dans vos templates PHP :', 'discord-bot-jlg'); ?></p>
             <code style="background: white; padding: 10px; display: block; border-radius: 4px;">
-                &lt;?php echo do_shortcode('[discord_stats show_discord_icon="true"]'); ?&gt;
+                <?php echo esc_html__('<?php echo do_shortcode(\'[discord_stats show_discord_icon="true"]\'); ?>', 'discord-bot-jlg'); ?>
             </code>
 
-            <h3>💡 Configurations recommandées</h3>
+            <h3><?php esc_html_e('💡 Configurations recommandées', 'discord-bot-jlg'); ?></h3>
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 15px;">
                 <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour une sidebar :</strong><br>
-                    <code style="font-size: 12px;">[discord_stats layout="vertical" show_discord_icon="true" discord_icon_position="top" compact="true"]</code>
+                    <?php echo wp_kses_post(__('<strong>Pour une sidebar :</strong><br>', 'discord-bot-jlg')); ?>
+                    <code style="font-size: 12px;"><?php echo esc_html__('[discord_stats layout="vertical" show_discord_icon="true" discord_icon_position="top" compact="true"]', 'discord-bot-jlg'); ?></code>
                 </div>
                 <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour un header :</strong><br>
-                    <code style="font-size: 12px;">[discord_stats show_discord_icon="true" show_title="true" title="Join us!" align="center" width="100%"]</code>
+                    <?php echo wp_kses_post(__('<strong>Pour un header :</strong><br>', 'discord-bot-jlg')); ?>
+                    <code style="font-size: 12px;"><?php echo esc_html__('[discord_stats show_discord_icon="true" show_title="true" title="Join us!" align="center" width="100%"]', 'discord-bot-jlg'); ?></code>
                 </div>
                 <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Pour un footer :</strong><br>
-                    <code style="font-size: 12px;">[discord_stats theme="dark" show_discord_icon="true" compact="true"]</code>
+                    <?php echo wp_kses_post(__('<strong>Pour un footer :</strong><br>', 'discord-bot-jlg')); ?>
+                    <code style="font-size: 12px;"><?php echo esc_html__('[discord_stats theme="dark" show_discord_icon="true" compact="true"]', 'discord-bot-jlg'); ?></code>
                 </div>
                 <div style="background: white; padding: 15px; border-radius: 4px;">
-                    <strong>Style gaming :</strong><br>
-                    <code style="font-size: 12px;">[discord_stats theme="dark" icon_online="🎮" label_online="Players" show_discord_icon="true"]</code>
+                    <?php echo wp_kses_post(__('<strong>Style gaming :</strong><br>', 'discord-bot-jlg')); ?>
+                    <code style="font-size: 12px;"><?php echo esc_html__('[discord_stats theme="dark" icon_online="🎮" label_online="Players" show_discord_icon="true"]', 'discord-bot-jlg'); ?></code>
                 </div>
             </div>
         </div>
@@ -814,12 +796,12 @@ class Discord_Bot_JLG_Admin {
     private function render_demo_troubleshooting() {
         ?>
         <div style="background: #fff8e1; padding: 20px; border-radius: 8px;">
-            <h2>❓ Dépannage</h2>
+            <h2><?php esc_html_e('❓ Dépannage', 'discord-bot-jlg'); ?></h2>
             <ul>
-                <li><strong>Erreur de connexion ?</strong> Vérifiez que le bot est bien sur votre serveur</li>
-                <li><strong>Stats à 0 ?</strong> Assurez-vous que le widget est activé dans les paramètres Discord</li>
-                <li><strong>Token invalide ?</strong> Régénérez le token dans le Developer Portal</li>
-                <li><strong>Cache ?</strong> Les stats sont mises à jour toutes les 5 minutes par défaut</li>
+                <li><?php echo wp_kses_post(__('<strong>Erreur de connexion ?</strong> Vérifiez que le bot est bien sur votre serveur', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('<strong>Stats à 0 ?</strong> Assurez-vous que le widget est activé dans les paramètres Discord', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('<strong>Token invalide ?</strong> Régénérez le token dans le Developer Portal', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('<strong>Cache ?</strong> Les stats sont mises à jour toutes les 5 minutes par défaut', 'discord-bot-jlg')); ?></li>
             </ul>
         </div>
         <?php
@@ -833,13 +815,19 @@ class Discord_Bot_JLG_Admin {
         <div style="margin-top: 30px; padding: 15px; background: #f0f0f0; border-radius: 8px; text-align: center;">
             <p style="margin: 0;">
                 <?php
+                $version_label = sprintf(
+                    /* translators: %s: plugin version. */
+                    __('Discord Bot - JLG v%s', 'discord-bot-jlg'),
+                    DISCORD_BOT_JLG_VERSION
+                );
                 printf(
-                    '%s | Développé par Jérôme Le Gousse |',
-                    esc_html(sprintf('Discord Bot - JLG v%s', DISCORD_BOT_JLG_VERSION))
+                    /* translators: %1$s: plugin version label. */
+                    esc_html__('%1$s | Développé par Jérôme Le Gousse |', 'discord-bot-jlg'),
+                    esc_html($version_label)
                 );
                 ?>
-               <a href="https://discord.com/developers/docs/intro" target="_blank" rel="noopener noreferrer">Documentation Discord API</a> |
-               <a href="#" onclick="return false;">Besoin d'aide ?</a>
+               <a href="https://discord.com/developers/docs/intro" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Documentation Discord API', 'discord-bot-jlg'); ?></a> |
+               <a href="#" onclick="return false;"><?php esc_html_e('Besoin d\'aide ?', 'discord-bot-jlg'); ?></a>
             </p>
         </div>
         <?php
@@ -892,7 +880,10 @@ class Discord_Bot_JLG_Admin {
         }
 
         if (!empty($options['demo_mode'])) {
-            echo '<div class="notice notice-info"><p>🎨 Mode démonstration activé - Les données affichées sont fictives</p></div>';
+            printf(
+                '<div class="notice notice-info"><p>%s</p></div>',
+                esc_html__('🎨 Mode démonstration activé - Les données affichées sont fictives', 'discord-bot-jlg')
+            );
             return;
         }
 
@@ -915,15 +906,25 @@ class Discord_Bot_JLG_Admin {
             }
 
             printf(
-                '<div class="notice notice-success"><p>✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres</p></div>',
-                esc_html($server_name),
-                esc_html(number_format_i18n($online_count)),
-                $total_display
+                '<div class="notice notice-success"><p>%s</p></div>',
+                sprintf(
+                    /* translators: 1: server name, 2: online members count, 3: total members count. */
+                    esc_html__('✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres', 'discord-bot-jlg'),
+                    esc_html($server_name),
+                    esc_html(number_format_i18n($online_count)),
+                    $total_display
+                )
             );
         } elseif (is_array($stats) && !empty($stats['is_demo'])) {
-            echo '<div class="notice notice-warning"><p>⚠️ Pas de configuration Discord détectée. Mode démo actif.</p></div>';
+            printf(
+                '<div class="notice notice-warning"><p>%s</p></div>',
+                esc_html__('⚠️ Pas de configuration Discord détectée. Mode démo actif.', 'discord-bot-jlg')
+            );
         } else {
-            echo '<div class="notice notice-error"><p>❌ Échec de la connexion. Vérifiez vos identifiants.</p></div>';
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html__('❌ Échec de la connexion. Vérifiez vos identifiants.', 'discord-bot-jlg')
+            );
         }
     }
 

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -193,6 +193,7 @@ class Discord_Bot_JLG_API {
                 if ($elapsed < $rate_limit_window) {
                     $retry_after = max(0, $rate_limit_window - $elapsed);
                     $message = sprintf(
+                        /* translators: %d: number of seconds to wait before the next refresh. */
                         __('Veuillez patienter %d secondes avant la prochaine actualisation.', 'discord-bot-jlg'),
                         $retry_after
                     );

--- a/discord-bot-jlg/languages/discord-bot-jlg.pot
+++ b/discord-bot-jlg/languages/discord-bot-jlg.pot
@@ -1,0 +1,696 @@
+# Copyright (C) 2025 Jérôme Le Gousse
+# This file is distributed under the GPL v2 or later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Discord Bot - JLG 1.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/discord-bot-jlg\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-09-21T22:42:33+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: discord-bot-jlg\n"
+
+#. Plugin Name of the plugin
+#: discord-bot-jlg.php
+#: inc/class-discord-admin.php:39
+msgid "Discord Bot - JLG"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: discord-bot-jlg.php
+msgid "https://yourwebsite.com/"
+msgstr ""
+
+#. Description of the plugin
+#: discord-bot-jlg.php
+msgid "Affiche les statistiques de votre serveur Discord (membres en ligne et total)"
+msgstr ""
+
+#. Author of the plugin
+#: discord-bot-jlg.php
+msgid "Jérôme Le Gousse"
+msgstr ""
+
+#: inc/class-discord-admin.php:40
+msgid "Discord Bot"
+msgstr ""
+
+#: inc/class-discord-admin.php:50
+#: inc/class-discord-admin.php:51
+msgid "Configuration"
+msgstr ""
+
+#: inc/class-discord-admin.php:59
+#: inc/class-discord-admin.php:60
+msgid "Guide & Démo"
+msgstr ""
+
+#: inc/class-discord-admin.php:83
+msgid "Configuration Discord API"
+msgstr ""
+
+#: inc/class-discord-admin.php:90
+msgid "ID du Serveur Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:98
+msgid "Token du Bot Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:106
+msgid "Options d'affichage"
+msgstr ""
+
+#: inc/class-discord-admin.php:113
+msgid "Mode démonstration"
+msgstr ""
+
+#: inc/class-discord-admin.php:121
+msgid "Afficher les membres en ligne"
+msgstr ""
+
+#: inc/class-discord-admin.php:129
+msgid "Afficher le total des membres"
+msgstr ""
+
+#: inc/class-discord-admin.php:137
+msgid "Titre du widget"
+msgstr ""
+
+#: inc/class-discord-admin.php:145
+msgid "Durée du cache (secondes)"
+msgstr ""
+
+#: inc/class-discord-admin.php:153
+msgid "CSS personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:228
+msgid "📚 Guide étape par étape"
+msgstr ""
+
+#: inc/class-discord-admin.php:242
+msgid "Étape 1 : Créer un Bot Discord"
+msgstr ""
+
+#. translators: %1$s: URL to the Discord Developer Portal.
+#: inc/class-discord-admin.php:249
+#, php-format
+msgid "Rendez-vous sur <a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\" style=\"color: #5865F2;\">Discord Developer Portal</a>"
+msgstr ""
+
+#: inc/class-discord-admin.php:258
+msgid "Cliquez sur <strong>\"New Application\"</strong> en haut à droite"
+msgstr ""
+
+#: inc/class-discord-admin.php:259
+msgid "Donnez un nom à votre application (ex: \"Stats Bot\")"
+msgstr ""
+
+#: inc/class-discord-admin.php:260
+msgid "Dans le menu de gauche, cliquez sur <strong>\"Bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:261
+msgid "Cliquez sur <strong>\"Add Bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:262
+msgid "Sous \"Token\", cliquez sur <strong>\"Copy\"</strong> pour copier le token du bot"
+msgstr ""
+
+#: inc/class-discord-admin.php:263
+msgid "⚠️ <strong>Important :</strong> Gardez ce token secret et ne le partagez jamais !"
+msgstr ""
+
+#: inc/class-discord-admin.php:266
+msgid "Étape 2 : Inviter le Bot sur votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:268
+msgid "Dans le menu de gauche, allez dans <strong>\"OAuth2\"</strong> &gt; <strong>\"URL Generator\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:269
+msgid "Dans \"Scopes\", cochez <strong>\"bot\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:270
+msgid "Dans \"Bot Permissions\", sélectionnez :"
+msgstr ""
+
+#: inc/class-discord-admin.php:272
+msgid "✅ View Channels"
+msgstr ""
+
+#: inc/class-discord-admin.php:273
+msgid "✅ Read Messages"
+msgstr ""
+
+#: inc/class-discord-admin.php:274
+msgid "✅ Send Messages (optionnel)"
+msgstr ""
+
+#: inc/class-discord-admin.php:276
+msgid "Copiez l'URL générée en bas de la page"
+msgstr ""
+
+#: inc/class-discord-admin.php:277
+msgid "Ouvrez cette URL dans votre navigateur"
+msgstr ""
+
+#: inc/class-discord-admin.php:278
+msgid "Sélectionnez votre serveur et cliquez sur <strong>\"Autoriser\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:281
+msgid "Étape 3 : Obtenir l'ID de votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:283
+msgid "Ouvrez Discord (application ou web)"
+msgstr ""
+
+#: inc/class-discord-admin.php:284
+msgid "Allez dans <strong>Paramètres utilisateur</strong> (engrenage en bas)"
+msgstr ""
+
+#: inc/class-discord-admin.php:285
+msgid "Dans <strong>\"Avancés\"</strong>, activez <strong>\"Mode développeur\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:286
+msgid "Retournez sur votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:287
+msgid "Faites un <strong>clic droit sur le nom du serveur</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:288
+msgid "Cliquez sur <strong>\"Copier l'ID\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:291
+msgid "Étape 4 : Activer le Widget (optionnel mais recommandé)"
+msgstr ""
+
+#: inc/class-discord-admin.php:293
+msgid "Dans Discord, allez dans <strong>Paramètres du serveur</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:294
+msgid "Dans <strong>\"Widget\"</strong>, activez <strong>\"Activer le widget du serveur\"</strong>"
+msgstr ""
+
+#: inc/class-discord-admin.php:295
+msgid "Cela permet une méthode de fallback si le bot a des problèmes"
+msgstr ""
+
+#: inc/class-discord-admin.php:306
+msgid "<strong>💡 Conseil :</strong> Après avoir rempli les champs ci-dessous, utilisez le bouton \"Tester la connexion\" pour vérifier que tout fonctionne !"
+msgstr ""
+
+#: inc/class-discord-admin.php:309
+msgid "Avec logo Discord officiel :"
+msgstr ""
+
+#: inc/class-discord-admin.php:317
+msgid "Logo Discord centré en haut :"
+msgstr ""
+
+#: inc/class-discord-admin.php:334
+msgid "Personnalisez l'affichage des statistiques Discord."
+msgstr ""
+
+#: inc/class-discord-admin.php:348
+msgid "L'ID de votre serveur Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:367
+msgid "Le token est actuellement défini via la constante <code>DISCORD_BOT_JLG_TOKEN</code> et remplace cette valeur."
+msgstr ""
+
+#: inc/class-discord-admin.php:369
+msgid "Le token de votre bot Discord (gardez-le secret !)."
+msgstr ""
+
+#: inc/class-discord-admin.php:387
+msgid "Activer le mode démonstration (affiche des données fictives pour tester l'apparence)"
+msgstr ""
+
+#: inc/class-discord-admin.php:388
+msgid "🎨 Parfait pour tester les styles et dispositions sans configuration Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:403
+msgid "Afficher le nombre d'utilisateurs en ligne"
+msgstr ""
+
+#: inc/class-discord-admin.php:418
+msgid "Afficher le nombre total de membres"
+msgstr ""
+
+#. translators: 1: minimum cache duration in seconds, 2: maximum cache duration in seconds.
+#: inc/class-discord-admin.php:451
+#, php-format
+msgid "Minimum %1$s secondes, maximum %2$s secondes (1 heure)"
+msgstr ""
+
+#: inc/class-discord-admin.php:469
+msgid "CSS personnalisé pour styliser l'affichage"
+msgstr ""
+
+#: inc/class-discord-admin.php:481
+msgid "🎮 Discord Bot - JLG - Configuration"
+msgstr ""
+
+#: inc/class-discord-admin.php:542
+msgid "🔧 Test de connexion"
+msgstr ""
+
+#: inc/class-discord-admin.php:543
+msgid "Vérifiez que votre configuration fonctionne :"
+msgstr ""
+
+#: inc/class-discord-admin.php:549
+msgid "Tester la connexion"
+msgstr ""
+
+#: inc/class-discord-admin.php:562
+msgid "🚀 Liens rapides"
+msgstr ""
+
+#: inc/class-discord-admin.php:566
+msgid "📖 Guide & Démo"
+msgstr ""
+
+#: inc/class-discord-admin.php:571
+msgid "🔗 Discord Developer Portal"
+msgstr ""
+
+#: inc/class-discord-admin.php:576
+msgid "📐 Gérer les Widgets"
+msgstr ""
+
+#. translators: %s: plugin version.
+#: inc/class-discord-admin.php:594
+#: inc/class-discord-admin.php:820
+#, php-format
+msgid "Discord Bot - JLG v%s"
+msgstr ""
+
+#. translators: %1$s: plugin version label.
+#: inc/class-discord-admin.php:599
+#, php-format
+msgid "%1$s | Développé par Jérôme Le Gousse"
+msgstr ""
+
+#: inc/class-discord-admin.php:616
+msgid "📖 Guide & Démonstration"
+msgstr ""
+
+#: inc/class-discord-admin.php:643
+msgid "<strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode démo. Vous pouvez les copier-coller directement !"
+msgstr ""
+
+#: inc/class-discord-admin.php:654
+msgid "Standard horizontal :"
+msgstr ""
+
+#: inc/class-discord-admin.php:658
+msgid "Vertical pour sidebar :"
+msgstr ""
+
+#: inc/class-discord-admin.php:663
+msgid "Compact mode sombre :"
+msgstr ""
+
+#: inc/class-discord-admin.php:667
+msgid "Avec titre personnalisé :"
+msgstr ""
+
+#: inc/class-discord-admin.php:671
+msgid "Icônes personnalisées :"
+msgstr ""
+
+#: inc/class-discord-admin.php:675
+msgid "Minimaliste (nombres uniquement) :"
+msgstr ""
+
+#: inc/class-discord-admin.php:681
+msgid "🎨 Prévisualisation en direct"
+msgstr ""
+
+#: inc/class-discord-admin.php:682
+msgid "Testez différentes configurations visuelles :"
+msgstr ""
+
+#: inc/class-discord-admin.php:702
+msgid "📖 Guide d'utilisation"
+msgstr ""
+
+#: inc/class-discord-admin.php:704
+msgid "Option 1 : Shortcode (avec paramètres)"
+msgstr ""
+
+#: inc/class-discord-admin.php:705
+msgid "Copiez ce code dans n'importe quelle page ou article :"
+msgstr ""
+
+#: inc/class-discord-admin.php:706
+msgid "[discord_stats]"
+msgstr ""
+
+#: inc/class-discord-admin.php:708
+msgid "Exemples avec paramètres :"
+msgstr ""
+
+#: inc/class-discord-admin.php:709
+msgid ""
+"// BASIQUES\n"
+"// Layout vertical pour sidebar\n"
+"[discord_stats layout=\"vertical\"]\n"
+"\n"
+"// Compact avec titre\n"
+"[discord_stats compact=\"true\" show_title=\"true\" title=\"Rejoignez-nous !\"]\n"
+"\n"
+"// Theme sombre centré\n"
+"[discord_stats theme=\"dark\" align=\"center\"]\n"
+"\n"
+"// AVEC LOGO DISCORD\n"
+"// Logo à gauche (classique)\n"
+"[discord_stats show_discord_icon=\"true\"]\n"
+"\n"
+"// Logo à droite avec thème sombre\n"
+"[discord_stats show_discord_icon=\"true\" discord_icon_position=\"right\" theme=\"dark\"]\n"
+"\n"
+"// Logo centré en haut (parfait pour widgets)\n"
+"[discord_stats show_discord_icon=\"true\" discord_icon_position=\"top\" align=\"center\"]\n"
+"\n"
+"// PERSONNALISATION AVANCÉE\n"
+"// Bannière complète pour header\n"
+"[discord_stats show_discord_icon=\"true\" show_title=\"true\" title=\"🎮 Rejoignez notre Discord !\" width=\"100%\" align=\"center\" theme=\"discord\"]\n"
+"\n"
+"// Sidebar élégante avec logo\n"
+"[discord_stats layout=\"vertical\" show_discord_icon=\"true\" discord_icon_position=\"top\" theme=\"minimal\" compact=\"true\"]\n"
+"\n"
+"// Gaming style avec icônes custom\n"
+"[discord_stats show_discord_icon=\"true\" icon_online=\"🎮\" label_online=\"Joueurs actifs\" icon_total=\"⚔️\" label_total=\"Guerriers\" theme=\"dark\"]\n"
+"\n"
+"// Minimaliste avec logo seul\n"
+"[discord_stats hide_labels=\"true\" hide_icons=\"true\" show_discord_icon=\"true\" discord_icon_position=\"top\" align=\"center\" theme=\"minimal\"]\n"
+"\n"
+"// Footer discret\n"
+"[discord_stats compact=\"true\" show_discord_icon=\"true\" discord_icon_position=\"left\" theme=\"light\"]\n"
+"\n"
+"// FONCTIONNALITÉS SPÉCIALES\n"
+"// Auto-refresh toutes les 30 secondes (minimum 10 secondes)\n"
+"[discord_stats refresh=\"true\" refresh_interval=\"30\" show_discord_icon=\"true\"]\n"
+"\n"
+"// Afficher seulement les membres en ligne avec logo\n"
+"[discord_stats show_online=\"true\" show_total=\"false\" show_discord_icon=\"true\"]\n"
+"\n"
+"// MODE DÉMO (pour tester l'apparence)\n"
+"[discord_stats demo=\"true\" show_discord_icon=\"true\" theme=\"dark\" layout=\"vertical\"]"
+msgstr ""
+
+#: inc/class-discord-admin.php:711
+msgid "ℹ️ L'auto-refresh nécessite un intervalle d'au moins 10 secondes (10 000 ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429."
+msgstr ""
+
+#: inc/class-discord-admin.php:713
+msgid "Tous les paramètres disponibles :"
+msgstr ""
+
+#: inc/class-discord-admin.php:715
+msgid "🎨 Apparence & Layout :"
+msgstr ""
+
+#: inc/class-discord-admin.php:717
+msgid "<strong>layout</strong> : horizontal, vertical, compact"
+msgstr ""
+
+#: inc/class-discord-admin.php:718
+msgid "<strong>theme</strong> : discord, dark, light, minimal"
+msgstr ""
+
+#: inc/class-discord-admin.php:719
+msgid "<strong>align</strong> : left, center, right"
+msgstr ""
+
+#: inc/class-discord-admin.php:720
+msgid "<strong>width</strong> : largeur CSS (ex: \"300px\", \"100%\")"
+msgstr ""
+
+#: inc/class-discord-admin.php:721
+msgid "<strong>compact</strong> : true/false (version réduite)"
+msgstr ""
+
+#: inc/class-discord-admin.php:722
+msgid "<strong>animated</strong> : true/false (animations hover)"
+msgstr ""
+
+#: inc/class-discord-admin.php:723
+msgid "<strong>class</strong> : classes CSS additionnelles"
+msgstr ""
+
+#: inc/class-discord-admin.php:726
+msgid "🎯 Logo Discord :"
+msgstr ""
+
+#: inc/class-discord-admin.php:728
+msgid "<strong>show_discord_icon</strong> : true/false (afficher le logo officiel)"
+msgstr ""
+
+#: inc/class-discord-admin.php:729
+msgid "<strong>discord_icon_position</strong> : left, right, top (position du logo)"
+msgstr ""
+
+#: inc/class-discord-admin.php:732
+msgid "📊 Données affichées :"
+msgstr ""
+
+#: inc/class-discord-admin.php:734
+msgid "<strong>show_online</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:735
+msgid "<strong>show_total</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:736
+msgid "<strong>show_title</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:737
+msgid "<strong>title</strong> : texte du titre"
+msgstr ""
+
+#: inc/class-discord-admin.php:738
+msgid "<strong>hide_labels</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:739
+msgid "<strong>hide_icons</strong> : true/false"
+msgstr ""
+
+#: inc/class-discord-admin.php:742
+msgid "✏️ Personnalisation textes/icônes :"
+msgstr ""
+
+#: inc/class-discord-admin.php:744
+msgid "<strong>icon_online</strong> : emoji/texte (défaut: 🟢)"
+msgstr ""
+
+#: inc/class-discord-admin.php:745
+msgid "<strong>icon_total</strong> : emoji/texte (défaut: 👥)"
+msgstr ""
+
+#: inc/class-discord-admin.php:746
+msgid "<strong>label_online</strong> : texte personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:747
+msgid "<strong>label_total</strong> : texte personnalisé"
+msgstr ""
+
+#: inc/class-discord-admin.php:750
+msgid "⚙️ Paramètres techniques :"
+msgstr ""
+
+#: inc/class-discord-admin.php:752
+msgid "<strong>refresh</strong> : true/false (auto-actualisation)"
+msgstr ""
+
+#: inc/class-discord-admin.php:753
+msgid "<strong>refresh_interval</strong> : secondes (minimum 10&nbsp;secondes / 10 000&nbsp;ms)"
+msgstr ""
+
+#: inc/class-discord-admin.php:754
+msgid "<strong>demo</strong> : true/false (mode démonstration)"
+msgstr ""
+
+#: inc/class-discord-admin.php:755
+msgid "<strong>border_radius</strong> : pixels (coins arrondis)"
+msgstr ""
+
+#: inc/class-discord-admin.php:756
+msgid "<strong>gap</strong> : pixels (espace entre éléments)"
+msgstr ""
+
+#: inc/class-discord-admin.php:757
+msgid "<strong>padding</strong> : pixels (espacement interne)"
+msgstr ""
+
+#: inc/class-discord-admin.php:761
+msgid "Option 2 : Widget"
+msgstr ""
+
+#: inc/class-discord-admin.php:762
+msgid "Allez dans <strong>Apparence &gt; Widgets</strong> et ajoutez le widget <strong>\"Discord Bot - JLG\"</strong> dans votre sidebar"
+msgstr ""
+
+#: inc/class-discord-admin.php:764
+msgid "Option 3 : Code PHP"
+msgstr ""
+
+#: inc/class-discord-admin.php:765
+msgid "Pour les développeurs, dans vos templates PHP :"
+msgstr ""
+
+#: inc/class-discord-admin.php:767
+msgid "<?php echo do_shortcode('[discord_stats show_discord_icon="
+msgstr ""
+
+#: inc/class-discord-admin.php:770
+msgid "💡 Configurations recommandées"
+msgstr ""
+
+#: inc/class-discord-admin.php:773
+msgid "<strong>Pour une sidebar :</strong><br>"
+msgstr ""
+
+#: inc/class-discord-admin.php:774
+msgid "[discord_stats layout=\"vertical\" show_discord_icon=\"true\" discord_icon_position=\"top\" compact=\"true\"]"
+msgstr ""
+
+#: inc/class-discord-admin.php:777
+msgid "<strong>Pour un header :</strong><br>"
+msgstr ""
+
+#: inc/class-discord-admin.php:778
+msgid "[discord_stats show_discord_icon=\"true\" show_title=\"true\" title=\"Join us!\" align=\"center\" width=\"100%\"]"
+msgstr ""
+
+#: inc/class-discord-admin.php:781
+msgid "<strong>Pour un footer :</strong><br>"
+msgstr ""
+
+#: inc/class-discord-admin.php:782
+msgid "[discord_stats theme=\"dark\" show_discord_icon=\"true\" compact=\"true\"]"
+msgstr ""
+
+#: inc/class-discord-admin.php:785
+msgid "<strong>Style gaming :</strong><br>"
+msgstr ""
+
+#: inc/class-discord-admin.php:786
+msgid "[discord_stats theme=\"dark\" icon_online=\"🎮\" label_online=\"Players\" show_discord_icon=\"true\"]"
+msgstr ""
+
+#: inc/class-discord-admin.php:799
+msgid "❓ Dépannage"
+msgstr ""
+
+#: inc/class-discord-admin.php:801
+msgid "<strong>Erreur de connexion ?</strong> Vérifiez que le bot est bien sur votre serveur"
+msgstr ""
+
+#: inc/class-discord-admin.php:802
+msgid "<strong>Stats à 0 ?</strong> Assurez-vous que le widget est activé dans les paramètres Discord"
+msgstr ""
+
+#: inc/class-discord-admin.php:803
+msgid "<strong>Token invalide ?</strong> Régénérez le token dans le Developer Portal"
+msgstr ""
+
+#: inc/class-discord-admin.php:804
+msgid "<strong>Cache ?</strong> Les stats sont mises à jour toutes les 5 minutes par défaut"
+msgstr ""
+
+#. translators: %1$s: plugin version label.
+#: inc/class-discord-admin.php:825
+#, php-format
+msgid "%1$s | Développé par Jérôme Le Gousse |"
+msgstr ""
+
+#: inc/class-discord-admin.php:829
+msgid "Documentation Discord API"
+msgstr ""
+
+#: inc/class-discord-admin.php:830
+msgid "Besoin d'aide ?"
+msgstr ""
+
+#: inc/class-discord-admin.php:885
+msgid "🎨 Mode démonstration activé - Les données affichées sont fictives"
+msgstr ""
+
+#: inc/class-discord-admin.php:905
+#: inc/class-discord-shortcode.php:252
+msgid "Total indisponible"
+msgstr ""
+
+#. translators: 1: server name, 2: online members count, 3: total members count.
+#: inc/class-discord-admin.php:912
+#, php-format
+msgid "✅ Connexion réussie ! Serveur : %1$s - %2$s en ligne / %3$s membres"
+msgstr ""
+
+#: inc/class-discord-admin.php:921
+msgid "⚠️ Pas de configuration Discord détectée. Mode démo actif."
+msgstr ""
+
+#: inc/class-discord-admin.php:926
+msgid "❌ Échec de la connexion. Vérifiez vos identifiants."
+msgstr ""
+
+#: inc/class-discord-api.php:156
+msgid "Votre session a expiré, veuillez recharger la page."
+msgstr ""
+
+#. translators: %d: number of seconds to wait before the next refresh.
+#: inc/class-discord-api.php:197
+#, php-format
+msgid "Veuillez patienter %d secondes avant la prochaine actualisation."
+msgstr ""
+
+#: inc/class-discord-api.php:271
+msgid "Actualisation en cours, veuillez réessayer dans quelques instants."
+msgstr ""
+
+#: inc/class-discord-shortcode.php:62
+msgid "En ligne"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:63
+msgid "Membres"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:97
+msgid "Impossible de récupérer les stats Discord"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:208
+msgid "Mode Démo"
+msgstr ""
+
+#: inc/class-discord-shortcode.php:264
+#: inc/class-discord-shortcode.php:273
+msgid "approx."
+msgstr ""


### PR DESCRIPTION
## Summary
- wrap WordPress admin menu labels, help content, and option controls in translation functions with proper escaping
- translate demo guide, notices, and helper panels while adding translator comments for dynamic placeholders
- regenerate the plugin POT file so the new strings are available for localization

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68d07dd0b460832ea5b77fba0d09687f