### PR TITLE
Clear uninstall refresh lock transient

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -35,6 +35,8 @@ define('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION', 300);
 function discord_bot_jlg_uninstall() {
     delete_option(DISCORD_BOT_JLG_OPTION_NAME);
     delete_transient(DISCORD_BOT_JLG_CACHE_KEY);
+    // Réplique le nettoyage effectué par Discord_Bot_JLG_API::clear_cache().
+    delete_transient(DISCORD_BOT_JLG_CACHE_KEY . '_refresh_lock');
 }
 
 register_uninstall_hook(__FILE__, 'discord_bot_jlg_uninstall');


### PR DESCRIPTION
## Summary
- remove the refresh lock transient during plugin uninstall
- document that the uninstall cleanup mirrors the API cache clearing routine

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d16fdd7eec832ebbd0ca15ff0d7111