### PR TITLE
Define DAY_IN_SECONDS in test bootstrap

### DIFF
--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -7,6 +7,10 @@ if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__);
 }
 
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
 require_once __DIR__ . '/../../inc/class-discord-http.php';
 require_once __DIR__ . '/../../inc/class-discord-api.php';
 require_once __DIR__ . '/../../inc/class-discord-widget.php';


### PR DESCRIPTION
## Summary
- define the DAY_IN_SECONDS constant in the PHPUnit bootstrap so tests have the expected WordPress stub constant

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8367d13cc832e9e1516ed3a0ea5ab