### PR TITLE
Add Discord stats Gutenberg block

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -1,0 +1,314 @@
+(function (blocks, element, components, blockEditor, i18n, serverSideRender) {
+    if (!blocks || !element || !components || !blockEditor || !i18n) {
+        return;
+    }
+
+    var registerBlockType = blocks.registerBlockType;
+    var createElement = element.createElement;
+    var Fragment = element.Fragment;
+    var __ = i18n.__;
+    var InspectorControls = blockEditor.InspectorControls;
+    var useBlockProps = blockEditor.useBlockProps || function () { return {}; };
+    var PanelBody = components.PanelBody;
+    var ToggleControl = components.ToggleControl;
+    var TextControl = components.TextControl;
+    var SelectControl = components.SelectControl;
+    var RangeControl = components.RangeControl;
+    var ServerSideRender = serverSideRender;
+
+    if (!registerBlockType || !InspectorControls) {
+        return;
+    }
+
+    var blockName = 'discord-bot-jlg/discord-stats';
+
+    var layoutOptions = [
+        { label: __('Horizontal', 'discord-bot-jlg'), value: 'horizontal' },
+        { label: __('Vertical', 'discord-bot-jlg'), value: 'vertical' }
+    ];
+
+    var themeOptions = [
+        { label: __('Discord', 'discord-bot-jlg'), value: 'discord' },
+        { label: __('Sombre', 'discord-bot-jlg'), value: 'dark' },
+        { label: __('Clair', 'discord-bot-jlg'), value: 'light' },
+        { label: __('Minimal', 'discord-bot-jlg'), value: 'minimal' }
+    ];
+
+    var alignOptions = [
+        { label: __('Gauche', 'discord-bot-jlg'), value: 'left' },
+        { label: __('Centre', 'discord-bot-jlg'), value: 'center' },
+        { label: __('Droite', 'discord-bot-jlg'), value: 'right' }
+    ];
+
+    var iconPositionOptions = [
+        { label: __('À gauche', 'discord-bot-jlg'), value: 'left' },
+        { label: __('En haut', 'discord-bot-jlg'), value: 'top' },
+        { label: __('À droite', 'discord-bot-jlg'), value: 'right' }
+    ];
+
+    var defaultAttributes = {
+        layout: 'horizontal',
+        show_online: true,
+        show_total: true,
+        show_title: false,
+        title: '',
+        theme: 'discord',
+        animated: true,
+        refresh: false,
+        refresh_interval: '60',
+        compact: false,
+        align: 'left',
+        width: '',
+        class: '',
+        icon_online: '🟢',
+        icon_total: '👥',
+        label_online: 'En ligne',
+        label_total: 'Membres',
+        hide_labels: false,
+        hide_icons: false,
+        border_radius: 8,
+        gap: 20,
+        padding: 15,
+        demo: false,
+        show_discord_icon: false,
+        discord_icon_position: 'left',
+        show_server_name: false
+    };
+
+    function attributesToShortcode(attributes) {
+        var pairs = [];
+
+        for (var key in defaultAttributes) {
+            if (!Object.prototype.hasOwnProperty.call(defaultAttributes, key)) {
+                continue;
+            }
+
+            var defaultValue = defaultAttributes[key];
+            var value = Object.prototype.hasOwnProperty.call(attributes, key) ? attributes[key] : defaultValue;
+
+            if (value === defaultValue || value === '' || value === undefined || value === null) {
+                continue;
+            }
+
+            var normalized = typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value);
+
+            if (normalized === '') {
+                continue;
+            }
+
+            normalized = normalized.replace(/"/g, '&quot;');
+            pairs.push(key + '="' + normalized + '"');
+        }
+
+        return '[discord_stats' + (pairs.length ? ' ' + pairs.join(' ') : '') + ']';
+    }
+
+    function updateAttribute(setAttributes, name) {
+        return function (value) {
+            var newValue = value;
+
+            if (typeof defaultAttributes[name] === 'boolean') {
+                newValue = !!value;
+            }
+
+            var update = {};
+            update[name] = newValue;
+            setAttributes(update);
+        };
+    }
+
+    registerBlockType(blockName, {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var setAttributes = props.setAttributes;
+            var blockProps = useBlockProps ? useBlockProps() : {};
+
+            var preview = ServerSideRender
+                ? createElement(ServerSideRender, {
+                    block: blockName,
+                    attributes: attributes
+                })
+                : createElement('div', { className: 'discord-bot-jlg-block-placeholder' }, __('Prévisualisation indisponible.', 'discord-bot-jlg'));
+
+            return createElement(
+                Fragment,
+                null,
+                createElement(
+                    InspectorControls,
+                    null,
+                    createElement(
+                        PanelBody,
+                        { title: __('Affichage', 'discord-bot-jlg'), initialOpen: true },
+                        createElement(SelectControl, {
+                            label: __('Disposition', 'discord-bot-jlg'),
+                            value: attributes.layout,
+                            options: layoutOptions,
+                            onChange: updateAttribute(setAttributes, 'layout')
+                        }),
+                        createElement(SelectControl, {
+                            label: __('Thème', 'discord-bot-jlg'),
+                            value: attributes.theme,
+                            options: themeOptions,
+                            onChange: updateAttribute(setAttributes, 'theme')
+                        }),
+                        createElement(SelectControl, {
+                            label: __('Alignement', 'discord-bot-jlg'),
+                            value: attributes.align,
+                            options: alignOptions,
+                            onChange: updateAttribute(setAttributes, 'align')
+                        }),
+                        createElement(TextControl, {
+                            label: __('Largeur (CSS)', 'discord-bot-jlg'),
+                            value: attributes.width,
+                            onChange: updateAttribute(setAttributes, 'width'),
+                            help: __('Utilisez une valeur CSS valide, ex. 100% ou 320px.', 'discord-bot-jlg')
+                        }),
+                        createElement(TextControl, {
+                            label: __('Classe(s) supplémentaire(s)', 'discord-bot-jlg'),
+                            value: attributes.class,
+                            onChange: updateAttribute(setAttributes, 'class')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Mode compact', 'discord-bot-jlg'),
+                            checked: !!attributes.compact,
+                            onChange: updateAttribute(setAttributes, 'compact')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Activer les animations', 'discord-bot-jlg'),
+                            checked: !!attributes.animated,
+                            onChange: updateAttribute(setAttributes, 'animated')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher l\'icône Discord', 'discord-bot-jlg'),
+                            checked: !!attributes.show_discord_icon,
+                            onChange: updateAttribute(setAttributes, 'show_discord_icon')
+                        }),
+                        !!attributes.show_discord_icon && createElement(SelectControl, {
+                            label: __('Position de l\'icône', 'discord-bot-jlg'),
+                            value: attributes.discord_icon_position,
+                            options: iconPositionOptions,
+                            onChange: updateAttribute(setAttributes, 'discord_icon_position')
+                        }),
+                        createElement(RangeControl, {
+                            label: __('Rayon des bords (px)', 'discord-bot-jlg'),
+                            value: attributes.border_radius,
+                            onChange: updateAttribute(setAttributes, 'border_radius'),
+                            min: 0,
+                            max: 50
+                        }),
+                        createElement(RangeControl, {
+                            label: __('Espacement interne (px)', 'discord-bot-jlg'),
+                            value: attributes.padding,
+                            onChange: updateAttribute(setAttributes, 'padding'),
+                            min: 0,
+                            max: 60
+                        }),
+                        createElement(RangeControl, {
+                            label: __('Espacement entre les éléments (px)', 'discord-bot-jlg'),
+                            value: attributes.gap,
+                            onChange: updateAttribute(setAttributes, 'gap'),
+                            min: 0,
+                            max: 80
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Contenu', 'discord-bot-jlg'), initialOpen: false },
+                        createElement(ToggleControl, {
+                            label: __('Afficher les membres en ligne', 'discord-bot-jlg'),
+                            checked: !!attributes.show_online,
+                            onChange: updateAttribute(setAttributes, 'show_online')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher le total des membres', 'discord-bot-jlg'),
+                            checked: !!attributes.show_total,
+                            onChange: updateAttribute(setAttributes, 'show_total')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher le titre', 'discord-bot-jlg'),
+                            checked: !!attributes.show_title,
+                            onChange: updateAttribute(setAttributes, 'show_title')
+                        }),
+                        !!attributes.show_title && createElement(TextControl, {
+                            label: __('Titre personnalisé', 'discord-bot-jlg'),
+                            value: attributes.title,
+                            onChange: updateAttribute(setAttributes, 'title')
+                        }),
+                        createElement(TextControl, {
+                            label: __('Icône "En ligne"', 'discord-bot-jlg'),
+                            value: attributes.icon_online,
+                            onChange: updateAttribute(setAttributes, 'icon_online')
+                        }),
+                        createElement(TextControl, {
+                            label: __('Icône "Membres"', 'discord-bot-jlg'),
+                            value: attributes.icon_total,
+                            onChange: updateAttribute(setAttributes, 'icon_total')
+                        }),
+                        createElement(TextControl, {
+                            label: __('Libellé "En ligne"', 'discord-bot-jlg'),
+                            value: attributes.label_online,
+                            onChange: updateAttribute(setAttributes, 'label_online'),
+                            placeholder: __('En ligne', 'discord-bot-jlg')
+                        }),
+                        createElement(TextControl, {
+                            label: __('Libellé "Membres"', 'discord-bot-jlg'),
+                            value: attributes.label_total,
+                            onChange: updateAttribute(setAttributes, 'label_total'),
+                            placeholder: __('Membres', 'discord-bot-jlg')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Masquer les libellés', 'discord-bot-jlg'),
+                            checked: !!attributes.hide_labels,
+                            onChange: updateAttribute(setAttributes, 'hide_labels')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Masquer les icônes', 'discord-bot-jlg'),
+                            checked: !!attributes.hide_icons,
+                            onChange: updateAttribute(setAttributes, 'hide_icons')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher le nom du serveur', 'discord-bot-jlg'),
+                            checked: !!attributes.show_server_name,
+                            onChange: updateAttribute(setAttributes, 'show_server_name')
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Interactions', 'discord-bot-jlg'), initialOpen: false },
+                        createElement(ToggleControl, {
+                            label: __('Activer le rafraîchissement automatique', 'discord-bot-jlg'),
+                            checked: !!attributes.refresh,
+                            onChange: updateAttribute(setAttributes, 'refresh')
+                        }),
+                        !!attributes.refresh && createElement(TextControl, {
+                            label: __('Intervalle de rafraîchissement (secondes)', 'discord-bot-jlg'),
+                            value: attributes.refresh_interval,
+                            onChange: updateAttribute(setAttributes, 'refresh_interval')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Forcer le mode démo', 'discord-bot-jlg'),
+                            checked: !!attributes.demo,
+                            onChange: updateAttribute(setAttributes, 'demo')
+                        })
+                    )
+                ),
+                createElement(
+                    'div',
+                    blockProps,
+                    preview
+                )
+            );
+        },
+        save: function (props) {
+            var attributes = (props && props.attributes) || {};
+            return attributesToShortcode(attributes);
+        }
+    });
+})(
+    window.wp && window.wp.blocks,
+    window.wp && window.wp.element,
+    window.wp && window.wp.components,
+    (window.wp && (window.wp.blockEditor || window.wp.editor)) || {},
+    window.wp && window.wp.i18n,
+    window.wp && window.wp.serverSideRender
+);

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -1,0 +1,127 @@
+{
+    "apiVersion": 2,
+    "name": "discord-bot-jlg/discord-stats",
+    "title": "Discord Server Stats",
+    "category": "widgets",
+    "icon": "chart-bar",
+    "description": "Affiche les statistiques de votre serveur Discord dans un bloc personnalisable.",
+    "keywords": [
+        "discord",
+        "bot",
+        "stats"
+    ],
+    "textdomain": "discord-bot-jlg",
+    "editorScript": "discord-bot-jlg-block-editor",
+    "editorStyle": "discord-bot-jlg-block-editor-style",
+    "style": "discord-bot-jlg-inline",
+    "supports": {
+        "html": false,
+        "customClassName": false
+    },
+    "attributes": {
+        "layout": {
+            "type": "string",
+            "default": "horizontal"
+        },
+        "show_online": {
+            "type": "boolean",
+            "default": true
+        },
+        "show_total": {
+            "type": "boolean",
+            "default": true
+        },
+        "show_title": {
+            "type": "boolean",
+            "default": false
+        },
+        "title": {
+            "type": "string",
+            "default": ""
+        },
+        "theme": {
+            "type": "string",
+            "default": "discord"
+        },
+        "animated": {
+            "type": "boolean",
+            "default": true
+        },
+        "refresh": {
+            "type": "boolean",
+            "default": false
+        },
+        "refresh_interval": {
+            "type": "string",
+            "default": "60"
+        },
+        "compact": {
+            "type": "boolean",
+            "default": false
+        },
+        "align": {
+            "type": "string",
+            "default": "left"
+        },
+        "width": {
+            "type": "string",
+            "default": ""
+        },
+        "class": {
+            "type": "string",
+            "default": ""
+        },
+        "icon_online": {
+            "type": "string",
+            "default": "\ud83d\udfe2"
+        },
+        "icon_total": {
+            "type": "string",
+            "default": "\ud83d\udc65"
+        },
+        "label_online": {
+            "type": "string",
+            "default": "En ligne"
+        },
+        "label_total": {
+            "type": "string",
+            "default": "Membres"
+        },
+        "hide_labels": {
+            "type": "boolean",
+            "default": false
+        },
+        "hide_icons": {
+            "type": "boolean",
+            "default": false
+        },
+        "border_radius": {
+            "type": "number",
+            "default": 8
+        },
+        "gap": {
+            "type": "number",
+            "default": 20
+        },
+        "padding": {
+            "type": "number",
+            "default": 15
+        },
+        "demo": {
+            "type": "boolean",
+            "default": false
+        },
+        "show_discord_icon": {
+            "type": "boolean",
+            "default": false
+        },
+        "discord_icon_position": {
+            "type": "string",
+            "default": "left"
+        },
+        "show_server_name": {
+            "type": "boolean",
+            "default": false
+        }
+    }
+}

--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -173,11 +173,63 @@ class DiscordServerStats {
 
         add_action('widgets_init', array($this->widget, 'register_widget'));
 
+        add_action('init', array($this, 'register_block'));
+
         add_action('wp_ajax_refresh_discord_stats', array($this->api, 'ajax_refresh_stats'));
         add_action('wp_ajax_nopriv_refresh_discord_stats', array($this->api, 'ajax_refresh_stats'));
         add_action('update_option_' . DISCORD_BOT_JLG_OPTION_NAME, array($this, 'handle_settings_update'), 10, 2);
 
         add_action(DISCORD_BOT_JLG_CRON_HOOK, array($this->api, 'refresh_cache_via_cron'));
+    }
+
+    public function register_block() {
+        if (!function_exists('register_block_type')) {
+            return;
+        }
+
+        $script_handle       = 'discord-bot-jlg-block-editor';
+        $editor_style_handle = 'discord-bot-jlg-block-editor-style';
+        $style_handle        = 'discord-bot-jlg-inline';
+
+        wp_register_script(
+            $script_handle,
+            DISCORD_BOT_JLG_PLUGIN_URL . 'assets/js/discord-bot-block.js',
+            array('wp-blocks', 'wp-element', 'wp-components', 'wp-block-editor', 'wp-data', 'wp-i18n', 'wp-server-side-render'),
+            DISCORD_BOT_JLG_VERSION,
+            true
+        );
+
+        wp_register_style(
+            'discord-bot-jlg',
+            DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg.css',
+            array(),
+            DISCORD_BOT_JLG_VERSION
+        );
+
+        wp_register_style(
+            $style_handle,
+            DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg-inline.css',
+            array('discord-bot-jlg'),
+            DISCORD_BOT_JLG_VERSION
+        );
+
+        wp_register_style(
+            $editor_style_handle,
+            DISCORD_BOT_JLG_PLUGIN_URL . 'assets/css/discord-bot-jlg.css',
+            array($style_handle),
+            DISCORD_BOT_JLG_VERSION
+        );
+
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations($script_handle, 'discord-bot-jlg', DISCORD_BOT_JLG_PLUGIN_PATH . 'languages');
+        }
+
+        register_block_type(
+            DISCORD_BOT_JLG_PLUGIN_PATH . 'block/discord-stats',
+            array(
+                'render_callback' => array($this->shortcode, 'render_shortcode')
+            )
+        );
     }
 
     public function activate() {

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -811,6 +811,10 @@ class Discord_Bot_JLG_Admin {
             <p style="margin-top: 10px;"><em><?php echo esc_html__('ℹ️ L\'auto-refresh nécessite un intervalle d\'au moins 10 secondes (10 000 ms). Toute valeur inférieure est automatiquement ajustée pour éviter les erreurs 429.', 'discord-bot-jlg'); ?></em></p>
             <p style="margin-top: 10px;"><em><?php echo esc_html__('🔐 Les rafraîchissements publics n\'utilisent plus de nonce WordPress. Un jeton reste exigé uniquement pour les requêtes effectuées par des utilisateurs connectés (administration).', 'discord-bot-jlg'); ?></em></p>
 
+            <h3><?php esc_html_e('Option 2 : Bloc Éditeur Gutenberg', 'discord-bot-jlg'); ?></h3>
+            <p><?php echo wp_kses_post(__('Ajoutez le bloc <strong>« Discord Server Stats »</strong> depuis l\'inserteur Gutenberg pour configurer vos statistiques en mode visuel. Toutes les options du shortcode sont disponibles via la barre latérale (mise en page, couleurs, libellés, rafraîchissement automatique, etc.).', 'discord-bot-jlg')); ?></p>
+            <p><?php echo wp_kses_post(__('Le bloc affiche immédiatement un aperçu rendu côté serveur. Lors de l\'enregistrement avec l\'éditeur classique, un shortcode équivalent est automatiquement inséré pour conserver la compatibilité.', 'discord-bot-jlg')); ?></p>
+
             <h4><?php esc_html_e('Tous les paramètres disponibles :', 'discord-bot-jlg'); ?></h4>
             <div style="background: white; padding: 15px; border-radius: 4px;">
                 <h5><?php esc_html_e('🎨 Apparence & Layout :', 'discord-bot-jlg'); ?></h5>


### PR DESCRIPTION
## Summary
- register the Discord stats Gutenberg block and its assets during plugin init
- provide block metadata and editor script to surface shortcode options via Inspector controls with shortcode fallback on save
- document the new block workflow in the admin usage guide

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68dbffbdc0e8832ebcecd19b0aead042