### PR TITLE
Fix admin preview SVG attributes

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -996,10 +996,11 @@ class Discord_Bot_JLG_Admin {
 
         $allowed_tags['svg'] = array(
             'class'      => true,
-            'viewbox'    => true,
+            'viewBox'    => true,
             'xmlns'      => true,
             'role'       => true,
             'aria-hidden'=> true,
+            'focusable'  => true,
         );
 
         $allowed_tags['path'] = array(


### PR DESCRIPTION
## Summary
- update the admin preview allowed SVG attributes to accept `viewBox`
- allow the `focusable` attribute on SVGs so the Discord logo markup is preserved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d16d8ba848832ebe8f5efd2871ab0d