### PR TITLE
Adjust default widget title localization

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -90,7 +90,7 @@ if (!function_exists('discord_bot_jlg_get_default_options')) {
             'show_online'    => true,
             'show_total'     => true,
             'custom_css'     => '',
-            'widget_title'   => __('Discord Server', 'discord-bot-jlg'),
+            'widget_title'   => 'Discord Server',
             'cache_duration' => DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION,
         );
     }
@@ -268,7 +268,13 @@ class DiscordServerStats {
      * @return array
      */
     public function provide_default_options($default = array()) {
-        return $this->default_options;
+        $options = $this->default_options;
+
+        if (empty($options['widget_title']) || 'Discord Server' === $options['widget_title']) {
+            $options['widget_title'] = __('Discord Server', 'discord-bot-jlg');
+        }
+
+        return $options;
     }
 
     /**
@@ -283,7 +289,13 @@ class DiscordServerStats {
             $value = array();
         }
 
-        return wp_parse_args($value, $this->default_options);
+        $options = wp_parse_args($value, $this->default_options);
+
+        if (empty($options['widget_title']) || 'Discord Server' === $options['widget_title']) {
+            $options['widget_title'] = __('Discord Server', 'discord-bot-jlg');
+        }
+
+        return $options;
     }
 
     public function handle_settings_update($old_value, $value) {

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -258,7 +258,11 @@ class Discord_Stats_Widget extends WP_Widget {
             $options = array();
         }
 
-        $default_title = isset($options['widget_title']) ? $options['widget_title'] : __('Discord Server', 'discord-bot-jlg');
+        $default_title = isset($options['widget_title']) ? $options['widget_title'] : '';
+
+        if ('' === $default_title || 'Discord Server' === $default_title) {
+            $default_title = esc_html__('Discord Server', 'discord-bot-jlg');
+        }
 
         $min_refresh = defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
             ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL


### PR DESCRIPTION
## Summary
- stop translating the default widget title during file load and defer localization to runtime
- translate the widget title fallback when providing plugin option defaults and widget instances

## Testing
- php -l discord-bot-jlg/discord-bot-jlg.php
- php -l discord-bot-jlg/inc/class-discord-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68dc4f85c918832e86031cd6721642ee