### PR TITLE
Handle browsers lacking fetch support for Discord auto-refresh

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -846,12 +846,35 @@
     }
 
     function initializeDiscordBot() {
-        if (typeof window.fetch !== 'function' || typeof window.FormData !== 'function') {
-            return;
-        }
-
         var config = window.discordBotJlg || {};
         globalConfig = config;
+        var missingFeatures = [];
+
+        if (typeof window.fetch !== 'function') {
+            missingFeatures.push('fetch');
+        }
+
+        if (typeof window.Promise !== 'function') {
+            missingFeatures.push('Promise');
+        }
+
+        if (typeof window.FormData !== 'function') {
+            missingFeatures.push('FormData');
+        }
+
+        if (missingFeatures.length) {
+            config.autoRefreshDisabled = true;
+
+            if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+                console.warn(
+                    'Discord Bot JLG auto-refresh disabled: missing browser APIs ('
+                    + missingFeatures.join(', ')
+                    + ').'
+                );
+            }
+
+            return;
+        }
 
         var requiresNonce = typeof config.requiresNonce === 'undefined'
             ? true

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -444,7 +444,7 @@ class Discord_Bot_JLG_Shortcode {
         wp_register_script(
             'discord-bot-jlg-frontend',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/js/discord-bot-jlg.js',
-            array(),
+            array('wp-polyfill', 'wp-api-fetch'),
             DISCORD_BOT_JLG_VERSION,
             true
         );

--- a/tests/js/discord-bot-jlg.test.js
+++ b/tests/js/discord-bot-jlg.test.js
@@ -141,10 +141,14 @@ describe('discord-bot-jlg integration', () => {
             setTimeoutSpy.mockRestore();
             setTimeoutSpy = null;
         }
+        if (typeof window.discordBotJlgInit === 'function') {
+            document.removeEventListener('DOMContentLoaded', window.discordBotJlgInit);
+        }
         delete global.fetch;
         delete window.fetch;
         delete global.FormData;
         delete window.FormData;
+        delete window.discordBotJlgInit;
         delete window.discordBotJlg;
         if (readyStateDescriptor) {
             Object.defineProperty(document, 'readyState', readyStateDescriptor);
@@ -372,6 +376,47 @@ describe('discord-bot-jlg integration', () => {
 
         const setTimeoutCalls = setTimeoutSpy.mock.calls;
         expect(setTimeoutCalls[setTimeoutCalls.length - 1][1]).toBe(15000);
+    });
+
+    test('auto refresh is disabled gracefully when required browser APIs are missing', () => {
+        createContainer();
+
+        window.discordBotJlg = {
+            ajaxUrl: 'https://example.com/wp-admin/admin-ajax.php',
+            nonce: 'nonce',
+            requiresNonce: true,
+            locale: 'en-US',
+            minRefreshInterval: '5'
+        };
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const originalPromise = window.Promise;
+
+        delete global.fetch;
+        delete window.fetch;
+        delete global.FormData;
+        delete window.FormData;
+        window.Promise = undefined;
+
+        try {
+            expect(() => loadScript()).not.toThrow();
+
+            const matchingCalls = warnSpy.mock.calls.filter((args) => {
+                return args.length && String(args[0]).indexOf('auto-refresh disabled') !== -1;
+            });
+
+            expect(matchingCalls.length).toBe(1);
+            expect(window.discordBotJlg.autoRefreshDisabled).toBe(true);
+            expect(setTimeoutSpy).not.toHaveBeenCalled();
+        } finally {
+            warnSpy.mockRestore();
+
+            if (typeof originalPromise === 'undefined') {
+                delete window.Promise;
+            } else {
+                window.Promise = originalPromise;
+            }
+        }
     });
 
     test('failed refresh clears inFlight flag and allows subsequent refresh', async () => {


### PR DESCRIPTION
## Summary
- add core script dependencies when registering the Discord frontend bundle
- guard the auto-refresh initialisation when modern browser APIs are missing and log a warning
- extend the Jest suite to cover the legacy no-fetch fallback path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd2034b17c832e919942fbc6ebac79