### PR TITLE
Hide diagnostics in public error responses

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -434,7 +434,16 @@ class Discord_Bot_JLG_API {
             $error_payload['retry_after'] = max(0, (int) $this->last_retry_after);
 
             if (!empty($last_error_message)) {
-                $error_payload['diagnostic'] = $last_error_message;
+                $this->log_debug(
+                    sprintf(
+                        'ajax_refresh_stats error (public request): %s',
+                        $last_error_message
+                    )
+                );
+
+                if (false === $is_public_request) {
+                    $error_payload['diagnostic'] = $last_error_message;
+                }
             }
 
             wp_send_json_error($error_payload, 503);
@@ -450,7 +459,16 @@ class Discord_Bot_JLG_API {
         );
 
         if (!empty($last_error_message)) {
-            $error_payload['diagnostic'] = $last_error_message;
+            $this->log_debug(
+                sprintf(
+                    'ajax_refresh_stats error (authenticated request): %s',
+                    $last_error_message
+                )
+            );
+
+            if (false === $is_public_request) {
+                $error_payload['diagnostic'] = $last_error_message;
+            }
         }
 
         $error_payload['retry_after'] = max(0, (int) $this->last_retry_after);


### PR DESCRIPTION
## Summary
- keep diagnostic details out of public AJAX error payloads while logging them for troubleshooting
- log error context for both public and authenticated refresh failures
- extend PHPUnit coverage to confirm diagnostics are hidden from visitors and still present for administrators

## Testing
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php

------
https://chatgpt.com/codex/tasks/task_e_68d99f8c4684832e9294294090bd4ff6