### PR TITLE
Add compatibility helper for boolean validation

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -129,6 +129,7 @@ function discord_bot_jlg_uninstall() {
 
 register_uninstall_hook(__FILE__, 'discord_bot_jlg_uninstall');
 
+require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/helpers.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-http.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-admin.php';

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -4,6 +4,10 @@ if (false === defined('ABSPATH')) {
     exit;
 }
 
+if (!function_exists('discord_bot_jlg_validate_bool')) {
+    require_once __DIR__ . '/helpers.php';
+}
+
 /**
  * Fournit les appels à l'API Discord ainsi que la gestion du cache et des données de démonstration.
  */
@@ -109,8 +113,8 @@ class Discord_Bot_JLG_API {
             )
         );
 
-        $args['force_demo']   = wp_validate_boolean($args['force_demo']);
-        $args['bypass_cache'] = wp_validate_boolean($args['bypass_cache']);
+        $args['force_demo']   = discord_bot_jlg_validate_bool($args['force_demo']);
+        $args['bypass_cache'] = discord_bot_jlg_validate_bool($args['bypass_cache']);
 
         $runtime_key = $this->get_runtime_cache_key($args);
 
@@ -365,7 +369,7 @@ class Discord_Bot_JLG_API {
         }
 
         if (isset($_POST['force_refresh'])) {
-            $force_refresh = wp_validate_boolean(wp_unslash($_POST['force_refresh']));
+            $force_refresh = discord_bot_jlg_validate_bool(wp_unslash($_POST['force_refresh']));
 
             if (
                 true === $force_refresh

--- a/discord-bot-jlg/inc/helpers.php
+++ b/discord-bot-jlg/inc/helpers.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Shared helper functions for Discord Bot JLG plugin.
+ */
+if (!function_exists('discord_bot_jlg_validate_bool')) {
+    /**
+     * Normalizes a value to a boolean, falling back when wp_validate_boolean() is unavailable.
+     *
+     * @param mixed $value Value to validate.
+     *
+     * @return bool
+     */
+    function discord_bot_jlg_validate_bool($value) {
+        if (function_exists('wp_validate_boolean')) {
+            return wp_validate_boolean($value);
+        }
+
+        if (is_string($value)) {
+            $value = trim($value);
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -13,6 +13,7 @@ if (!defined('DAY_IN_SECONDS')) {
     define('DAY_IN_SECONDS', 86400);
 }
 
+require_once __DIR__ . '/../../inc/helpers.php';
 require_once __DIR__ . '/../../inc/class-discord-http.php';
 require_once __DIR__ . '/../../inc/class-discord-api.php';
 require_once __DIR__ . '/../../inc/class-discord-widget.php';
@@ -430,6 +431,29 @@ function wp_safe_remote_get($url, $args = array()) {
     );
 }
 
+function current_user_can($capability) {
+    return true;
+}
+
+function __($text, $domain = null) {
+    return $text;
+}
+
+if (!function_exists('wp_validate_boolean')) {
+    $api = new Discord_Bot_JLG_API('discord_bot_jlg_test_option', 'discord_bot_jlg_test_cache');
+
+    $stats = $api->get_stats(
+        array(
+            'force_demo'   => 'true',
+            'bypass_cache' => 'false',
+        )
+    );
+
+    if (!is_array($stats)) {
+        throw new RuntimeException('Discord Bot JLG API should load without wp_validate_boolean.');
+    }
+}
+
 function wp_validate_boolean($value) {
     if (is_bool($value)) {
         return $value;
@@ -441,14 +465,6 @@ function wp_validate_boolean($value) {
     }
 
     return (bool) $value;
-}
-
-function current_user_can($capability) {
-    return true;
-}
-
-function __($text, $domain = null) {
-    return $text;
 }
 
 class WP_Error {


### PR DESCRIPTION
## Summary
- add a reusable boolean validation helper that falls back when `wp_validate_boolean()` is unavailable
- switch the Discord API class to use the helper and ensure the helper is always loaded
- extend the PHPUnit bootstrap to require the helper and assert the API works without `wp_validate_boolean()`

## Testing
- php -l discord-bot-jlg/inc/helpers.php
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/tests/phpunit/bootstrap.php


------
https://chatgpt.com/codex/tasks/task_e_68dbe8e6f69c832e9a70a994ff7f06aa