### PR TITLE
Ensure server name spans full width above stats

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -192,7 +192,8 @@
     gap: 6px;
     line-height: 1.4;
     color: inherit;
-    flex: 0 0 100%;
+    flex: 0 0 auto;
+    flex-basis: 100%;
     width: 100%;
     order: -1;
 }

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -9,7 +9,8 @@
 }
 
 .discord-server-name {
-    flex: 0 0 100%;
+    flex: 0 0 auto;
+    flex-basis: 100%;
     width: 100%;
     order: -1;
 }


### PR DESCRIPTION
## Summary
- ensure the server name block in the inline stylesheet spans the full width and appears before the stat cards
- mirror the same flex-basis change in the main stylesheet so non-inline usage behaves identically on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf6dd9c58832e8c132b7713998367