### PR TITLE
Add v2 Discord bot secret encryption with random IV

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Accédez à la page **Discord Bot** dans l’administration pour :
 
 Il est possible de forcer l'utilisation d'un token spécifique en définissant la constante `DISCORD_BOT_JLG_TOKEN` dans votre fichier `wp-config.php` ou dans un plugin mu. Lorsque cette constante est présente (et non vide), elle est utilisée à la place de la valeur enregistrée dans l'administration et le champ correspondant devient en lecture seule.
 
+### Nouvelle version du secret chiffré
+
+Les tokens stockés en base de données sont désormais encodés avec le préfixe `dbjlg_enc_v2:` et un vecteur d'initialisation (IV) généré aléatoirement pour chaque chiffrement. Les anciens secrets (`dbjlg_enc_v1:`) restent pris en charge et seront automatiquement déchiffrés. Pour bénéficier du nouvel encodage renforcé, il suffit de ressaisir et enregistrer le token du bot depuis l’interface d’administration (ou de l’effacer puis de le coller à nouveau).
+
 ### Ajuster la taille maximale des réponses HTTP
 
 Par défaut, le client HTTP plafonne les réponses distantes à 1 048 576 octets pour éviter de charger des fichiers trop volumineux. Si vous devez assouplir ou renforcer cette limite (par exemple pour supporter des payloads plus importants renvoyés par un proxy), vous pouvez utiliser le filtre `discord_bot_jlg_http_max_bytes` :

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Helpers.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Helpers.php
@@ -1,0 +1,55 @@
+<?php
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+/**
+ * @group discord-bot-jlg
+ */
+class Test_Discord_Bot_JLG_Helpers extends WP_UnitTestCase {
+
+    public function test_encrypt_secret_uses_v2_format() {
+        $first  = discord_bot_jlg_encrypt_secret('super-secret');
+        $second = discord_bot_jlg_encrypt_secret('super-secret');
+
+        $this->assertFalse(is_wp_error($first));
+        $this->assertFalse(is_wp_error($second));
+
+        $this->assertStringStartsWith(DISCORD_BOT_JLG_SECRET_PREFIX, $first);
+        $this->assertStringStartsWith(DISCORD_BOT_JLG_SECRET_PREFIX, $second);
+        $this->assertNotSame($first, $second, 'Le chiffrement doit utiliser un IV aléatoire.');
+
+        $payload = substr($first, strlen(DISCORD_BOT_JLG_SECRET_PREFIX));
+        $binary  = base64_decode($payload, true);
+
+        $this->assertIsString($binary);
+        $this->assertGreaterThan(48, strlen($binary));
+
+        $decrypted = discord_bot_jlg_decrypt_secret($first);
+
+        $this->assertFalse(is_wp_error($decrypted));
+        $this->assertSame('super-secret', $decrypted);
+    }
+
+    public function test_decrypt_secret_supports_legacy_format() {
+        $legacy_plain  = 'legacy-secret';
+        $legacy_secret = $this->encrypt_secret_v1($legacy_plain);
+
+        $this->assertTrue(discord_bot_jlg_is_encrypted_secret($legacy_secret));
+
+        $decrypted = discord_bot_jlg_decrypt_secret($legacy_secret);
+
+        $this->assertFalse(is_wp_error($decrypted));
+        $this->assertSame($legacy_plain, $decrypted);
+    }
+
+    private function encrypt_secret_v1($plaintext) {
+        $key_material = hash('sha256', AUTH_KEY, true);
+        $iv_material  = hash('sha256', AUTH_SALT . AUTH_KEY, true);
+        $iv           = substr($iv_material, 0, 16);
+
+        $ciphertext = openssl_encrypt($plaintext, 'aes-256-cbc', $key_material, OPENSSL_RAW_DATA, $iv);
+        $mac        = hash_hmac('sha256', $ciphertext, AUTH_SALT, true);
+
+        return DISCORD_BOT_JLG_SECRET_PREFIX_V1 . base64_encode($ciphertext . $mac);
+    }
+}


### PR DESCRIPTION
## Summary
- switch helper encryption to a v2 format that uses a cryptographically random IV and authenticates IV+ciphertext
- keep backwards compatibility with legacy v1 payloads while expanding sanitization coverage
- document the new secret format for administrators and add helper unit tests

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: phpunit not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc34e1be84832eaa2d3904322bc05d