### PR TITLE
Localize front-end strings and expose via script data

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -3,6 +3,24 @@
 
     var ERROR_CLASS = 'discord-stats-error';
     var ERROR_MESSAGE_CLASS = 'discord-error-message';
+    var globalConfig = {};
+
+    if (typeof window !== 'undefined' && window.discordBotJlg) {
+        globalConfig = window.discordBotJlg;
+    }
+
+    function getLocalizedString(key, fallback) {
+        if (
+            globalConfig
+            && Object.prototype.hasOwnProperty.call(globalConfig, key)
+            && typeof globalConfig[key] === 'string'
+            && globalConfig[key]
+        ) {
+            return globalConfig[key];
+        }
+
+        return fallback;
+    }
 
     function getOrCreateErrorMessageElement(container) {
         if (!container) {
@@ -68,12 +86,14 @@
     }
 
     function getDemoBadgeLabel(container) {
+        var fallbackLabel = getLocalizedString('demoBadgeLabel', 'Mode Démo');
+
         if (!container) {
-            return 'Mode Démo';
+            return fallbackLabel;
         }
 
         if (container.dataset && container.dataset.demoBadgeLabel) {
-            return container.dataset.demoBadgeLabel;
+            return container.dataset.demoBadgeLabel || fallbackLabel;
         }
 
         var existingBadge = container.querySelector('.discord-demo-badge');
@@ -85,7 +105,7 @@
             return label;
         }
 
-        var defaultLabel = 'Mode Démo';
+        var defaultLabel = fallbackLabel;
 
         if (container.dataset) {
             container.dataset.demoBadgeLabel = defaultLabel;
@@ -165,7 +185,11 @@
 
                 if (!data.success) {
                     if (data.data && data.data.nonce_expired) {
-                        var nonceMessage = data.data.message || 'Votre session a expiré, veuillez recharger la page.';
+                        var nonceMessage = data.data.message
+                            || getLocalizedString(
+                                'nonceExpiredFallback',
+                                'Votre session a expiré, veuillez recharger la page.'
+                            );
                         console.warn(nonceMessage);
                         showErrorMessage(container, nonceMessage);
                         return;
@@ -182,7 +206,13 @@
                         console.warn(errorMessage);
                         showErrorMessage(container, errorMessage);
                     } else if (container) {
-                        showErrorMessage(container, 'Une erreur est survenue lors de la récupération des statistiques.');
+                        showErrorMessage(
+                            container,
+                            getLocalizedString(
+                                'genericError',
+                                'Une erreur est survenue lors de la récupération des statistiques.'
+                            )
+                        );
                     }
 
                     return;
@@ -278,8 +308,20 @@
                 }
             })
             .catch(function (error) {
-                console.error('Erreur lors de la mise à jour des statistiques Discord :', error);
-                showErrorMessage(container, 'Une erreur est survenue lors de la récupération des statistiques.');
+                console.error(
+                    getLocalizedString(
+                        'consoleErrorPrefix',
+                        'Erreur lors de la mise à jour des statistiques Discord :'
+                    ),
+                    error
+                );
+                showErrorMessage(
+                    container,
+                    getLocalizedString(
+                        'genericError',
+                        'Une erreur est survenue lors de la récupération des statistiques.'
+                    )
+                );
             });
     }
 
@@ -289,6 +331,7 @@
         }
 
         var config = window.discordBotJlg || {};
+        globalConfig = config;
         if (!config.ajaxUrl || !config.nonce) {
             return;
         }

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -159,7 +159,7 @@ class Discord_Bot_JLG_API {
                 );
             }
 
-            wp_send_json_error('Nonce invalide', 403);
+            wp_send_json_error(__('Nonce invalide', 'discord-bot-jlg'), 403);
         }
 
         $options = get_option($this->option_name);
