### PR TITLE
Add PHPUnit test for successful Discord stats caching

### DIFF
--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php
@@ -3,12 +3,103 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/bootstrap.php';
 
+if (!function_exists('wp_remote_retrieve_response_code')) {
+    function wp_remote_retrieve_response_code($response) {
+        if (is_array($response) && isset($response['response']['code'])) {
+            return (int) $response['response']['code'];
+        }
+
+        return 0;
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_response_message')) {
+    function wp_remote_retrieve_response_message($response) {
+        if (is_array($response) && isset($response['response']['message'])) {
+            return (string) $response['response']['message'];
+        }
+
+        return '';
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_body')) {
+    function wp_remote_retrieve_body($response) {
+        if (is_array($response) && isset($response['body'])) {
+            return $response['body'];
+        }
+
+        return '';
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_header')) {
+    function wp_remote_retrieve_header($response, $header) {
+        if (!is_array($response) || empty($response['headers']) || !is_array($response['headers'])) {
+            return '';
+        }
+
+        $header = strtolower((string) $header);
+
+        foreach ($response['headers'] as $name => $value) {
+            if (strtolower((string) $name) === $header) {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+}
+
 class Mock_Discord_Bot_JLG_Http_Client extends Discord_Bot_JLG_Http_Client {
     public $call_count = 0;
 
     public function get($url, array $args = array(), $context = '') {
         $this->call_count++;
         return new WP_Error('http_error', 'Simulated failure');
+    }
+}
+
+class Successful_Mock_Discord_Bot_JLG_Http_Client extends Discord_Bot_JLG_Http_Client {
+    public $requests = array();
+    private $widget_payload;
+    private $bot_payload;
+
+    public function __construct(array $widget_payload, array $bot_payload) {
+        $this->widget_payload = $widget_payload;
+        $this->bot_payload    = $bot_payload;
+    }
+
+    public function get($url, array $args = array(), $context = '') {
+        $this->requests[] = array(
+            'url'     => $url,
+            'args'    => $args,
+            'context' => $context,
+        );
+
+        if ('widget' === $context) {
+            return array(
+                'response' => array(
+                    'code'    => 200,
+                    'message' => 'OK',
+                ),
+                'body'    => wp_json_encode($this->widget_payload),
+                'headers' => array(),
+            );
+        }
+
+        if ('bot' === $context) {
+            return array(
+                'response' => array(
+                    'code'    => 200,
+                    'message' => 'OK',
+                ),
+                'body'    => wp_json_encode($this->bot_payload),
+                'headers' => array(),
+            );
+        }
+
+        return new WP_Error('unexpected_context', 'Unexpected context: ' . $context);
     }
 }
 
@@ -53,6 +144,66 @@ class Test_Discord_Bot_JLG_API extends TestCase {
         $entry = wp_test_get_transient_entry($cache_key);
         $this->assertNotNull($entry);
         $this->assertSame(120, $entry['ttl']);
+    }
+
+    public function test_get_stats_stores_successful_payload() {
+        $option_name    = 'discord_server_stats_options';
+        $cache_key      = 'discord_server_stats_cache';
+        $cache_duration = 180;
+
+        $GLOBALS['wp_test_options'][$option_name] = array(
+            'server_id'      => '246810',
+            'cache_duration' => $cache_duration,
+            'bot_token'      => 'token-123',
+        );
+
+        $widget_payload = array(
+            'presence_count' => 9,
+            'name'           => 'Widget Guild',
+            'members'        => array(
+                array('id' => 1),
+                array('id' => 2),
+            ),
+        );
+
+        $bot_payload = array(
+            'approximate_presence_count' => 42,
+            'approximate_member_count'   => 120,
+            'name'                       => 'Bot Guild',
+        );
+
+        $http_client = new Successful_Mock_Discord_Bot_JLG_Http_Client($widget_payload, $bot_payload);
+        $api         = new Discord_Bot_JLG_API($option_name, $cache_key, 60, $http_client);
+
+        $stats = $api->get_stats(array('bypass_cache' => true));
+
+        $this->assertCount(2, $http_client->requests, 'Expected widget and bot requests');
+        $this->assertSame(9, $stats['online']);
+        $this->assertSame(120, $stats['total']);
+        $this->assertSame('Widget Guild', $stats['server_name']);
+        $this->assertTrue($stats['has_total']);
+        $this->assertTrue($stats['total_is_approximate']);
+        $this->assertSame('', $api->get_last_error_message());
+
+        $cached_stats = get_transient($cache_key);
+        $this->assertSame($stats, $cached_stats);
+        $this->assertArrayNotHasKey('fallback_demo', $cached_stats);
+        $this->assertArrayNotHasKey('is_demo', $cached_stats);
+
+        $cache_entry = wp_test_get_transient_entry($cache_key);
+        $this->assertNotNull($cache_entry);
+        $this->assertSame($cache_duration, $cache_entry['ttl']);
+        $this->assertSame($stats, $cache_entry['value']);
+
+        $last_good_key   = $cache_key . Discord_Bot_JLG_API::LAST_GOOD_SUFFIX;
+        $last_good_entry = wp_test_get_transient_entry($last_good_key);
+        $this->assertNotNull($last_good_entry);
+        $this->assertSame(0, $last_good_entry['ttl']);
+        $this->assertArrayHasKey('stats', $last_good_entry['value']);
+        $this->assertArrayHasKey('timestamp', $last_good_entry['value']);
+        $this->assertSame($stats, $last_good_entry['value']['stats']);
+        $this->assertIsInt($last_good_entry['value']['timestamp']);
+        $this->assertGreaterThan(0, $last_good_entry['value']['timestamp']);
     }
 
     public function test_ajax_refresh_stats_reuses_cached_fallback_until_retry_window() {


### PR DESCRIPTION
## Summary
- add lightweight WordPress HTTP helper stubs for the isolated PHPUnit suite
- cover successful Discord stats retrieval to assert caching and last-good snapshot behaviour

## Testing
- phpunit --configuration phpunit.xml.dist *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d69f2edac0832ea1316d38df35c6a3