### PR TITLE
Purge all cached Discord stats when credentials change

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -339,11 +339,30 @@ class Discord_Bot_JLG_API {
     /**
      * Supprime les statistiques mises en cache pour forcer une prochaine récupération.
      *
+     * @param bool $full Supprime également les données persistantes (sauvegardes et indicateurs) si vrai.
+     *
      * @return void
      */
-    public function clear_cache() {
+    public function clear_cache($full = false) {
+        if (true === $full) {
+            $this->purge_full_cache();
+            return;
+        }
+
         delete_transient($this->cache_key);
         delete_transient($this->cache_key . self::REFRESH_LOCK_SUFFIX);
+    }
+
+    /**
+     * Supprime toutes les données de cache, y compris les sauvegardes de secours.
+     *
+     * @return void
+     */
+    public function purge_full_cache() {
+        delete_transient($this->cache_key);
+        delete_transient($this->cache_key . self::REFRESH_LOCK_SUFFIX);
+        delete_transient($this->cache_key . '_fallback_bypass');
+        delete_transient($this->get_last_good_cache_key());
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow the cache API to wipe all related transients, including fallback and last-good values
- purge every cached value when server credentials change so outdated stats are not displayed
- align the uninstall cleanup with the extended cache purge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2bd75da94832eb5afea72169cf8b5