### PR TITLE
Allow public stats refresh without nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Pour activer l'auto-actualisation, utilisez par exemple :
 
 Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moins 10 secondes (10 000 ms). Toute valeur plus basse est automatiquement portée à 10 secondes pour éviter les erreurs 429 de Discord.
 
+### Rafraîchissement public & sécurité
+
+Les appels AJAX publics déclenchés par l'auto-actualisation n'utilisent plus de nonce WordPress. La protection repose désormais sur le cache et sur la limitation de fréquence côté serveur (intervalle minimal de 10 secondes, ajustable dans les options). Les utilisateurs connectés continuent à profiter d'un nonce pour les actions nécessitant des privilèges d'administration (ex. forcer un rafraîchissement depuis le back-office).
+
 ### Widget
 Un widget « Discord Bot - JLG » est disponible via le menu « Widgets ».
 

--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -289,7 +289,10 @@
     function updateStats(container, config, formatter, locale) {
         var formData = new FormData();
         formData.append('action', config.action || 'refresh_discord_stats');
-        formData.append('_ajax_nonce', config.nonce);
+
+        if (config.nonce) {
+            formData.append('_ajax_nonce', config.nonce);
+        }
 
         fetch(config.ajaxUrl, {
             method: 'POST',
@@ -305,7 +308,7 @@
                 }
 
                 if (!data.success) {
-                    if (data.data && data.data.nonce_expired) {
+                    if (config.nonce && data.data && data.data.nonce_expired) {
                         var nonceMessage = data.data.message
                             || getLocalizedString(
                                 'nonceExpiredFallback',
@@ -465,7 +468,7 @@
 
         var config = window.discordBotJlg || {};
         globalConfig = config;
-        if (!config.ajaxUrl || !config.nonce) {
+        if (!config.ajaxUrl) {
             return;
         }
 

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -802,6 +802,7 @@ class Discord_Bot_JLG_Admin {
                 <li><?php echo wp_kses_post(__('<strong>Stats à 0 ?</strong> Assurez-vous que le widget est activé dans les paramètres Discord', 'discord-bot-jlg')); ?></li>
                 <li><?php echo wp_kses_post(__('<strong>Token invalide ?</strong> Régénérez le token dans le Developer Portal', 'discord-bot-jlg')); ?></li>
                 <li><?php echo wp_kses_post(__('<strong>Cache ?</strong> Les stats sont mises à jour toutes les 5 minutes par défaut', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('<strong>Rafraîchissement public :</strong> Aucun nonce n\'est requis pour l\'auto-actualisation, un délai minimal de 10&nbsp;s limite les abus.', 'discord-bot-jlg')); ?></li>
             </ul>
         </div>
         <?php

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -170,18 +170,10 @@ class Discord_Bot_JLG_API {
         $is_public_request  = ('wp_ajax_nopriv_refresh_discord_stats' === $current_action);
         $nonce              = isset($_POST['_ajax_nonce']) ? sanitize_text_field(wp_unslash($_POST['_ajax_nonce'])) : '';
 
-        if (empty($nonce) || !wp_verify_nonce($nonce, 'refresh_discord_stats')) {
-            if (true === $is_public_request) {
-                wp_send_json_error(
-                    array(
-                        'nonce_expired' => true,
-                        'message'       => __('Votre session a expiré, veuillez recharger la page.', 'discord-bot-jlg'),
-                    ),
-                    403
-                );
+        if (false === $is_public_request) {
+            if (empty($nonce) || !wp_verify_nonce($nonce, 'refresh_discord_stats')) {
+                wp_send_json_error(__('Nonce invalide', 'discord-bot-jlg'), 403);
             }
-
-            wp_send_json_error(__('Nonce invalide', 'discord-bot-jlg'), 403);
         }
 
         $options = get_option($this->option_name);

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -349,7 +349,7 @@ class Discord_Bot_JLG_Shortcode {
             array(
                 'ajaxUrl' => admin_url('admin-ajax.php'),
                 'action'  => 'refresh_discord_stats',
-                'nonce'   => wp_create_nonce('refresh_discord_stats'),
+                'nonce'   => is_user_logged_in() ? wp_create_nonce('refresh_discord_stats') : '',
                 'locale'  => $locale,
                 'minRefreshInterval' => defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
                     ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL


### PR DESCRIPTION
## Summary
- skip nonce enforcement for public refresh requests and only generate nonces for logged-in visitors
- adjust the frontend refresh script so public calls omit the nonce and keep nonce-expiry handling for privileged flows
- document the new public refresh behaviour in the README and the admin troubleshooting panel

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d2d4c7de74832eadf5a60a42261ce3