### PR TITLE
Allow shortcode width to accept CSS min/max/clamp functions

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -383,6 +383,20 @@ class Discord_Bot_JLG_Shortcode {
             return $width;
         }
 
+        $numeric_pattern = '-?\d+(?:\.\d+)?(?:px|em|rem|%|vh|vw|vmin|vmax|ch|ex|cm|mm|in|pt|pc)?';
+        $variable_pattern = 'var\(\s*--[A-Za-z0-9_-]+\s*\)';
+        $function_value_pattern = '(?:' . $numeric_pattern . '|' . $variable_pattern . ')';
+
+        $min_max_pattern = '/^(?:min|max)\(\s*' . $function_value_pattern . '(?:\s*,\s*' . $function_value_pattern . ')+\s*\)$/i';
+        if (preg_match($min_max_pattern, $width)) {
+            return $width;
+        }
+
+        $clamp_pattern = '/^clamp\(\s*' . $function_value_pattern . '\s*,\s*' . $function_value_pattern . '\s*,\s*' . $function_value_pattern . '\s*\)$/i';
+        if (preg_match($clamp_pattern, $width)) {
+            return $width;
+        }
+
         return '';
     }
 

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -52,4 +52,37 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertStringNotContainsString('width: 100%;position:fixed', $html);
         $this->assertStringNotContainsString('width:100%;position:fixed', $html);
     }
+
+    public function test_render_shortcode_accepts_min_function_width() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array(
+            'width' => 'min(100%, 50vw)',
+        ));
+
+        $this->assertStringContainsString('style="', $html);
+        $this->assertStringContainsString('width: min(100%, 50vw)', $html);
+    }
+
+    public function test_render_shortcode_accepts_max_function_width() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array(
+            'width' => 'max(300px, var(--discord-width))',
+        ));
+
+        $this->assertStringContainsString('style="', $html);
+        $this->assertStringContainsString('width: max(300px, var(--discord-width))', $html);
+    }
+
+    public function test_render_shortcode_accepts_clamp_function_width() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array(
+            'width' => 'clamp(200px, 50%, var(--max-width))',
+        ));
+
+        $this->assertStringContainsString('style="', $html);
+        $this->assertStringContainsString('width: clamp(200px, 50%, var(--max-width))', $html);
+    }
 }


### PR DESCRIPTION
## Summary
- allow CSS min(), max(), and clamp() width expressions in the shortcode sanitizer while maintaining strict character filtering
- add PHPUnit coverage ensuring min/max/clamp width attributes are rendered by the shortcode

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: phpunit not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4518359c832e81784e24fc954c44