### PR TITLE
Fix nested permissions list in API steps

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -296,12 +296,14 @@ class Discord_Bot_JLG_Admin {
         <ol>
             <li><?php echo wp_kses_post(__('Dans le menu de gauche, allez dans <strong>"OAuth2"</strong> &gt; <strong>"URL Generator"</strong>', 'discord-bot-jlg')); ?></li>
             <li><?php echo wp_kses_post(__('Dans "Scopes", cochez <strong>"bot"</strong>', 'discord-bot-jlg')); ?></li>
-            <li><?php echo wp_kses_post(__('Dans "Bot Permissions", sélectionnez :', 'discord-bot-jlg')); ?></li>
+            <li>
+                <?php echo wp_kses_post(__('Dans "Bot Permissions", sélectionnez :', 'discord-bot-jlg')); ?>
                 <ul>
                     <li><?php esc_html_e('✅ View Channels', 'discord-bot-jlg'); ?></li>
                     <li><?php esc_html_e('✅ Read Messages', 'discord-bot-jlg'); ?></li>
                     <li><?php esc_html_e('✅ Send Messages (optionnel)', 'discord-bot-jlg'); ?></li>
                 </ul>
+            </li>
             <li><?php esc_html_e('Copiez l\'URL générée en bas de la page', 'discord-bot-jlg'); ?></li>
             <li><?php esc_html_e('Ouvrez cette URL dans votre navigateur', 'discord-bot-jlg'); ?></li>
             <li><?php echo wp_kses_post(__('Sélectionnez votre serveur et cliquez sur <strong>"Autoriser"</strong>', 'discord-bot-jlg')); ?></li>


### PR DESCRIPTION
## Summary
- wrap the bot permission checklist inside its parent list item in the Discord API setup guide
- ensure the markup maintains the existing translations and escaping helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99f8f530c832e9fc323caf8b2b485