### PR TITLE
Respect reduced motion preferences for Discord stats animations

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -86,6 +86,20 @@
     }
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .discord-stats-container .discord-demo-badge {
+        animation: none;
+    }
+
+    .discord-stats-container.discord-animated .discord-logo-svg {
+        transition: none;
+    }
+
+    .discord-stats-container.discord-animated .discord-logo-svg:hover {
+        transform: none;
+    }
+}
+
 .discord-stats-container.discord-demo-mode .discord-online .discord-number {
     animation: demo-variation 10s ease-in-out infinite;
 }

--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -322,6 +322,21 @@
             : DEFAULT_NUMBER_FORMATTER;
 
         element.textContent = safeFormatter.format(value);
+
+        var prefersReducedMotion = false;
+        if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+            try {
+                prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            } catch (error) {
+                prefersReducedMotion = false;
+            }
+        }
+
+        if (prefersReducedMotion) {
+            element.style.transform = 'scale(1)';
+            return;
+        }
+
         element.style.transform = 'scale(1.2)';
         setTimeout(function () {
             element.style.transform = 'scale(1)';


### PR DESCRIPTION
## Summary
- wrap the demo badge pulse effect and animated logo hover transition in a reduced-motion media query
- skip the stat number scaling animation when the user prefers reduced motion

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcf6d8a64c832e9984157139364e30