### PR TITLE
Display settings notices on options page

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -538,6 +538,7 @@ class Discord_Bot_JLG_Admin {
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('🎮 Discord Bot - JLG - Configuration', 'discord-bot-jlg'); ?></h1>
+            <?php settings_errors('discord_stats_settings'); ?>
             <?php $this->handle_test_connection_request(); ?>
 
             <div style="display: flex; gap: 20px; margin-top: 20px;">


### PR DESCRIPTION
## Summary
- ensure the Discord Bot options page outputs WordPress settings notices so users can see success or error messages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d80754f9a4832e858649f5f468e3db