### PR TITLE
Allow admin preview data attributes

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -1047,12 +1047,18 @@ class Discord_Bot_JLG_Admin {
             array(
                 'style'                 => true,
                 'data-demo'             => true,
+                'data-fallback-demo'    => true,
+                'data-stale'            => true,
+                'data-last-updated'     => true,
                 'data-refresh'          => true,
+                'data-show-server-name' => true,
+                'data-server-name'      => true,
                 'data-value'            => true,
                 'data-label-total'      => true,
                 'data-label-unavailable'=> true,
                 'data-label-approx'     => true,
                 'data-placeholder'      => true,
+                'data-role'             => true,
             )
         );
         $allowed_tags['div'] = $div_attributes;


### PR DESCRIPTION
## Summary
- allow the admin preview sanitizer to accept all data attributes used by the public shortcode output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d83b3345a4832e8f145ef4c5e19097