### PR TITLE
Add mobile layout adjustments for discord stats

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -211,3 +211,14 @@
 .discord-server-name--muted {
     opacity: 0.75;
 }
+
+@media (max-width: 600px) {
+    .discord-stats-container .discord-stats-wrapper {
+        flex-direction: column;
+    }
+
+    .discord-stats-container .discord-stat {
+        flex: 1 1 100%;
+        width: 100%;
+    }
+}

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -58,3 +58,14 @@
 .widget .discord-stat {
     justify-content: center;
 }
+
+@media (max-width: 600px) {
+    .discord-stats-wrapper {
+        flex-direction: column;
+    }
+
+    .discord-stat {
+        flex: 1 1 100%;
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- add a mobile breakpoint to stack discord stats vertically and give each card full width
- mirror the responsive rules in the inline stylesheet to keep embeds consistent

## Testing
- manual verification via mobile viewport screenshot

------
https://chatgpt.com/codex/tasks/task_e_68dc5ca983b4832e99db247818c993ac