### PR TITLE
Add ARIA live status to Discord statistics numbers

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -293,7 +293,7 @@ class Discord_Bot_JLG_Shortcode {
                         <?php if (!$hide_icons): ?>
                         <span class="discord-icon"><?php echo esc_html($atts['icon_online']); ?></span>
                         <?php endif; ?>
-                        <span class="discord-number"><?php echo esc_html(number_format_i18n((int) $stats['online'])); ?></span>
+                        <span class="discord-number" role="status" aria-live="polite"><?php echo esc_html(number_format_i18n((int) $stats['online'])); ?></span>
                         <?php if (!$hide_labels): ?>
                         <span class="discord-label"><?php echo esc_html($atts['label_online']); ?></span>
                         <?php endif; ?>
@@ -328,7 +328,7 @@ class Discord_Bot_JLG_Shortcode {
                         <?php if (!$hide_icons): ?>
                         <span class="discord-icon"><?php echo esc_html($atts['icon_total']); ?></span>
                         <?php endif; ?>
-                        <span class="discord-number"><?php echo $has_total ? esc_html(number_format_i18n((int) $stats['total'])) : '&mdash;'; ?></span>
+                        <span class="discord-number" role="status" aria-live="polite"><?php echo $has_total ? esc_html(number_format_i18n((int) $stats['total'])) : '&mdash;'; ?></span>
                         <span class="discord-approx-indicator" aria-hidden="true"<?php echo $total_is_approximate ? '' : ' hidden'; ?>>≈</span>
                         <span class="<?php echo esc_attr(implode(' ', $label_classes)); ?>">
                             <span class="discord-label-text"><?php echo esc_html($has_total ? $atts['label_total'] : $label_unavailable); ?></span>

--- a/tests/js/discord-bot-jlg.test.js
+++ b/tests/js/discord-bot-jlg.test.js
@@ -52,6 +52,8 @@ function createContainer(options = {}) {
     online.className = 'discord-online';
     const onlineNumber = document.createElement('span');
     onlineNumber.className = 'discord-number';
+    onlineNumber.setAttribute('role', 'status');
+    onlineNumber.setAttribute('aria-live', 'polite');
     onlineNumber.textContent = '0';
     online.appendChild(onlineNumber);
 
@@ -64,6 +66,8 @@ function createContainer(options = {}) {
 
     const totalNumber = document.createElement('span');
     totalNumber.className = 'discord-number';
+    totalNumber.setAttribute('role', 'status');
+    totalNumber.setAttribute('aria-live', 'polite');
     totalNumber.textContent = '0';
 
     const totalLabelText = document.createElement('span');
@@ -200,6 +204,10 @@ describe('discord-bot-jlg integration', () => {
         );
         expect(onlineNumber.textContent).toBe('42');
         expect(totalNumber.textContent).toBe('128');
+        expect(onlineNumber.getAttribute('role')).toBe('status');
+        expect(onlineNumber.getAttribute('aria-live')).toBe('polite');
+        expect(totalNumber.getAttribute('role')).toBe('status');
+        expect(totalNumber.getAttribute('aria-live')).toBe('polite');
         expect(labelExtra.textContent).toBe('');
         expect(container.dataset.serverName).toBe('Test Server');
         expect(container.classList.contains('discord-stats-error')).toBe(false);


### PR DESCRIPTION
## Summary
- add role="status" and aria-live="polite" to the Discord stats number spans rendered by the shortcode
- ensure the Jest helper markup mirrors the new accessibility attributes and assert they persist after updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd0f045218832ebcfb477d9ba880a0