### PR TITLE
Allow nested calc expressions in shortcode width

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -378,7 +378,7 @@ class Discord_Bot_JLG_Shortcode {
             return $lower_width;
         }
 
-        $calc_pattern = '/^calc\(\s*[0-9+\-*\/\.%\sA-Za-z()]+\)$/';
+        $calc_pattern = '/^calc\(\s*[0-9+\-*\/\.,%\sA-Za-z_()\-]+\)$/';
         if (preg_match($calc_pattern, $width)) {
             return $width;
         }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -52,4 +52,16 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertStringNotContainsString('width: 100%;position:fixed', $html);
         $this->assertStringNotContainsString('width:100%;position:fixed', $html);
     }
+
+    public function test_render_shortcode_accepts_calc_with_nested_functions() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $width = 'calc(min(100%, 320px) - 2rem)';
+
+        $html = $shortcode->render_shortcode(array(
+            'width' => $width,
+        ));
+
+        $this->assertStringContainsString('width: ' . $width, $html);
+    }
 }


### PR DESCRIPTION
## Summary
- allow CSS `calc()` width values with nested functions, commas, and CSS variable characters during shortcode validation
- add PHPUnit coverage to ensure calc widths with nested functions are preserved in rendered HTML

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc43c694e8832e935c10661c740750