### PR TITLE
Track Discord fallback state and surface admin warning

### DIFF
--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -155,6 +155,21 @@ function get_option($name) {
     return isset($GLOBALS['wp_test_options'][$name]) ? $GLOBALS['wp_test_options'][$name] : false;
 }
 
+function update_option($name, $value, $autoload = null) {
+    $GLOBALS['wp_test_options'][$name] = $value;
+
+    return true;
+}
+
+function delete_option($name) {
+    if (isset($GLOBALS['wp_test_options'][$name])) {
+        unset($GLOBALS['wp_test_options'][$name]);
+        return true;
+    }
+
+    return false;
+}
+
 function set_transient($key, $value, $expiration) {
     $expiration = (int) $expiration;
     $expires_at = ($expiration > 0) ? time() + $expiration : 0;


### PR DESCRIPTION
## Summary
- persist the last fallback usage with timestamp and reason inside the API layer and clear it once real data resumes
- expose the fallback metadata to the admin UI and display a warning with retry information when stale data is active
- extend the PHPUnit suite (plus its bootstrap) to cover the new fallback flag behaviour and notice lifecycle

## Testing
- npm test
- phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dc12e96d6c832e8009ef482aca9d5a