### PR TITLE
Add WP-CLI support for Discord Bot cache maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,12 @@ Le fichier `phpunit.xml.dist` du plugin référence automatiquement le bootstrap
 ## Support
 - Portail développeur Discord : https://discord.com/developers/applications
 - Notes de version disponibles dans l’interface du plugin.
+
+### CLI
+
+Deux commandes WP-CLI facilitent les opérations :
+
+- `wp discord-bot refresh-cache` force l'appel API immédiat en ignorant le cache ;
+- `wp discord-bot clear-cache` purge toutes les données (transients, sauvegardes et limites de taux).
+
+Les deux commandes retournent un code de sortie non nul en cas d'erreur afin de permettre l'automatisation dans vos scripts d'exploitation.

--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -136,6 +136,21 @@ require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-admin.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-shortcode.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-widget.php';
 
+if (defined('WP_CLI') && WP_CLI) {
+    require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-cli.php';
+
+    WP_CLI::add_command(
+        'discord-bot',
+        new Discord_Bot_JLG_CLI(
+            new Discord_Bot_JLG_API(
+                DISCORD_BOT_JLG_OPTION_NAME,
+                DISCORD_BOT_JLG_CACHE_KEY,
+                DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION
+            )
+        )
+    );
+}
+
 function discord_bot_jlg_load_textdomain() {
     load_plugin_textdomain('discord-bot-jlg', false, dirname(plugin_basename(__FILE__)) . '/languages');
 }

--- a/discord-bot-jlg/inc/class-discord-cli.php
+++ b/discord-bot-jlg/inc/class-discord-cli.php
@@ -1,0 +1,103 @@
+<?php
+
+if (false === defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Fournit l'intégration WP-CLI pour piloter le cache du plugin.
+ */
+class Discord_Bot_JLG_CLI {
+
+    /**
+     * Service d'accès aux statistiques Discord.
+     *
+     * @var Discord_Bot_JLG_API
+     */
+    private $api;
+
+    /**
+     * Prépare la commande WP-CLI en recevant une instance de l'API du plugin.
+     *
+     * @param Discord_Bot_JLG_API $api Service utilisé pour manipuler les statistiques Discord.
+     */
+    public function __construct(Discord_Bot_JLG_API $api) {
+        $this->api = $api;
+    }
+
+    /**
+     * Force l'actualisation du cache des statistiques.
+     *
+     * ## EXAMPLES
+     *
+     *     wp discord-bot refresh-cache
+     *
+     * @when after_wp_load
+     *
+     * @param array $args       Liste d'arguments positionnels (non utilisés).
+     * @param array $assoc_args Liste d'arguments nommés (non utilisés).
+     *
+     * @return void
+     */
+    public function refresh_cache($args, $assoc_args) {
+        $stats = $this->api->get_stats(array('bypass_cache' => true));
+        $last_error = $this->api->get_last_error_message();
+
+        if (!is_array($stats)) {
+            $message = ('' !== $last_error)
+                ? $last_error
+                : __('Impossible de récupérer des statistiques valides.', 'discord-bot-jlg');
+
+            \WP_CLI::error($message);
+            return;
+        }
+
+        if ('' !== $last_error) {
+            \WP_CLI::error($last_error);
+            return;
+        }
+
+        $server_name = isset($stats['server_name']) ? (string) $stats['server_name'] : '';
+        $online      = isset($stats['online']) ? (int) $stats['online'] : 0;
+        $total       = isset($stats['total']) ? $stats['total'] : null;
+
+        if ('' === $server_name) {
+            $server_name = __('Serveur Discord', 'discord-bot-jlg');
+        }
+
+        $total_display = (null === $total || '' === $total)
+            ? __('n/d', 'discord-bot-jlg')
+            : (string) $total;
+
+        \WP_CLI::log(
+            sprintf(
+                /* traducteurs : 1: nom du serveur, 2: membres en ligne, 3: total de membres */
+                __('%1$s — En ligne : %2$d — Total : %3$s', 'discord-bot-jlg'),
+                $server_name,
+                $online,
+                $total_display
+            )
+        );
+
+        \WP_CLI::success(__('Le cache des statistiques a été actualisé.', 'discord-bot-jlg'));
+    }
+
+    /**
+     * Vide l'ensemble des données mises en cache par le plugin.
+     *
+     * ## EXAMPLES
+     *
+     *     wp discord-bot clear-cache
+     *
+     * @when after_wp_load
+     *
+     * @param array $args       Liste d'arguments positionnels (non utilisés).
+     * @param array $assoc_args Liste d'arguments nommés (non utilisés).
+     *
+     * @return void
+     */
+    public function clear_cache($args, $assoc_args) {
+        $this->api->clear_all_cached_data();
+        \WP_CLI::success(__('Tous les caches Discord Bot JLG ont été vidés.', 'discord-bot-jlg'));
+    }
+}


### PR DESCRIPTION
## Summary
- add a WP-CLI integration class to refresh or purge the Discord Bot cache
- register the new command when WP-CLI is available and document the usage in the README

## Testing
- php -l discord-bot-jlg/inc/class-discord-cli.php

------
https://chatgpt.com/codex/tasks/task_e_68dc06ba8764832e8ccd53808c4e5466