### PR TITLE
Localize widget strings and ensure escaping

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -54,16 +54,7 @@ add_action('plugins_loaded', 'discord_bot_jlg_load_textdomain');
 
 class DiscordServerStats {
 
-    private $default_options = array(
-        'server_id'      => '',
-        'bot_token'      => '',
-        'demo_mode'      => false,
-        'show_online'    => true,
-        'show_total'     => true,
-        'custom_css'     => '',
-        'widget_title'   => 'Discord Server',
-        'cache_duration' => DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION,
-    );
+    private $default_options;
 
     private $api;
     private $admin;
@@ -71,6 +62,17 @@ class DiscordServerStats {
     private $widget;
 
     public function __construct() {
+        $this->default_options = array(
+            'server_id'      => '',
+            'bot_token'      => '',
+            'demo_mode'      => false,
+            'show_online'    => true,
+            'show_total'     => true,
+            'custom_css'     => '',
+            'widget_title'   => __('Discord Server', 'discord-bot-jlg'),
+            'cache_duration' => DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION,
+        );
+
         $this->api       = new Discord_Bot_JLG_API(DISCORD_BOT_JLG_OPTION_NAME, DISCORD_BOT_JLG_CACHE_KEY, DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION);
         $this->admin     = new Discord_Bot_JLG_Admin(DISCORD_BOT_JLG_OPTION_NAME, $this->api);
         $this->shortcode = new Discord_Bot_JLG_Shortcode(DISCORD_BOT_JLG_OPTION_NAME, $this->api);

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -16,8 +16,8 @@ class Discord_Stats_Widget extends WP_Widget {
     public function __construct() {
         parent::__construct(
             'discord_stats_widget',
-            'Discord Bot - JLG',
-            array('description' => 'Affiche les statistiques de votre serveur Discord')
+            esc_html__('Discord Bot - JLG', 'discord-bot-jlg'),
+            array('description' => esc_html__('Affiche les statistiques de votre serveur Discord', 'discord-bot-jlg'))
         );
     }
 
@@ -25,10 +25,11 @@ class Discord_Stats_Widget extends WP_Widget {
         echo $args['before_widget'];
 
         $options = get_option(DISCORD_BOT_JLG_OPTION_NAME);
-        $title   = !empty($options['widget_title']) ? $options['widget_title'] : 'Discord Server';
+        $title   = !empty($options['widget_title']) ? $options['widget_title'] : __('Discord Server', 'discord-bot-jlg');
 
         if (!empty($title)) {
-            echo $args['before_title'] . apply_filters('widget_title', $title) . $args['after_title'];
+            $filtered_title = apply_filters('widget_title', $title);
+            echo $args['before_title'] . esc_html($filtered_title) . $args['after_title'];
         }
 
         echo do_shortcode('[discord_stats]');
@@ -39,7 +40,10 @@ class Discord_Stats_Widget extends WP_Widget {
     public function form($instance) {
         ?>
         <p>
-            Configurez les options dans le menu principal <a href="<?php echo esc_url(admin_url('admin.php?page=discord-bot-jlg')); ?>">Discord Bot</a>
+            <?php echo esc_html__('Configurez les options dans le menu principal', 'discord-bot-jlg'); ?>
+            <a href="<?php echo esc_url(admin_url('admin.php?page=discord-bot-jlg')); ?>">
+                <?php echo esc_html__('Discord Bot', 'discord-bot-jlg'); ?>
+            </a>
         </p>
         <?php
     }


### PR DESCRIPTION
## Summary
- localize widget labels and form message with translation helpers and escape rendered output
- ensure the widget title fallback is translatable and escaped before display
- initialize default widget title with a localized string during plugin setup

## Testing
- php -l discord-bot-jlg/inc/class-discord-widget.php
- php -l discord-bot-jlg/discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68d25de93e98832eaf4845fd7d9fbde1