### PR TITLE
Improve admin options layout responsiveness

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-admin.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-admin.css
@@ -6,3 +6,32 @@
 #adminmenu .toplevel_page_discord-bot-jlg:hover .wp-menu-image img {
     opacity: 1 !important;
 }
+
+.discord-bot-settings-layout {
+    display: flex;
+    gap: 20px;
+    margin-top: 20px;
+    flex-wrap: wrap;
+    align-items: flex-start;
+}
+
+.discord-bot-settings-main {
+    flex: 1 1 420px;
+    min-width: 0;
+}
+
+.discord-bot-settings-sidebar {
+    flex: 0 0 300px;
+    max-width: 100%;
+}
+
+@media (max-width: 782px) {
+    .discord-bot-settings-layout {
+        flex-direction: column;
+    }
+
+    .discord-bot-settings-main,
+    .discord-bot-settings-sidebar {
+        flex: 1 1 100%;
+    }
+}

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -624,7 +624,7 @@ class Discord_Bot_JLG_Admin {
             <?php settings_errors('discord_stats_settings'); ?>
             <?php $this->handle_test_connection_request(); ?>
 
-            <div style="display: flex; gap: 20px; margin-top: 20px;">
+            <div class="discord-bot-settings-layout">
                 <?php
                 $this->render_options_form();
                 $this->render_options_sidebar();
@@ -663,7 +663,7 @@ class Discord_Bot_JLG_Admin {
      */
     private function render_options_form() {
         ?>
-        <div style="flex: 1;">
+        <div class="discord-bot-settings-main">
             <form action="options.php" method="post">
                 <?php
                 settings_fields('discord_stats_settings');
@@ -680,7 +680,7 @@ class Discord_Bot_JLG_Admin {
      */
     private function render_options_sidebar() {
         ?>
-        <div style="width: 300px;">
+        <div class="discord-bot-settings-sidebar">
             <?php
             $this->render_connection_test_panel();
             $this->render_quick_links_panel();


### PR DESCRIPTION
## Summary
- replace inline layout styling on the Discord bot settings page with semantic classes
- add admin stylesheet rules to control flex wrapping and responsive stacking below the WordPress breakpoint

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68dd0f038d20832e9dc1af1ee446cca9