### PR TITLE
Adjust Discord icon fill by theme

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -44,7 +44,10 @@
     margin-bottom: 15px;
 }
 
-.discord-stats-container.discord-theme-discord .discord-logo-svg,
+.discord-stats-container.discord-theme-discord .discord-logo-svg {
+    fill: #5865F2;
+}
+
 .discord-stats-container.discord-theme-dark .discord-logo-svg {
     fill: #ffffff;
 }


### PR DESCRIPTION
## Summary
- set the Discord theme logo fill to the brand purple instead of forcing white
- keep the dark theme icon fill white for contrast

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d19ee27924832e953156cb6d148e1e