### PR TITLE
Refactor Discord API interactions for extensibility

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -73,6 +73,7 @@ function discord_bot_jlg_uninstall() {
 
 register_uninstall_hook(__FILE__, 'discord_bot_jlg_uninstall');
 
+require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-http.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-admin.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-shortcode.php';

--- a/discord-bot-jlg/inc/class-discord-http.php
+++ b/discord-bot-jlg/inc/class-discord-http.php
@@ -1,0 +1,64 @@
+<?php
+
+if (false === defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Fournit un client HTTP centralisé pour personnaliser les appels à l'API Discord.
+ */
+class Discord_Bot_JLG_Http_Client {
+
+    /**
+     * Exécute une requête GET en appliquant les filtres d'extension nécessaires.
+     *
+     * @param string $url     URL cible.
+     * @param array  $args    Arguments transmis à wp_safe_remote_get.
+     * @param string $context Contexte fonctionnel (ex. widget, bot).
+     *
+     * @return array|WP_Error
+     */
+    public function get($url, array $args = array(), $context = '') {
+        $defaults = array(
+            'timeout' => 10,
+            'headers' => array(
+                'User-Agent' => 'WordPress Discord Stats Plugin',
+            ),
+        );
+
+        $args = wp_parse_args($args, $defaults);
+        $args['headers'] = isset($args['headers']) && is_array($args['headers'])
+            ? wp_parse_args($args['headers'], $defaults['headers'])
+            : $defaults['headers'];
+
+        $context = sanitize_key($context);
+
+        /**
+         * Filtre les arguments transmis à wp_safe_remote_get pour un appel Discord.
+         *
+         * @since 1.0.1
+         *
+         * @param array  $args    Arguments de la requête.
+         * @param string $url     URL cible.
+         * @param string $context Contexte (widget, bot, ...).
+         */
+        $args = apply_filters('discord_bot_jlg_http_request_args', $args, $url, $context);
+
+        if (!empty($context)) {
+            /**
+             * Filtre les arguments transmis à wp_safe_remote_get pour un contexte dédié.
+             *
+             * Les hooks spécifiques `discord_bot_jlg_widget_request_args` et
+             * `discord_bot_jlg_bot_request_args` permettent d'ajuster les paramètres au cas par cas.
+             *
+             * @since 1.0.1
+             *
+             * @param array  $args Arguments de la requête.
+             * @param string $url  URL cible.
+             */
+            $args = apply_filters('discord_bot_jlg_' . $context . '_request_args', $args, $url);
+        }
+
+        return wp_safe_remote_get($url, $args);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated HTTP client with filters to customize Discord requests
- inject the HTTP client into the API class and reuse it for widget/bot calls while flushing caches when clearing
- memoize plugin options to avoid redundant database reads across shortcode renders

## Testing
- php -l discord-bot-jlg/inc/class-discord-http.php
- php -l discord-bot-jlg/inc/class-discord-api.php

------
https://chatgpt.com/codex/tasks/task_e_68d44c0153b0832e99b3f69f9100633f