### PR TITLE
Improve rate limiting resilience and compatibility

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -372,8 +372,20 @@
                 }
 
                 if (!data.data || data.data.rate_limited) {
+                    var rateLimitMessage = '';
+
                     if (data.data && data.data.message) {
-                        console.warn(data.data.message);
+                        rateLimitMessage = data.data.message;
+                    } else {
+                        rateLimitMessage = getLocalizedString(
+                            'rateLimited',
+                            'Actualisation trop fréquente, veuillez patienter avant de réessayer.'
+                        );
+                    }
+
+                    if (rateLimitMessage) {
+                        console.warn(rateLimitMessage);
+                        showErrorMessage(container, rateLimitMessage);
                     }
 
                     return;

--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://yourwebsite.com/
  * Description: Affiche les statistiques de votre serveur Discord (membres en ligne et total)
  * Version: 1.0
+ * Requires at least: 5.2
  * Author: Jérôme Le Gousse
  * Text Domain: discord-bot-jlg
  * Domain Path: /languages
@@ -110,7 +111,7 @@ class DiscordServerStats {
     }
 
     public function deactivate() {
-        $this->api->clear_cache();
+        $this->api->clear_all_cached_data();
     }
 
     public function handle_settings_update($old_value, $value) {

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -100,7 +100,11 @@ class Discord_Bot_JLG_Shortcode {
 
         $this->enqueue_assets($options);
 
-        $unique_id = wp_unique_id('discord-stats-');
+        if (function_exists('wp_unique_id')) {
+            $unique_id = wp_unique_id('discord-stats-');
+        } else {
+            $unique_id = str_replace('.', '-', uniqid('discord-stats-', true));
+        }
 
         $is_demo          = !empty($stats['is_demo']);
         $is_fallback_demo = !empty($stats['fallback_demo']);
@@ -362,6 +366,7 @@ class Discord_Bot_JLG_Shortcode {
                 'nonceExpiredFallback' => __('Votre session a expiré, veuillez recharger la page.', 'discord-bot-jlg'),
                 'consoleErrorPrefix'   => __('Erreur lors de la mise à jour des statistiques Discord :', 'discord-bot-jlg'),
                 'staleNotice'          => __('Données mises en cache du %s', 'discord-bot-jlg'),
+                'rateLimited'          => __('Actualisation trop fréquente, veuillez patienter avant de réessayer.', 'discord-bot-jlg'),
             )
         );
 


### PR DESCRIPTION
## Summary
- introduce per-visitor rate limiting with hashed identifiers while retaining the global cooldown and purge helpers
- surface rate limit feedback in the public script and localize the message
- add a wp_unique_id fallback, declare the minimum WordPress version, and purge all cached data on deactivation

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c4e6a660832ea2737ae98d8c014a