### PR TITLE
Track fallback streaks and surface admin notice

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -168,6 +168,7 @@ class DiscordServerStats {
         add_action('admin_menu', array($this->admin, 'add_admin_menu'));
         add_action('admin_init', array($this->admin, 'settings_init'));
         add_action('admin_enqueue_scripts', array($this->admin, 'enqueue_admin_styles'), 10, 1);
+        add_action('admin_notices', array($this->admin, 'maybe_render_fallback_notice'));
 
         add_shortcode('discord_stats', array($this->shortcode, 'render_shortcode'));
 


### PR DESCRIPTION
## Summary
- count consecutive fallback responses in the API, persist the streak, and expose a getter for administrators
- show an admin notice when the fallback streak exceeds a filterable threshold and hook it into the plugin bootstrap
- expand the PHPUnit coverage to confirm streak increments/resets and the new admin warning behaviour

## Testing
- phpunit -c phpunit.xml.dist *(fails: phpunit binary is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc06bcf60c832e9b1f326fb9878ad8