### PR TITLE
Fix SVG viewbox attribute for Gutenberg preview

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -1235,7 +1235,7 @@ class Discord_Bot_JLG_Admin {
 
         $allowed_tags['svg'] = array(
             'class'       => true,
-            'viewBox'     => true,
+            'viewbox'     => true,
             'xmlns'       => true,
             'role'        => true,
             'aria-hidden' => true,


### PR DESCRIPTION
## Summary
- ensure the Gutenberg admin preview keeps the SVG viewbox attribute by allowing the lowercase `viewbox`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc54d65a78832e9596683d0ac1e1a8