### PR TITLE
Add persistent fallback for stale Discord stats

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -108,6 +108,8 @@ class Discord_Bot_JLG_Shortcode {
 
         $has_total            = !empty($stats['has_total']) && isset($stats['total']) && null !== $stats['total'];
         $total_is_approximate = !empty($stats['total_is_approximate']);
+        $is_stale             = !empty($stats['stale']);
+        $last_updated         = isset($stats['last_updated']) ? (int) $stats['last_updated'] : 0;
 
         $container_classes = array('discord-stats-container');
 
@@ -180,6 +182,14 @@ class Discord_Bot_JLG_Shortcode {
             sprintf('data-demo="%s"', esc_attr($is_forced_demo ? 'true' : 'false')),
             sprintf('data-fallback-demo="%s"', esc_attr($is_fallback_demo ? 'true' : 'false')),
         );
+
+        if ($is_stale) {
+            $attributes[] = 'data-stale="true"';
+        }
+
+        if ($last_updated > 0) {
+            $attributes[] = sprintf('data-last-updated="%d"', $last_updated);
+        }
 
         if (!empty($style_declarations)) {
             $attributes[] = sprintf('style="%s"', esc_attr(implode('; ', $style_declarations)));


### PR DESCRIPTION
## Summary
- record the last successful Discord stats payload and reuse it when fresh data fails
- expose stale metadata via shortcode attributes for front-end consumers
- surface a visitor notice when cached numbers are shown while keeping real counts visible

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68d27cde1a38832ea630408b9c950bc8