### PR TITLE
Encrypt stored Discord bot tokens

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -1635,7 +1635,30 @@ class Discord_Bot_JLG_API {
             return DISCORD_BOT_JLG_TOKEN;
         }
 
-        return isset($options['bot_token']) ? $options['bot_token'] : '';
+        if (!isset($options['bot_token']) || '' === $options['bot_token']) {
+            return '';
+        }
+
+        $stored_token = $options['bot_token'];
+
+        if (!is_string($stored_token)) {
+            return '';
+        }
+
+        if (!discord_bot_jlg_is_encrypted_secret($stored_token)) {
+            return $stored_token;
+        }
+
+        $decrypted = discord_bot_jlg_decrypt_secret($stored_token);
+
+        if (is_wp_error($decrypted)) {
+            $this->last_error = $decrypted->get_error_message();
+            $this->flush_options_cache();
+
+            return '';
+        }
+
+        return $decrypted;
     }
 
     private function get_cache_duration($options) {

--- a/discord-bot-jlg/inc/helpers.php
+++ b/discord-bot-jlg/inc/helpers.php
@@ -3,6 +3,10 @@
  * Shared helper functions for Discord Bot JLG plugin.
  */
 
+if (!defined('DISCORD_BOT_JLG_SECRET_PREFIX')) {
+    define('DISCORD_BOT_JLG_SECRET_PREFIX', 'dbjlg_enc_v1:');
+}
+
 if (!function_exists('discord_bot_jlg_validate_bool')) {
     /**
      * Normalizes a value to a boolean, falling back when wp_validate_boolean() is unavailable.
@@ -21,5 +25,143 @@ if (!function_exists('discord_bot_jlg_validate_bool')) {
         }
 
         return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}
+
+if (!function_exists('discord_bot_jlg_is_encrypted_secret')) {
+    /**
+     * Détermine si une valeur correspond à un secret chiffré reconnu.
+     *
+     * @param mixed $value Valeur à évaluer.
+     *
+     * @return bool
+     */
+    function discord_bot_jlg_is_encrypted_secret($value) {
+        return (
+            is_string($value)
+            && '' !== $value
+            && 0 === strpos($value, DISCORD_BOT_JLG_SECRET_PREFIX)
+        );
+    }
+}
+
+if (!function_exists('discord_bot_jlg_encrypt_secret')) {
+    /**
+     * Chiffre un secret à l'aide d'OpenSSL en utilisant AUTH_KEY et AUTH_SALT.
+     *
+     * @param string $secret Secret en clair à chiffrer.
+     *
+     * @return string|WP_Error Secret chiffré (préfixé) ou erreur.
+     */
+    function discord_bot_jlg_encrypt_secret($secret) {
+        if (!is_string($secret) || '' === $secret) {
+            return '';
+        }
+
+        if (!defined('AUTH_KEY') || !defined('AUTH_SALT')) {
+            return new WP_Error(
+                'discord_bot_jlg_encrypt_secret_missing_keys',
+                __('Les constantes AUTH_KEY et AUTH_SALT sont requises pour chiffrer le token Discord.', 'discord-bot-jlg')
+            );
+        }
+
+        if (!function_exists('openssl_encrypt')) {
+            return new WP_Error(
+                'discord_bot_jlg_encrypt_secret_missing_openssl',
+                __('La bibliothèque OpenSSL est requise pour chiffrer le token Discord.', 'discord-bot-jlg')
+            );
+        }
+
+        $key_material = hash('sha256', AUTH_KEY, true);
+        $iv_material  = hash('sha256', AUTH_SALT . AUTH_KEY, true);
+        $iv           = substr($iv_material, 0, 16);
+
+        $ciphertext = openssl_encrypt($secret, 'aes-256-cbc', $key_material, OPENSSL_RAW_DATA, $iv);
+
+        if (false === $ciphertext) {
+            return new WP_Error(
+                'discord_bot_jlg_encrypt_secret_failed',
+                __('Le chiffrement du token Discord a échoué.', 'discord-bot-jlg')
+            );
+        }
+
+        $mac = hash_hmac('sha256', $ciphertext, AUTH_SALT, true);
+
+        return DISCORD_BOT_JLG_SECRET_PREFIX . base64_encode($ciphertext . $mac);
+    }
+}
+
+if (!function_exists('discord_bot_jlg_decrypt_secret')) {
+    /**
+     * Déchiffre un secret généré par discord_bot_jlg_encrypt_secret().
+     *
+     * @param string $secret Secret chiffré à déchiffrer.
+     *
+     * @return string|WP_Error Secret en clair ou erreur.
+     */
+    function discord_bot_jlg_decrypt_secret($secret) {
+        if (!is_string($secret) || '' === $secret) {
+            return new WP_Error(
+                'discord_bot_jlg_decrypt_secret_invalid_value',
+                __('Le token chiffré fourni est invalide.', 'discord-bot-jlg')
+            );
+        }
+
+        if (!discord_bot_jlg_is_encrypted_secret($secret)) {
+            return new WP_Error(
+                'discord_bot_jlg_decrypt_secret_unrecognized_prefix',
+                __('Le format du token enregistré n’est pas reconnu comme un secret chiffré.', 'discord-bot-jlg')
+            );
+        }
+
+        if (!defined('AUTH_KEY') || !defined('AUTH_SALT')) {
+            return new WP_Error(
+                'discord_bot_jlg_decrypt_secret_missing_keys',
+                __('Les constantes AUTH_KEY et AUTH_SALT sont requises pour déchiffrer le token Discord.', 'discord-bot-jlg')
+            );
+        }
+
+        if (!function_exists('openssl_decrypt')) {
+            return new WP_Error(
+                'discord_bot_jlg_decrypt_secret_missing_openssl',
+                __('La bibliothèque OpenSSL est requise pour déchiffrer le token Discord.', 'discord-bot-jlg')
+            );
+        }
+
+        $payload = substr($secret, strlen(DISCORD_BOT_JLG_SECRET_PREFIX));
+        $decoded = base64_decode($payload, true);
+
+        if (false === $decoded || strlen($decoded) <= 32) {
+            return new WP_Error(
+                'discord_bot_jlg_decrypt_secret_invalid_payload',
+                __('Le token chiffré est corrompu ou incomplet.', 'discord-bot-jlg')
+            );
+        }
+
+        $ciphertext = substr($decoded, 0, -32);
+        $mac        = substr($decoded, -32);
+        $expected   = hash_hmac('sha256', $ciphertext, AUTH_SALT, true);
+
+        if (!hash_equals($expected, $mac)) {
+            return new WP_Error(
+                'discord_bot_jlg_decrypt_secret_mac_mismatch',
+                __('Le token chiffré n’a pas pu être vérifié.', 'discord-bot-jlg')
+            );
+        }
+
+        $key_material = hash('sha256', AUTH_KEY, true);
+        $iv_material  = hash('sha256', AUTH_SALT . AUTH_KEY, true);
+        $iv           = substr($iv_material, 0, 16);
+
+        $plaintext = openssl_decrypt($ciphertext, 'aes-256-cbc', $key_material, OPENSSL_RAW_DATA, $iv);
+
+        if (false === $plaintext) {
+            return new WP_Error(
+                'discord_bot_jlg_decrypt_secret_failed',
+                __('Le déchiffrement du token Discord a échoué.', 'discord-bot-jlg')
+            );
+        }
+
+        return $plaintext;
     }
 }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -121,7 +121,26 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
         $result = $this->admin->sanitize_options($input);
         $expected = array_merge($this->get_expected_defaults(), $expected_overrides);
 
+        $result_token   = isset($result['bot_token']) ? $result['bot_token'] : '';
+        $expected_token = $this->saved_options['bot_token'];
+
+        if (array_key_exists('bot_token', $expected_overrides)) {
+            $expected_token = $expected_overrides['bot_token'];
+        }
+
+        unset($expected['bot_token'], $result['bot_token']);
+
         $this->assertSame($expected, $result);
+
+        if ('' === $expected_token) {
+            $this->assertSame('', $result_token);
+        } else {
+            $this->assertTrue(discord_bot_jlg_is_encrypted_secret($result_token));
+            $decrypted = discord_bot_jlg_decrypt_secret($result_token);
+
+            $this->assertFalse(is_wp_error($decrypted));
+            $this->assertSame($expected_token, $decrypted);
+        }
     }
 
     /**
@@ -139,6 +158,9 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
         $expected = $this->get_expected_defaults();
 
         $this->assertSame($expected['bot_token'], $result['bot_token']);
+
+        unset($expected['bot_token'], $result['bot_token']);
+
         $this->assertSame($expected, $result);
     }
 
@@ -152,6 +174,15 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
         $expected = $this->get_expected_defaults();
         $expected['widget_title'] = sanitize_text_field('Updated title');
 
+        $this->assertTrue(discord_bot_jlg_is_encrypted_secret($result['bot_token']));
+
+        $decrypted = discord_bot_jlg_decrypt_secret($result['bot_token']);
+
+        $this->assertFalse(is_wp_error($decrypted));
+        $this->assertSame($this->saved_options['bot_token'], $decrypted);
+
+        unset($expected['bot_token'], $result['bot_token']);
+
         $this->assertSame($expected, $result);
     }
 
@@ -163,6 +194,10 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
         $result   = $this->admin->sanitize_options($input);
         $expected = $this->get_expected_defaults();
         $expected['bot_token'] = '';
+
+        $this->assertSame('', $result['bot_token']);
+
+        unset($expected['bot_token'], $result['bot_token']);
 
         $this->assertSame($expected, $result);
     }


### PR DESCRIPTION
## Summary
- add helper utilities to encrypt and decrypt Discord bot tokens with a versioned prefix tied to AUTH_KEY/AUTH_SALT
- ensure option sanitization stores encrypted tokens, migrates legacy values, and reflects encrypted status in the admin UI while handling decryption errors
- decrypt stored tokens on use within the API client and update PHPUnit coverage to match the new behavior

## Testing
- php -l discord-bot-jlg/inc/helpers.php
- php -l discord-bot-jlg/inc/class-discord-admin.php
- php -l discord-bot-jlg/inc/class-discord-api.php
- php -l discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php

------
https://chatgpt.com/codex/tasks/task_e_68dc06c6f368832ebf6bd1bfff9901b0