### PR TITLE
Clear fallback details when purging cache

### DIFF
--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -634,6 +634,7 @@ class Discord_Bot_JLG_API {
         $this->clear_client_rate_limits();
         $this->reset_runtime_cache();
         $this->flush_options_cache();
+        $this->clear_last_fallback_details();
     }
 
     private function get_runtime_cache_key($args) {

--- a/discord-bot-jlg/inc/class-discord-cli.php
+++ b/discord-bot-jlg/inc/class-discord-cli.php
@@ -98,6 +98,6 @@ class Discord_Bot_JLG_CLI {
      */
     public function clear_cache($args, $assoc_args) {
         $this->api->clear_all_cached_data();
-        \WP_CLI::success(__('Tous les caches Discord Bot JLG ont été vidés.', 'discord-bot-jlg'));
+        \WP_CLI::success(__('Tous les caches Discord Bot JLG et les traces de secours ont été vidés.', 'discord-bot-jlg'));
     }
 }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php
@@ -230,6 +230,24 @@ class Test_Discord_Bot_JLG_API extends TestCase {
         $this->assertFalse(get_option(Discord_Bot_JLG_API::LAST_FALLBACK_OPTION));
     }
 
+    public function test_clear_all_cached_data_removes_last_fallback_option() {
+        $option_name = 'discord_server_stats_options';
+        $cache_key   = 'discord_server_stats_cache';
+
+        update_option(
+            Discord_Bot_JLG_API::LAST_FALLBACK_OPTION,
+            array(
+                'timestamp' => time(),
+                'reason'    => 'Test reason',
+            )
+        );
+
+        $api = new Discord_Bot_JLG_API($option_name, $cache_key, 60);
+        $api->clear_all_cached_data();
+
+        $this->assertFalse(get_option(Discord_Bot_JLG_API::LAST_FALLBACK_OPTION));
+    }
+
     public function test_ajax_refresh_stats_returns_retry_after_with_uncached_fallback() {
         $option_name = 'discord_server_stats_options';
         $cache_key   = 'discord_server_stats_cache';


### PR DESCRIPTION
## Summary
- ensure purging cached data clears the last fallback option
- cover the fallback removal in the API PHPUnit suite
- document via WP-CLI feedback that fallback traces are cleared

## Testing
- not run (phpunit binary not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd209ddb9c832eacfa533e3b82f9f5