### PR TITLE
Allow clearing stored bot token when submitting an empty field

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -202,7 +202,9 @@ class Discord_Bot_JLG_Admin {
         if (!$constant_overridden && array_key_exists('bot_token', $input)) {
             $raw_token = trim((string) $input['bot_token']);
 
-            if ('' !== $raw_token) {
+            if ('' === $raw_token) {
+                $sanitized['bot_token'] = '';
+            } else {
                 $sanitized['bot_token'] = sanitize_text_field($raw_token);
             }
         }
@@ -422,7 +424,7 @@ class Discord_Bot_JLG_Admin {
 
                 if ($has_saved_token) {
                     echo '<br />';
-                    echo esc_html__('Un token est déjà enregistré. Laissez ce champ vide pour le conserver ou saisissez un nouveau token pour le remplacer.', 'discord-bot-jlg');
+                    echo esc_html__('Un token est déjà enregistré. Saisissez un nouveau token pour le remplacer ou laissez ce champ vide pour le supprimer.', 'discord-bot-jlg');
                 }
             }
             ?>

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -142,15 +142,15 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
         $this->assertSame($expected, $result);
     }
 
-    public function test_sanitize_options_preserves_stored_bot_token_when_input_empty() {
+    public function test_sanitize_options_clears_stored_bot_token_when_input_empty() {
         $input = array(
             'bot_token' => '',
         );
 
         $result   = $this->admin->sanitize_options($input);
         $expected = $this->get_expected_defaults();
+        $expected['bot_token'] = '';
 
-        $this->assertSame($expected['bot_token'], $result['bot_token']);
         $this->assertSame($expected, $result);
     }
 


### PR DESCRIPTION
## Summary
- allow `sanitize_options` to clear the stored bot token when an empty value is submitted and no constant override is in place
- update the admin UI help text to mention the ability to remove the saved token
- adjust the admin sanitization test to assert the empty bot token is stored when the input field is blank

## Testing
- phpunit -c discord-bot-jlg/phpunit.xml.dist *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ce6a9c5c832e91e9379a2fa029d9