### PR TITLE
Ensure uninstall purges all cache transients

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -34,9 +34,17 @@ define('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION', 300);
  */
 function discord_bot_jlg_uninstall() {
     delete_option(DISCORD_BOT_JLG_OPTION_NAME);
-    delete_transient(DISCORD_BOT_JLG_CACHE_KEY);
-    // Réplique le nettoyage effectué par Discord_Bot_JLG_API::clear_cache().
-    delete_transient(DISCORD_BOT_JLG_CACHE_KEY . '_refresh_lock');
+    if (!class_exists('Discord_Bot_JLG_API')) {
+        require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
+    }
+
+    $api = new Discord_Bot_JLG_API(
+        DISCORD_BOT_JLG_OPTION_NAME,
+        DISCORD_BOT_JLG_CACHE_KEY,
+        DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION
+    );
+
+    $api->clear_cache();
 }
 
 register_uninstall_hook(__FILE__, 'discord_bot_jlg_uninstall');


### PR DESCRIPTION
## Summary
- make the uninstall routine reuse the API cache clearing logic
- expand the cache purge to delete fallback bypass and last-good entries and their transient options

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68d2bd794218832eb0ad4d81e219146a