### PR TITLE
Improve option reuse and rate limit flexibility

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -37,10 +37,7 @@ class Discord_Bot_JLG_Shortcode {
      * @return string HTML du composant de statistiques prêt à être inséré dans la page.
      */
     public function render_shortcode($atts) {
-        $options = get_option($this->option_name);
-        if (!is_array($options)) {
-            $options = array();
-        }
+        $options = $this->api->get_plugin_options();
 
         $atts = shortcode_atts(
             array(


### PR DESCRIPTION
## Summary
- expose the API option cache through a public accessor and reuse it in the shortcode renderer
- return a structured JSON error when demo mode blocks AJAX refreshes
- add a filter hook to override the public rate-limit identifier while keeping fingerprint generation overridable

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68d50a763cf8832e9eb0cdadc035a149