### PR TITLE
Preserve stored Discord bot token when empty input

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -202,9 +202,7 @@ class Discord_Bot_JLG_Admin {
         if (!$constant_overridden && array_key_exists('bot_token', $input)) {
             $raw_token = trim((string) $input['bot_token']);
 
-            if ('' === $raw_token) {
-                $sanitized['bot_token'] = '';
-            } else {
+            if ('' !== $raw_token) {
                 $sanitized['bot_token'] = sanitize_text_field($raw_token);
             }
         }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -142,6 +142,18 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
         $this->assertSame($expected, $result);
     }
 
+    public function test_sanitize_options_preserves_stored_bot_token_when_input_empty() {
+        $input = array(
+            'bot_token' => '',
+        );
+
+        $result   = $this->admin->sanitize_options($input);
+        $expected = $this->get_expected_defaults();
+
+        $this->assertSame($expected['bot_token'], $result['bot_token']);
+        $this->assertSame($expected, $result);
+    }
+
     private function get_expected_defaults(): array {
         return array(
             'server_id'      => '',


### PR DESCRIPTION
## Summary
- update the admin option sanitizer to keep the saved bot token when no new value is supplied
- add a PHPUnit test covering the empty token submission scenario

## Testing
- `vendor/bin/phpunit -c discord-bot-jlg/phpunit.xml.dist` *(fails: vendor/bin/phpunit not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d723f20354832e8c3d8d3438947e54