### PR TITLE
Allow clearing token and conditionally log errors

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -181,7 +181,9 @@ class Discord_Bot_JLG_Admin {
             'show_online'    => 0,
             'show_total'     => 0,
             'widget_title'   => '',
-            'cache_duration' => 300,
+            'cache_duration' => isset($current_options['cache_duration'])
+                ? (int) $current_options['cache_duration']
+                : 300,
             'custom_css'     => '',
         );
 
@@ -200,7 +202,9 @@ class Discord_Bot_JLG_Admin {
         if (!$constant_overridden && array_key_exists('bot_token', $input)) {
             $raw_token = trim((string) $input['bot_token']);
 
-            if ('' !== $raw_token) {
+            if ('' === $raw_token) {
+                $sanitized['bot_token'] = '';
+            } else {
                 $sanitized['bot_token'] = sanitize_text_field($raw_token);
             }
         }
@@ -213,12 +217,26 @@ class Discord_Bot_JLG_Admin {
             $sanitized['widget_title'] = sanitize_text_field($input['widget_title']);
         }
 
-        if (isset($input['cache_duration'])) {
-            $cache_duration               = absint($input['cache_duration']);
-            $sanitized['cache_duration'] = max(
-                Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
-                min(3600, $cache_duration)
-            );
+        if (array_key_exists('cache_duration', $input)) {
+            $raw_cache_duration = is_string($input['cache_duration'])
+                ? trim($input['cache_duration'])
+                : $input['cache_duration'];
+
+            if ('' === $raw_cache_duration) {
+                $fallback_duration          = isset($current_options['cache_duration'])
+                    ? (int) $current_options['cache_duration']
+                    : 300;
+                $sanitized['cache_duration'] = max(
+                    Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                    min(3600, $fallback_duration)
+                );
+            } else {
+                $cache_duration              = absint($raw_cache_duration);
+                $sanitized['cache_duration'] = max(
+                    Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                    min(3600, $cache_duration)
+                );
+            }
         }
 
         if (isset($input['custom_css'])) {

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -887,6 +887,19 @@ class Discord_Bot_JLG_API {
         delete_transient($this->get_fallback_retry_key());
     }
 
+    private function log_debug($message) {
+        if ('' === trim((string) $message)) {
+            return;
+        }
+
+        $debug_enabled = (defined('WP_DEBUG') && WP_DEBUG)
+            || (defined('WP_DEBUG_LOG') && WP_DEBUG_LOG);
+
+        if ($debug_enabled) {
+            error_log('[discord-bot-jlg] ' . $message);
+        }
+    }
+
     private function store_last_good_stats($stats) {
         if (!is_array($stats)) {
             return;
@@ -926,7 +939,7 @@ class Discord_Bot_JLG_API {
                 __('Erreur lors de l\'appel du widget Discord : %s', 'discord-bot-jlg'),
                 $response->get_error_message()
             );
-            error_log('Discord API error (widget): ' . $response->get_error_message());
+            $this->log_debug('Discord API error (widget): ' . $response->get_error_message());
             return false;
         }
 
@@ -948,7 +961,7 @@ class Discord_Bot_JLG_API {
                     $response_code
                 );
             }
-            error_log('Discord API error (widget): HTTP ' . $response_code);
+            $this->log_debug('Discord API error (widget): HTTP ' . $response_code);
             return false;
         }
 
@@ -1023,7 +1036,7 @@ class Discord_Bot_JLG_API {
                 __('Erreur lors de l\'appel de l\'API Discord (bot) : %s', 'discord-bot-jlg'),
                 $response->get_error_message()
             );
-            error_log('Discord API error (bot): ' . $response->get_error_message());
+            $this->log_debug('Discord API error (bot): ' . $response->get_error_message());
             return false;
         }
 
@@ -1045,7 +1058,7 @@ class Discord_Bot_JLG_API {
                     $response_code
                 );
             }
-            error_log('Discord API error (bot): HTTP ' . $response_code);
+            $this->log_debug('Discord API error (bot): HTTP ' . $response_code);
             return false;
         }
 


### PR DESCRIPTION
## Summary
- allow administrators to clear the stored bot token and keep prior cache duration when fields are submitted empty
- retain the configured or default cache duration instead of forcing the minimum when the input is blank
- only log Discord API errors when WordPress debugging is enabled to avoid noisy production logs

## Testing
- find discord-bot-jlg -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d440559e74832e82d1f55fe20599a0