### PR TITLE
Handle non-JSON AJAX responses and expose nonce flag

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -173,7 +173,13 @@ class Discord_Bot_JLG_API {
 
         if (false === $is_public_request) {
             if (empty($nonce) || !wp_verify_nonce($nonce, 'refresh_discord_stats')) {
-                wp_send_json_error(__('Nonce invalide', 'discord-bot-jlg'), 403);
+                wp_send_json_error(
+                    array(
+                        'nonce_expired' => true,
+                        'message'       => __('Nonce invalide', 'discord-bot-jlg'),
+                    ),
+                    403
+                );
             }
         }
 


### PR DESCRIPTION
## Summary
- add defensive handling for failed or non-JSON AJAX responses in the front-end refresh routine
- surface a nonce_expired flag and message when nonce verification fails server-side

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68d3be17395c832e8aa778892bc17619