### PR TITLE
Ensure uninstall routine loads HTTP client dependency

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -56,12 +56,14 @@ if (!function_exists('discord_bot_jlg_get_default_options')) {
 function discord_bot_jlg_uninstall() {
     delete_option(DISCORD_BOT_JLG_OPTION_NAME);
 
-    if (!class_exists('Discord_Bot_JLG_Http_Client')) {
-        require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-http.php';
-    }
-
     if (!class_exists('Discord_Bot_JLG_API')) {
+        if (!class_exists('Discord_Bot_JLG_Http_Client')) {
+            require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-http.php';
+        }
+
         require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
+    } elseif (!class_exists('Discord_Bot_JLG_Http_Client')) {
+        require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-http.php';
     }
 
     if (class_exists('Discord_Bot_JLG_API')) {


### PR DESCRIPTION
## Summary
- ensure the uninstall routine loads the HTTP client dependency before instantiating the API class
- add a fallback include when the API class is already loaded but the HTTP client is not

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d65121dac4832e872d0dbbb7a2dcd8