### PR TITLE
Ensure Discord shortcode width is responsive

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -1,5 +1,6 @@
 .discord-stats-container {
     margin: 20px 0;
+    max-width: 100%;
 }
 
 .discord-stats-wrapper {

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -178,7 +178,16 @@ class Discord_Bot_JLG_Shortcode {
             $validated_width = $this->validate_width_value($atts['width']);
 
             if ('' !== $validated_width) {
-                $style_declarations[] = 'width: ' . $validated_width;
+                $width_keyword_values = array('auto', 'fit-content', 'max-content', 'min-content');
+                $lower_width         = strtolower($validated_width);
+
+                if (!in_array($lower_width, $width_keyword_values, true)) {
+                    $style_declarations[] = 'width: 100%';
+                } else {
+                    $style_declarations[] = 'width: ' . $validated_width;
+                }
+
+                $style_declarations[] = 'max-width: ' . $validated_width;
             }
         }
 

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -61,7 +61,8 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         ));
 
         $this->assertStringContainsString('style="', $html);
-        $this->assertStringContainsString('width: min(100%, 50vw)', $html);
+        $this->assertStringContainsString('width: 100%', $html);
+        $this->assertStringContainsString('max-width: min(100%, 50vw)', $html);
     }
 
     public function test_render_shortcode_accepts_max_function_width() {
@@ -72,7 +73,8 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         ));
 
         $this->assertStringContainsString('style="', $html);
-        $this->assertStringContainsString('width: max(300px, var(--discord-width))', $html);
+        $this->assertStringContainsString('width: 100%', $html);
+        $this->assertStringContainsString('max-width: max(300px, var(--discord-width))', $html);
     }
 
     public function test_render_shortcode_accepts_clamp_function_width() {
@@ -83,6 +85,20 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         ));
 
         $this->assertStringContainsString('style="', $html);
-        $this->assertStringContainsString('width: clamp(200px, 50%, var(--max-width))', $html);
+        $this->assertStringContainsString('width: 100%', $html);
+        $this->assertStringContainsString('max-width: clamp(200px, 50%, var(--max-width))', $html);
+    }
+
+    public function test_render_shortcode_adds_max_width_and_fluid_width() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array(
+            'width' => '600px',
+        ));
+
+        $this->assertStringContainsString('style="', $html);
+        $this->assertStringContainsString('width: 100%', $html);
+        $this->assertStringContainsString('max-width: 600px', $html);
+        $this->assertStringContainsString('width: 100%; max-width: 600px', $html);
     }
 }


### PR DESCRIPTION
## Summary
- adjust shortcode inline styles to add a responsive max-width when a width attribute is provided
- add a stylesheet safeguard so the stats container never exceeds 100% width
- extend PHPUnit coverage to confirm the responsive width output

## Testing
- ⚠️ `phpunit --configuration phpunit.xml.dist` *(fails: phpunit is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd20a0096c832e882a2dd087000507