### PR TITLE
Improve option storage and public rate limiting

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -107,7 +107,7 @@ class DiscordServerStats {
     }
 
     public function activate() {
-        add_option(DISCORD_BOT_JLG_OPTION_NAME, $this->default_options);
+        add_option(DISCORD_BOT_JLG_OPTION_NAME, $this->default_options, '', false);
     }
 
     public function deactivate() {


### PR DESCRIPTION
## Summary
- disable autoload when creating the plugin option to avoid loading secrets on every request
- harden public rate-limit fingerprint generation with proxy-aware IP detection, anonymisation, and filters for customization

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68d3da8ac9f0832ebd75dcfe643a7492