### PR TITLE
Ensure full cache purge clears all artifacts

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -114,7 +114,7 @@ class DiscordServerStats {
         $new_bot_token = isset($value['bot_token']) ? (string) $value['bot_token'] : '';
 
         if ($old_server_id !== $new_server_id || $old_bot_token !== $new_bot_token) {
-            $this->api->clear_cache(true);
+            $this->api->clear_all_cached_data();
             return;
         }
 

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -359,6 +359,15 @@ class Discord_Bot_JLG_API {
      * @return void
      */
     public function purge_full_cache() {
+        $this->clear_all_cached_data();
+    }
+
+    /**
+     * Supprime toutes les informations mises en cache, y compris les drapeaux de secours.
+     *
+     * @return void
+     */
+    public function clear_all_cached_data() {
         delete_transient($this->cache_key);
         delete_transient($this->cache_key . self::REFRESH_LOCK_SUFFIX);
         delete_transient($this->cache_key . '_fallback_bypass');


### PR DESCRIPTION
## Summary
- add a dedicated public helper on the API service to wipe every cached artifact, including fallback flags
- use the new purge helper whenever the cache must be fully reset, especially after server ID or bot token updates

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/discord-bot-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68d2c4207d20832e844856667a75915c