### PR TITLE
Ensure server name spans full width above stats

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -192,6 +192,9 @@
     gap: 6px;
     line-height: 1.4;
     color: inherit;
+    flex: 0 0 100%;
+    width: 100%;
+    order: -1;
 }
 
 .discord-stats-container .discord-server-name__text {

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -8,6 +8,12 @@
     flex-wrap: wrap;
 }
 
+.discord-server-name {
+    flex: 0 0 100%;
+    width: 100%;
+    order: -1;
+}
+
 .discord-stat {
     background: #5865F2;
     color: white;


### PR DESCRIPTION
## Summary
- ensure the server name element spans the full width and is ordered before the stats cards in the inline stylesheet
- mirror the same layout adjustment in the main stylesheet so standalone usage behaves consistently

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc5cabad78832eb699b3e05d5a9bba