### PR TITLE
Ensure uninstall loads HTTP client

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -56,6 +56,10 @@ if (!function_exists('discord_bot_jlg_get_default_options')) {
 function discord_bot_jlg_uninstall() {
     delete_option(DISCORD_BOT_JLG_OPTION_NAME);
 
+    if (!class_exists('Discord_Bot_JLG_Http_Client')) {
+        require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-http.php';
+    }
+
     if (!class_exists('Discord_Bot_JLG_API')) {
         require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
     }


### PR DESCRIPTION
## Summary
- ensure the uninstall routine loads the HTTP client class when needed before instantiating the API wrapper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c02a1d5c832e874ea68610399570