### PR TITLE
Validate shortcode width attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Pour activer l'auto-actualisation, utilisez par exemple :
 [discord_stats refresh="true" refresh_interval="60"]
 ```
 
+L'attribut optionnel `width` accepte uniquement des longueurs CSS valides comme `320px`, `75%`, `42rem`, ainsi que les mots-clés `auto`, `fit-content`, `min-content` et `max-content`. Les expressions `calc(...)` sont prises en charge lorsqu'elles ne contiennent que des nombres, des unités usuelles et les opérateurs arithmétiques de base. Toute valeur non conforme est ignorée afin d'éviter l'injection de styles indésirables.
+
 Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moins 10 secondes (10 000 ms). Toute valeur plus basse est automatiquement portée à 10 secondes pour éviter les erreurs 429 de Discord.
 
 Les rafraîchissements publics (visiteurs non connectés) n'exigent plus de nonce WordPress ; seuls les administrateurs connectés utilisent un jeton de sécurité pour l'action AJAX `refresh_discord_stats`.

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -175,7 +175,11 @@ class Discord_Bot_JLG_Shortcode {
         );
 
         if (!empty($atts['width'])) {
-            $style_declarations[] = 'width: ' . sanitize_text_field($atts['width']);
+            $validated_width = $this->validate_width_value($atts['width']);
+
+            if ('' !== $validated_width) {
+                $style_declarations[] = 'width: ' . $validated_width;
+            }
         }
 
         $attributes = array(
@@ -344,6 +348,42 @@ class Discord_Bot_JLG_Shortcode {
 
         <?php
         return ob_get_clean();
+    }
+
+    private function validate_width_value($raw_width) {
+        if (is_array($raw_width)) {
+            return '';
+        }
+
+        $width = trim((string) $raw_width);
+
+        if ('' === $width) {
+            return '';
+        }
+
+        $width = preg_replace('/\s+/', ' ', $width);
+
+        if (null === $width) {
+            return '';
+        }
+
+        $length_pattern = '/^(?:\d+(?:\.\d+)?)(?:px|em|rem|%|vh|vw|vmin|vmax|ch|ex|cm|mm|in|pt|pc)$/i';
+        if (preg_match($length_pattern, $width)) {
+            return $width;
+        }
+
+        $keywords = array('auto', 'fit-content', 'max-content', 'min-content');
+        $lower_width = strtolower($width);
+        if (in_array($lower_width, $keywords, true)) {
+            return $lower_width;
+        }
+
+        $calc_pattern = '/^calc\(\s*[0-9+\-*\/\.%\sA-Za-z()]+\)$/';
+        if (preg_match($calc_pattern, $width)) {
+            return $width;
+        }
+
+        return '';
     }
 
     private function enqueue_assets($options, $needs_script = false) {

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -1,0 +1,55 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class Test_Discord_Bot_JLG_Shortcode extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        $GLOBALS['wp_test_options'] = array();
+    }
+
+    private function get_shortcode_instance() {
+        $api = new class {
+            public function get_plugin_options() {
+                return array(
+                    'show_online'   => true,
+                    'show_total'    => true,
+                    'widget_title'  => 'Mon serveur',
+                    'custom_css'    => '',
+                );
+            }
+
+            public function get_stats() {
+                return array(
+                    'online'             => 12,
+                    'total'              => 42,
+                    'has_total'          => true,
+                    'total_is_approximate' => false,
+                    'stale'              => false,
+                    'fallback_demo'      => false,
+                    'is_demo'            => false,
+                );
+            }
+
+            public function get_demo_stats() {
+                return $this->get_stats();
+            }
+        };
+
+        return new Discord_Bot_JLG_Shortcode(DISCORD_BOT_JLG_OPTION_NAME, $api);
+    }
+
+    public function test_render_shortcode_rejects_malicious_width() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array(
+            'width' => '100%;position:fixed',
+        ));
+
+        $this->assertStringNotContainsString('position:fixed', $html);
+        $this->assertStringNotContainsString('width: 100%;position:fixed', $html);
+        $this->assertStringNotContainsString('width:100%;position:fixed', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated validator for the shortcode width attribute and ignore unsafe values
- document the accepted width formats in the README
- provide unit coverage to ensure malicious width values do not leak into the rendered HTML and extend the test bootstrap with the required WordPress stubs

## Testing
- `phpunit --testsuite discord-bot-jlg` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da57531688832e883d1b048abf8993