### PR TITLE
Ensure Discord stats block remains responsive

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -3,6 +3,8 @@
     --discord-gap: 20px;
     --discord-padding: 15px;
     --discord-radius: 8px;
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 .discord-stats-container .discord-stats-wrapper {

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -1,5 +1,7 @@
 .discord-stats-container {
     margin: 20px 0;
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 .discord-stats-wrapper {

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -178,7 +178,7 @@ class Discord_Bot_JLG_Shortcode {
             $validated_width = $this->validate_width_value($atts['width']);
 
             if ('' !== $validated_width) {
-                $style_declarations[] = 'width: ' . $validated_width;
+                $style_declarations[] = 'max-width: ' . $validated_width;
             }
         }
 


### PR DESCRIPTION
## Summary
- add responsive safeguards to the Discord stats container styles
- emit max-width instead of a fixed width when rendering the shortcode so custom widths stay fluid

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd2037e51c832e9e4fc2a859d96e4e