### PR TITLE
Handle array inputs when validating booleans

### DIFF
--- a/discord-bot-jlg/inc/helpers.php
+++ b/discord-bot-jlg/inc/helpers.php
@@ -12,6 +12,27 @@ if (!function_exists('discord_bot_jlg_validate_bool')) {
      * @return bool
      */
     function discord_bot_jlg_validate_bool($value) {
+        if (is_array($value)) {
+            $found = false;
+
+            $iterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($value));
+            foreach ($iterator as $item) {
+                if (is_scalar($item)) {
+                    $value = $item;
+                    $found = true;
+                    break;
+                }
+            }
+
+            if (false === $found) {
+                $value = null;
+            }
+        }
+
+        if (!is_scalar($value)) {
+            return false;
+        }
+
         if (function_exists('wp_validate_boolean')) {
             return wp_validate_boolean($value);
         }


### PR DESCRIPTION
## Summary
- ensure the boolean helper extracts the first scalar value from array inputs and falls back safely for non-scalar data
- add PHPUnit coverage for ajax_refresh_stats when force_refresh is provided as an array

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: phpunit executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc06b5395c832ea879846238a46da7