### PR TITLE
Add capability check before testing Discord connection

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -557,9 +557,22 @@ class Discord_Bot_JLG_Admin {
      * Traite la demande de test de connexion depuis la page d'options.
      */
     private function handle_test_connection_request() {
-        if (isset($_POST['test_connection']) && check_admin_referer('discord_test_connection')) {
-            $this->test_discord_connection();
+        if (!isset($_POST['test_connection']) || !check_admin_referer('discord_test_connection')) {
+            return;
         }
+
+        if (!current_user_can('manage_options')) {
+            add_settings_error(
+                'discord_stats_settings',
+                'discord_bot_jlg_access_denied',
+                esc_html__('Accès refusé : vous n\'avez pas les droits suffisants pour tester la connexion Discord.', 'discord-bot-jlg'),
+                'error'
+            );
+
+            return;
+        }
+
+        $this->test_discord_connection();
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure the Discord connection test handler requires the `manage_options` capability
- display an admin notice when the capability check fails

## Testing
- not run (WordPress test environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68d86c43d084832e8beb4d573f30658c