### PR TITLE
Limit trusted proxy headers for public IP detection

### DIFF
--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php
@@ -328,4 +328,25 @@ class Test_Discord_Bot_JLG_API extends TestCase {
             $GLOBALS['wp_test_timezone_string'] = $previous_timezone;
         }
     }
+
+    public function test_public_request_ip_ignores_untrusted_headers() {
+        $option_name = 'discord_server_stats_options';
+        $cache_key   = 'discord_server_stats_cache';
+
+        $api = new Discord_Bot_JLG_API($option_name, $cache_key, 60);
+
+        $server_vars = array(
+            'REMOTE_ADDR'            => '198.51.100.23',
+            'HTTP_X_FORWARDED_FOR'   => '203.0.113.5',
+            'HTTP_X_CLUSTER_CLIENT_IP' => '192.0.2.1',
+        );
+
+        $reflection = new ReflectionClass($api);
+        $method     = $reflection->getMethod('get_public_request_ip');
+        $method->setAccessible(true);
+
+        $ip = $method->invoke($api, $server_vars);
+
+        $this->assertSame('198.51.100.23', $ip, 'Untrusted proxy headers should be ignored by default');
+    }
 }


### PR DESCRIPTION
## Summary
- add a filter-backed helper that lists trusted proxy headers and document how to configure it
- update public IP extraction to rely on REMOTE_ADDR and explicitly trusted proxy headers only
- refresh the fingerprint documentation and add a unit test to ensure untrusted headers are ignored

## Testing
- `php -d auto_prepend_file=/tmp/wp_widget_stub.php /root/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_68d91e4bd134832eb946facf439d266c