### PR TITLE
Add PHPUnit coverage for Discord admin sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Un widget « Discord Bot - JLG » est disponible via le menu « Widgets ».
 ## Désinstallation
 La suppression du plugin depuis WordPress efface automatiquement l’option `discord_server_stats_options` et le transient `discord_server_stats_cache` associés aux statistiques du serveur.
 
+## Tests
+Le plugin est compatible avec la suite de tests WordPress générée par `wp scaffold plugin-tests`.
+
+1. Installez la bibliothèque de tests WordPress et définissez la variable d'environnement `WP_TESTS_DIR` (ou laissez la valeur par défaut `sys_get_temp_dir()/wordpress-tests-lib`).
+2. Depuis le dossier `discord-bot-jlg`, exécutez :
+
+```
+phpunit --testsuite discord-bot-jlg
+```
+
+Le fichier `phpunit.xml.dist` du plugin référence automatiquement le bootstrap de la suite de tests.
+
 ## Support
 - Portail développeur Discord : https://discord.com/developers/applications
 - Notes de version disponibles dans l’interface du plugin.

--- a/discord-bot-jlg/phpunit.xml.dist
+++ b/discord-bot-jlg/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/phpunit/includes/bootstrap.php"
+         colors="true"
+         backupGlobals="false"
+         backupStaticAttributes="false">
+    <testsuites>
+        <testsuite name="discord-bot-jlg">
+            <directory suffix=".php">tests/phpunit/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * @group discord-bot-jlg
+ */
+class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
+
+    /**
+     * @var Discord_Bot_JLG_Admin
+     */
+    protected $admin;
+
+    /**
+     * @var Discord_Bot_JLG_API
+     */
+    protected $api;
+
+    /**
+     * @var array
+     */
+    protected $saved_options;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->saved_options = array(
+            'server_id'      => '424242424242424242',
+            'bot_token'      => 'stored-token',
+            'demo_mode'      => 1,
+            'show_online'    => 1,
+            'show_total'     => 1,
+            'widget_title'   => 'Existing title',
+            'cache_duration' => 450,
+            'custom_css'     => '.existing { color: blue; }',
+        );
+
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, $this->saved_options);
+
+        $this->api = new Discord_Bot_JLG_API(
+            DISCORD_BOT_JLG_OPTION_NAME,
+            DISCORD_BOT_JLG_CACHE_KEY,
+            DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION
+        );
+
+        $this->admin = new Discord_Bot_JLG_Admin(DISCORD_BOT_JLG_OPTION_NAME, $this->api);
+    }
+
+    public function sanitize_options_data_provider() {
+        $sanitized_css = sanitize_textarea_field("body { color: red; }\n<script>alert('test');</script>");
+
+        return array(
+            'invalid-server-id' => array(
+                array(
+                    'server_id'    => 'abc123',
+                    'bot_token'    => ' new token ',
+                    'demo_mode'    => '1',
+                    'show_online'  => '1',
+                    'show_total'   => '',
+                    'widget_title' => ' <strong>Stats</strong> ',
+                    'cache_duration' => '45',
+                    'custom_css'   => "body { color: red; }\n<script>alert('test');</script>",
+                ),
+                array(
+                    'server_id'    => '',
+                    'bot_token'    => sanitize_text_field(' new token '),
+                    'demo_mode'    => 1,
+                    'show_online'  => 1,
+                    'show_total'   => 0,
+                    'widget_title' => sanitize_text_field(' <strong>Stats</strong> '),
+                    'cache_duration' => 45,
+                    'custom_css'   => $sanitized_css,
+                ),
+                false,
+            ),
+            'valid-server-id-below-min-cache' => array(
+                array(
+                    'server_id'      => '123456789012345678',
+                    'cache_duration' => '5',
+                    'demo_mode'      => '',
+                    'show_online'    => 'yes',
+                    'show_total'     => 'yes',
+                ),
+                array(
+                    'server_id'      => '123456789012345678',
+                    'cache_duration' => Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                    'demo_mode'      => 0,
+                    'show_online'    => 1,
+                    'show_total'     => 1,
+                ),
+                false,
+            ),
+            'cache-duration-above-max' => array(
+                array(
+                    'cache_duration' => 7200,
+                ),
+                array(
+                    'cache_duration' => 3600,
+                ),
+                false,
+            ),
+            'empty-cache-duration-fallback' => array(
+                array(
+                    'cache_duration' => '',
+                ),
+                array(
+                    'cache_duration' => 450,
+                ),
+                false,
+            ),
+            'bot-token-constant-preserves-value' => array(
+                array(
+                    'bot_token' => '',
+                ),
+                array(
+                    'bot_token' => 'stored-token',
+                ),
+                true,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider sanitize_options_data_provider
+     */
+    public function test_sanitize_options(array $input, array $expected_overrides, $define_constant) {
+        if ($define_constant && !defined('DISCORD_BOT_JLG_TOKEN')) {
+            define('DISCORD_BOT_JLG_TOKEN', 'constant-token');
+        }
+
+        $result = $this->admin->sanitize_options($input);
+
+        $expected = array(
+            'server_id'      => '',
+            'bot_token'      => $this->saved_options['bot_token'],
+            'demo_mode'      => 0,
+            'show_online'    => 0,
+            'show_total'     => 0,
+            'widget_title'   => '',
+            'cache_duration' => max(
+                Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                min(3600, (int) $this->saved_options['cache_duration'])
+            ),
+            'custom_css'     => '',
+        );
+
+        $expected = array_merge($expected, $expected_overrides);
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/includes/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/includes/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+$_tests_dir = getenv('WP_TESTS_DIR');
+
+if (!$_tests_dir) {
+    $_tests_dir = rtrim(sys_get_temp_dir(), '/\\') . '/wordpress-tests-lib';
+}
+
+if (!file_exists($_tests_dir . '/includes/functions.php')) {
+    fwrite(STDERR, sprintf("Could not find WordPress test suite in %s.\n", $_tests_dir));
+    exit(1);
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _discord_bot_jlg_tests_load_plugin() {
+    require dirname(dirname(dirname(__DIR__))) . '/discord-bot-jlg.php';
+}
+tests_add_filter('muplugins_loaded', '_discord_bot_jlg_tests_load_plugin');
+
+require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
## Summary
- configure PHPUnit for the plugin and load the WordPress test suite
- add unit coverage for Discord_Bot_JLG_Admin::sanitize_options via data providers
- document how to execute the new tests for maintainers

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: phpunit executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d65d50512c832e83fdc6c81673ffdc