### PR TITLE
Refactor uninstall cache purge to reuse API cleanup

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -34,11 +34,20 @@ define('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION', 300);
  */
 function discord_bot_jlg_uninstall() {
     delete_option(DISCORD_BOT_JLG_OPTION_NAME);
-    delete_transient(DISCORD_BOT_JLG_CACHE_KEY);
-    // Réplique le nettoyage effectué par Discord_Bot_JLG_API::purge_full_cache().
-    delete_transient(DISCORD_BOT_JLG_CACHE_KEY . '_refresh_lock');
-    delete_transient(DISCORD_BOT_JLG_CACHE_KEY . '_fallback_bypass');
-    delete_transient(DISCORD_BOT_JLG_CACHE_KEY . '_last_good');
+
+    if (!class_exists('Discord_Bot_JLG_API')) {
+        require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
+    }
+
+    if (class_exists('Discord_Bot_JLG_API')) {
+        $api = new Discord_Bot_JLG_API(
+            DISCORD_BOT_JLG_OPTION_NAME,
+            DISCORD_BOT_JLG_CACHE_KEY,
+            DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION
+        );
+
+        $api->clear_cache(true);
+    }
 }
 
 register_uninstall_hook(__FILE__, 'discord_bot_jlg_uninstall');

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -13,6 +13,7 @@ class Discord_Bot_JLG_API {
 
     const REFRESH_LOCK_SUFFIX = '_refresh_lock';
     const LAST_GOOD_SUFFIX = '_last_good';
+    const FALLBACK_BYPASS_SUFFIX = '_fallback_bypass';
 
     private $option_name;
     private $cache_key;
@@ -193,7 +194,7 @@ class Discord_Bot_JLG_API {
         }
 
         $rate_limit_key = $this->cache_key . self::REFRESH_LOCK_SUFFIX;
-        $fallback_bypass_key = $this->cache_key . '_fallback_bypass';
+        $fallback_bypass_key = $this->get_fallback_bypass_key();
         $cache_duration = $this->get_cache_duration($options);
         $default_public_refresh = max(self::MIN_PUBLIC_REFRESH_INTERVAL, (int) $cache_duration);
         $rate_limit_window = (int) apply_filters('discord_bot_jlg_public_refresh_interval', $default_public_refresh, $options);
@@ -361,7 +362,7 @@ class Discord_Bot_JLG_API {
     public function purge_full_cache() {
         delete_transient($this->cache_key);
         delete_transient($this->cache_key . self::REFRESH_LOCK_SUFFIX);
-        delete_transient($this->cache_key . '_fallback_bypass');
+        delete_transient($this->get_fallback_bypass_key());
         delete_transient($this->get_last_good_cache_key());
     }
 
@@ -412,6 +413,10 @@ class Discord_Bot_JLG_API {
 
     private function get_last_good_cache_key() {
         return $this->cache_key . self::LAST_GOOD_SUFFIX;
+    }
+
+    private function get_fallback_bypass_key() {
+        return $this->cache_key . self::FALLBACK_BYPASS_SUFFIX;
     }
 
     private function store_last_good_stats($stats) {


### PR DESCRIPTION
## Summary
- instantiate the Discord API service during uninstall to reuse the centralized full cache purge
- add a reusable fallback bypass suffix constant and helper so transient keys are consistently deleted

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68d2c420bc1c832e858d94bd903e3a39