### PR TITLE
Supprime le verrou lors de la désinstallation

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -36,7 +36,7 @@ function discord_bot_jlg_uninstall() {
     delete_option(DISCORD_BOT_JLG_OPTION_NAME);
     delete_transient(DISCORD_BOT_JLG_CACHE_KEY);
     // Réplique le nettoyage effectué par Discord_Bot_JLG_API::clear_cache().
-    delete_transient(DISCORD_BOT_JLG_CACHE_KEY . '_refresh_lock');
+    delete_transient(DISCORD_BOT_JLG_CACHE_KEY . Discord_Bot_JLG_API::REFRESH_LOCK_SUFFIX);
 }
 
 register_uninstall_hook(__FILE__, 'discord_bot_jlg_uninstall');

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -11,7 +11,7 @@ class Discord_Bot_JLG_API {
 
     const MIN_PUBLIC_REFRESH_INTERVAL = 10;
 
-    private const REFRESH_LOCK_SUFFIX = '_refresh_lock';
+    public const REFRESH_LOCK_SUFFIX = '_refresh_lock';
 
     private $option_name;
     private $cache_key;


### PR DESCRIPTION
## Summary
- supprime le transient de verrou `_refresh_lock` lors de la désinstallation du plugin
- expose la constante `REFRESH_LOCK_SUFFIX` pour qu'elle soit réutilisable lors du nettoyage

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68d18155421c832e89fc0f9b8d012606