### PR TITLE
Add configurable HTTP response size limit to Discord client

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ Accédez à la page **Discord Bot** dans l’administration pour :
 
 Il est possible de forcer l'utilisation d'un token spécifique en définissant la constante `DISCORD_BOT_JLG_TOKEN` dans votre fichier `wp-config.php` ou dans un plugin mu. Lorsque cette constante est présente (et non vide), elle est utilisée à la place de la valeur enregistrée dans l'administration et le champ correspondant devient en lecture seule.
 
+### Ajuster la taille maximale des réponses HTTP
+
+Par défaut, le client HTTP plafonne les réponses distantes à 1 048 576 octets pour éviter de charger des fichiers trop volumineux. Si vous devez assouplir ou renforcer cette limite (par exemple pour supporter des payloads plus importants renvoyés par un proxy), vous pouvez utiliser le filtre `discord_bot_jlg_http_max_bytes` :
+
+```php
+add_filter('discord_bot_jlg_http_max_bytes', function ($max_bytes, $url, $context) {
+    if ('widget' === $context) {
+        return 2 * MB_IN_BYTES; // Autorise jusqu'à 2 Mo pour les appels du widget.
+    }
+
+    return $max_bytes;
+}, 10, 3);
+```
+
+Le callback reçoit la valeur par défaut (1 048 576), l’URL ciblée et le contexte (`widget`, `bot`, etc.). Retournez une valeur entière strictement positive pour activer la nouvelle limite. Toute valeur inférieure ou égale à zéro réappliquera la limite par défaut.
+
 ## Utilisation
 ### Shortcode
 ```

--- a/discord-bot-jlg/inc/class-discord-http.php
+++ b/discord-bot-jlg/inc/class-discord-http.php
@@ -19,8 +19,32 @@ class Discord_Bot_JLG_Http_Client {
      * @return array|WP_Error
      */
     public function get($url, array $args = array(), $context = '') {
+        $context = sanitize_key($context);
+        $default_limit = 1048576;
+
+        /**
+         * Filtre la taille maximale (en octets) autorisée pour la réponse HTTP.
+         *
+         * @since 1.1.0
+         *
+         * @param int    $max_bytes Taille maximale de la réponse en octets.
+         * @param string $url       URL cible.
+         * @param string $context   Contexte fonctionnel.
+         */
+        $max_response_bytes = (int) apply_filters(
+            'discord_bot_jlg_http_max_bytes',
+            $default_limit,
+            $url,
+            $context
+        );
+
+        if ($max_response_bytes <= 0) {
+            $max_response_bytes = $default_limit;
+        }
+
         $defaults = array(
             'timeout' => 10,
+            'limit_response_size' => $max_response_bytes,
             'headers' => array(
                 'User-Agent' => 'WordPress Discord Stats Plugin',
             ),
@@ -30,8 +54,6 @@ class Discord_Bot_JLG_Http_Client {
         $args['headers'] = isset($args['headers']) && is_array($args['headers'])
             ? wp_parse_args($args['headers'], $defaults['headers'])
             : $defaults['headers'];
-
-        $context = sanitize_key($context);
 
         /**
          * Filtre les arguments transmis à wp_safe_remote_get pour un appel Discord.

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Http_Client.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Http_Client.php
@@ -1,0 +1,46 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class Test_Discord_Bot_JLG_Http_Client extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        $GLOBALS['wp_test_last_remote_request'] = null;
+        remove_all_filters('discord_bot_jlg_http_max_bytes');
+    }
+
+    public function test_get_passes_limit_response_size_argument() {
+        $client = new Discord_Bot_JLG_Http_Client();
+        $url    = 'https://discord.com/api';
+
+        $response = $client->get($url);
+
+        $this->assertIsArray($response);
+        $this->assertIsArray($GLOBALS['wp_test_last_remote_request']);
+        $this->assertSame($url, $GLOBALS['wp_test_last_remote_request']['url']);
+        $this->assertArrayHasKey('limit_response_size', $GLOBALS['wp_test_last_remote_request']['args']);
+        $this->assertSame(1048576, $GLOBALS['wp_test_last_remote_request']['args']['limit_response_size']);
+    }
+
+    public function test_filter_can_customize_limit_response_size() {
+        add_filter(
+            'discord_bot_jlg_http_max_bytes',
+            function ($max_bytes, $url, $context) {
+                $this->assertSame('https://discord.com/api', $url);
+                $this->assertSame('widget', $context);
+                return 2048;
+            },
+            10,
+            3
+        );
+
+        $client = new Discord_Bot_JLG_Http_Client();
+        $url    = 'https://discord.com/api';
+
+        $client->get($url, array(), 'widget');
+
+        $this->assertIsArray($GLOBALS['wp_test_last_remote_request']);
+        $this->assertSame(2048, $GLOBALS['wp_test_last_remote_request']['args']['limit_response_size']);
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
          beStrictAboutOutputDuringTests="true">
     <testsuites>
         <testsuite name="Discord Bot - JLG">
+            <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Http_Client.php</file>
             <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php</file>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
## Summary
- cap Discord HTTP responses at 1 MiB by default and allow customization through a new filter
- extend the PHPUnit bootstrap to support filters and capture wp_safe_remote_get arguments for assertions
- document the new hook and cover the HTTP client with dedicated tests

## Testing
- phpunit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d91e525a74832ebdd50fa7f43bec9d