@@ -168,7 +168,7 @@ class Discord_Bot_JLG_API {
         }
 
         if (!empty($options['demo_mode'])) {
-            wp_send_json_error('Mode démo actif');
+            wp_send_json_error(__('Mode démo actif', 'discord-bot-jlg'));
         }
 
         $rate_limit_key = $this->cache_key . '_refresh_lock';
@@ -276,7 +276,7 @@ class Discord_Bot_JLG_API {
 
         delete_transient($rate_limit_key);
 
-        wp_send_json_error('Impossible de récupérer les stats');
+        wp_send_json_error(__('Impossible de récupérer les stats', 'discord-bot-jlg'));
     }
 
     /**
@@ -305,7 +305,7 @@ class Discord_Bot_JLG_API {
         return array(
             'online'               => (int) round($base_online + $variation),
             'total'                => (int) $base_total,
-            'server_name'          => 'Serveur Démo',
+            'server_name'          => __('Serveur Démo', 'discord-bot-jlg'),
             'is_demo'              => true,
             'fallback_demo'        => (bool) $is_fallback,
             'has_total'            => true,

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -347,6 +347,10 @@ class Discord_Bot_JLG_Shortcode {
                 'minRefreshInterval' => defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
                     ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
                     : 10,
+                'demoBadgeLabel'       => __('Mode Démo', 'discord-bot-jlg'),
+                'genericError'         => __('Une erreur est survenue lors de la récupération des statistiques.', 'discord-bot-jlg'),
+                'nonceExpiredFallback' => __('Votre session a expiré, veuillez recharger la page.', 'discord-bot-jlg'),
+                'consoleErrorPrefix'   => __('Erreur lors de la mise à jour des statistiques Discord :', 'discord-bot-jlg'),
             )
         );
 

--- a/discord-bot-jlg/languages/discord-bot-jlg.pot
+++ b/discord-bot-jlg/languages/discord-bot-jlg.pot
@@ -661,13 +661,26 @@ msgid "❌ Échec de la connexion. Vérifiez vos identifiants."
 msgstr ""
 
 #: inc/class-discord-api.php:156
+#: inc/class-discord-shortcode.php:352
 msgid "Votre session a expiré, veuillez recharger la page."
+msgstr ""
+
+#: inc/class-discord-api.php:162
+msgid "Nonce invalide"
+msgstr ""
+
+#: inc/class-discord-api.php:171
+msgid "Mode démo actif"
 msgstr ""
 
 #. translators: %d: number of seconds to wait before the next refresh.
 #: inc/class-discord-api.php:197
 #, php-format
 msgid "Veuillez patienter %d secondes avant la prochaine actualisation."
+msgstr ""
+
+#: inc/class-discord-api.php:279
+msgid "Impossible de récupérer les stats"
 msgstr ""
 
 #: inc/class-discord-api.php:271
@@ -686,11 +699,27 @@ msgstr ""
 msgid "Impossible de récupérer les stats Discord"
 msgstr ""
 
+#: inc/class-discord-api.php:308
+msgid "Serveur Démo"
+msgstr ""
+
 #: inc/class-discord-shortcode.php:208
+#: inc/class-discord-shortcode.php:350
 msgid "Mode Démo"
 msgstr ""
 
 #: inc/class-discord-shortcode.php:264
 #: inc/class-discord-shortcode.php:273
 msgid "approx."
+msgstr ""
+
+#: inc/class-discord-shortcode.php:351
+#: assets/js/discord-bot-jlg.js:213
+#: assets/js/discord-bot-jlg.js:322
+msgid "Une erreur est survenue lors de la récupération des statistiques."
+msgstr ""
+
+#: inc/class-discord-shortcode.php:353
+#: assets/js/discord-bot-jlg.js:314
+msgid "Erreur lors de la mise à jour des statistiques Discord :"
 msgstr ""


### PR DESCRIPTION
## Summary
- wrap API error and demo strings in translation calls with the `discord-bot-jlg` text domain
- expose localized front-end messages through the shortcode script registration
- consume localized strings in the front-end script while keeping French fallbacks and update the POT catalog

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d14cd570b0832e970a23677b8343ff