### PR TITLE
Add minimal theme option to Discord widget

### DIFF
--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -35,7 +35,7 @@ class Discord_Stats_Widget extends WP_Widget {
 
         $allowed_layouts   = array('horizontal', 'vertical');
         $allowed_positions = array('left', 'right', 'top');
-        $allowed_themes    = array('discord', 'dark', 'light');
+        $allowed_themes    = array('discord', 'dark', 'light', 'minimal');
 
         $layout = sanitize_key($instance['layout']);
         if (!in_array($layout, $allowed_layouts, true)) {
@@ -124,7 +124,7 @@ class Discord_Stats_Widget extends WP_Widget {
         $instance['discord_icon_position'] = in_array($icon_position, array('left', 'right', 'top'), true) ? $icon_position : 'left';
 
         $theme = isset($new_instance['theme']) ? sanitize_key($new_instance['theme']) : 'discord';
-        $instance['theme'] = in_array($theme, array('discord', 'dark', 'light'), true) ? $theme : 'discord';
+        $instance['theme'] = in_array($theme, array('discord', 'dark', 'light', 'minimal'), true) ? $theme : 'discord';
 
         $instance['refresh'] = !empty($new_instance['refresh']) ? 1 : 0;
         $min_refresh = defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
@@ -219,6 +219,7 @@ class Discord_Stats_Widget extends WP_Widget {
                 <option value="discord" <?php selected($instance['theme'], 'discord'); ?>><?php esc_html_e('Discord', 'discord-bot-jlg'); ?></option>
                 <option value="dark" <?php selected($instance['theme'], 'dark'); ?>><?php esc_html_e('Sombre', 'discord-bot-jlg'); ?></option>
                 <option value="light" <?php selected($instance['theme'], 'light'); ?>><?php esc_html_e('Clair', 'discord-bot-jlg'); ?></option>
+                <option value="minimal" <?php selected($instance['theme'], 'minimal'); ?>><?php esc_html_e('Minimal', 'discord-bot-jlg'); ?></option>
             </select>
         </p>
 

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
@@ -1,0 +1,48 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class Test_Discord_Stats_Widget extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        $GLOBALS['discord_bot_jlg_last_shortcode'] = null;
+        $GLOBALS['wp_test_options'] = array();
+    }
+
+    public function test_update_accepts_minimal_theme() {
+        $widget = new Discord_Stats_Widget();
+
+        $new_instance = array(
+            'theme' => 'minimal',
+        );
+
+        $updated = $widget->update($new_instance, array());
+
+        $this->assertSame('minimal', $updated['theme']);
+    }
+
+    public function test_widget_shortcode_includes_minimal_theme() {
+        $widget = new Discord_Stats_Widget();
+
+        $args = array(
+            'before_widget' => '',
+            'after_widget'  => '',
+            'before_title'  => '',
+            'after_title'   => '',
+        );
+
+        $instance = array(
+            'theme'  => 'minimal',
+            'layout' => 'vertical',
+        );
+
+        ob_start();
+        $widget->widget($args, $instance);
+        ob_end_clean();
+
+        $this->assertNotNull($GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('theme="minimal"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -9,6 +9,60 @@ if (!defined('ABSPATH')) {
 
 require_once __DIR__ . '/../../inc/class-discord-http.php';
 require_once __DIR__ . '/../../inc/class-discord-api.php';
+require_once __DIR__ . '/../../inc/class-discord-widget.php';
+
+if (!defined('DISCORD_BOT_JLG_OPTION_NAME')) {
+    define('DISCORD_BOT_JLG_OPTION_NAME', 'discord_server_stats_options');
+}
+
+if (!class_exists('WP_Widget')) {
+    class WP_Widget {
+        public $id_base;
+
+        public function __construct($id_base = '', $name = '', $widget_options = array()) {
+            $this->id_base = $id_base;
+        }
+
+        public function get_field_id($field_name) {
+            return $this->id_base . '-' . $field_name;
+        }
+
+        public function get_field_name($field_name) {
+            return $this->id_base . '[' . $field_name . ']';
+        }
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null) {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html_e')) {
+    function esc_html_e($text, $domain = null) {
+        echo esc_html__($text, $domain);
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return is_string($text) ? $text : (string) $text;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) {
+        return is_string($text) ? $text : (string) $text;
+    }
+}
+
+if (!function_exists('do_shortcode')) {
+    function do_shortcode($shortcode) {
+        $GLOBALS['discord_bot_jlg_last_shortcode'] = $shortcode;
+        return $shortcode;
+    }
+}
 
 function wp_parse_args($args, $defaults = array()) {
     if (is_object($args)) {


### PR DESCRIPTION
## Summary
- allow the Discord stats widget to accept and render the new "minimal" theme value
- expose the minimal theme in the widget form and provide test stubs for the widget class
- cover minimal theme handling with PHPUnit tests

## Testing
- ⚠️ `phpunit --bootstrap discord-bot-jlg/tests/phpunit/bootstrap.php discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php` *(phpunit binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66f95354c832eaf13018657c51a99