### PR TITLE
Improve Discord bot options handling and caching

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -887,7 +887,6 @@ class Discord_Bot_JLG_Admin {
             return;
         }
 
-        $this->api->clear_cache();
         $stats = $this->api->get_stats(
             array(
                 'bypass_cache' => true,


### PR DESCRIPTION
## Summary
- ensure the plugin always merges saved options with the expected defaults
- memoize Discord stats retrieval per request and reset the runtime cache when persistent caches are cleared
- avoid purging cached data when running the admin connection test so fallbacks remain available

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d42f19df1c832ea9179d1535614738