### PR TITLE
Remove placeholder help link from demo footer

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -893,7 +893,7 @@ class Discord_Bot_JLG_Admin {
                 );
                 ?>
                <a href="https://discord.com/developers/docs/intro" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Documentation Discord API', 'discord-bot-jlg'); ?></a> |
-               <a href="#" onclick="return false;"><?php esc_html_e('Besoin d\'aide ?', 'discord-bot-jlg'); ?></a>
+               <?php esc_html_e('Besoin d\'aide ?', 'discord-bot-jlg'); ?>
             </p>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- replace the placeholder "Besoin d'aide ?" anchor in the demo footer with translated text to avoid a broken link

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d86c381f08832e9a760ee66edf42a9