### PR TITLE
Remove PHP 7.1 constant visibility

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -11,7 +11,7 @@ class Discord_Bot_JLG_API {
 
     const MIN_PUBLIC_REFRESH_INTERVAL = 10;
 
-    private const REFRESH_LOCK_SUFFIX = '_refresh_lock';
+    const REFRESH_LOCK_SUFFIX = '_refresh_lock';
 
     private $option_name;
     private $cache_key;


### PR DESCRIPTION
## Summary
- replace the private class constant visibility with a regular const declaration to maintain compatibility with PHP versions prior to 7.1
- verify that no other PHP 7.1+ specific features are used in the Discord API class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d18153c870832e96842aaebe3e59ef