### PR TITLE
Sanitize custom CSS and extend shortcode tests

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -274,7 +274,7 @@ class Discord_Bot_JLG_Admin {
         }
 
         if (isset($input['custom_css'])) {
-            $sanitized['custom_css'] = sanitize_textarea_field($input['custom_css']);
+            $sanitized['custom_css'] = discord_bot_jlg_sanitize_custom_css($input['custom_css']);
         }
 
         return $sanitized;

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -423,8 +423,17 @@ class Discord_Bot_JLG_Shortcode {
         $this->register_assets();
 
         if (!self::$inline_css_added && is_array($options) && !empty($options['custom_css'])) {
-            wp_add_inline_style('discord-bot-jlg-inline', $options['custom_css']);
-            self::$inline_css_added = true;
+            $custom_css = discord_bot_jlg_sanitize_custom_css($options['custom_css']);
+
+            if (
+                '' !== $custom_css
+                && false === strpos($custom_css, '</')
+                && false === stripos($custom_css, '<script')
+                && false === stripos($custom_css, '<style')
+            ) {
+                wp_add_inline_style('discord-bot-jlg-inline', $custom_css);
+                self::$inline_css_added = true;
+            }
         }
 
         wp_enqueue_style('discord-bot-jlg');

--- a/discord-bot-jlg/inc/helpers.php
+++ b/discord-bot-jlg/inc/helpers.php
@@ -237,3 +237,40 @@ if (!function_exists('discord_bot_jlg_decrypt_secret')) {
         return $plaintext;
     }
 }
+
+if (!function_exists('discord_bot_jlg_sanitize_custom_css')) {
+    /**
+     * Sanitizes custom CSS by removing any HTML/JS tags while preserving CSS syntax.
+     *
+     * @param string $css Raw CSS provided by the user.
+     *
+     * @return string Sanitized CSS string safe to store.
+     */
+    function discord_bot_jlg_sanitize_custom_css($css) {
+        if (!is_string($css)) {
+            if (is_scalar($css)) {
+                $css = (string) $css;
+            } else {
+                return '';
+            }
+        }
+
+        if ('' === $css) {
+            return '';
+        }
+
+        $css = str_replace("\0", '', $css);
+
+        $css = preg_replace('#<\s*(script|style)[^>]*>.*?<\s*/\s*(?:script|style)\s*>#is', '', $css);
+        $css = preg_replace('#<!--.*?-->#s', '', $css);
+        $css = preg_replace('#<\?(?:php|=)?[\s\S]*?\?>#i', '', $css);
+
+        $css = strip_tags($css);
+
+        $css = preg_replace('#</[^>]*>#i', '', $css);
+
+        $css = str_ireplace(array('<script', '</script', '<style', '</style'), '', $css);
+
+        return trim($css);
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -81,7 +81,10 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
     }
 
     public function sanitize_options_data_provider(): array {
-        $sanitized_css = sanitize_textarea_field("body { color: red; }\n<script>alert('test');</script>");
+        $malicious_css     = "body { color: red; }\n<script>alert('test');</script>";
+        $sanitized_css     = discord_bot_jlg_sanitize_custom_css($malicious_css);
+        $media_query_css   = "@media (min-width: 600px) {\n  .wrapper > .item { color: red; }\n}\n";
+        $sanitized_media   = discord_bot_jlg_sanitize_custom_css($media_query_css);
 
         return array(
             'invalid-server-id' => array(
@@ -93,7 +96,7 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                     'show_total'   => '',
                     'widget_title' => ' <strong>Stats</strong> ',
                     'cache_duration' => '45',
-                    'custom_css'   => "body { color: red; }\n<script>alert('test');</script>",
+                    'custom_css'   => $malicious_css,
                 ),
                 array(
                     'server_id'    => '',
@@ -136,6 +139,22 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                 ),
                 array(
                     'cache_duration' => 450,
+                ),
+            ),
+            'custom-css-media-query-preserved' => array(
+                array(
+                    'custom_css' => $media_query_css,
+                ),
+                array(
+                    'custom_css' => $sanitized_media,
+                ),
+            ),
+            'custom-css-script-removed' => array(
+                array(
+                    'custom_css' => $malicious_css,
+                ),
+                array(
+                    'custom_css' => $sanitized_css,
                 ),
             ),
         );

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -8,35 +8,51 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
     protected function setUp(): void {
         parent::setUp();
         $GLOBALS['wp_test_options'] = array();
+        $GLOBALS['wp_test_registered_styles'] = array();
+        $GLOBALS['wp_test_enqueued_styles']   = array();
+        $GLOBALS['wp_test_inline_styles']     = array();
+        $GLOBALS['wp_test_registered_scripts'] = array();
+        $GLOBALS['wp_test_enqueued_scripts']   = array();
+        $GLOBALS['wp_test_localized_scripts']  = array();
+
+        $this->reset_shortcode_static_state();
     }
 
-    private function get_shortcode_instance() {
-        $api = new class {
-            public function get_plugin_options() {
-                return array(
-                    'show_online'   => true,
-                    'show_total'    => true,
-                    'widget_title'  => 'Mon serveur',
-                    'custom_css'    => '',
-                );
-            }
+    private function reset_shortcode_static_state() {
+        $reflection = new ReflectionClass(Discord_Bot_JLG_Shortcode::class);
+        foreach (array('assets_registered', 'inline_css_added', 'footer_hook_added') as $property_name) {
+            $property = $reflection->getProperty($property_name);
+            $property->setAccessible(true);
+            $property->setValue(null, false);
+        }
+    }
 
-            public function get_stats() {
-                return array(
-                    'online'             => 12,
-                    'total'              => 42,
-                    'has_total'          => true,
-                    'total_is_approximate' => false,
-                    'stale'              => false,
-                    'fallback_demo'      => false,
-                    'is_demo'            => false,
-                );
-            }
+    private function get_shortcode_instance($custom_css = '') {
+        $api = $this->getMockBuilder(Discord_Bot_JLG_API::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(array('get_plugin_options', 'get_stats', 'get_demo_stats'))
+            ->getMock();
 
-            public function get_demo_stats() {
-                return $this->get_stats();
-            }
-        };
+        $options = array(
+            'show_online'   => true,
+            'show_total'    => true,
+            'widget_title'  => 'Mon serveur',
+            'custom_css'    => $custom_css,
+        );
+
+        $stats = array(
+            'online'               => 12,
+            'total'                => 42,
+            'has_total'            => true,
+            'total_is_approximate' => false,
+            'stale'                => false,
+            'fallback_demo'        => false,
+            'is_demo'              => false,
+        );
+
+        $api->method('get_plugin_options')->willReturn($options);
+        $api->method('get_stats')->willReturn($stats);
+        $api->method('get_demo_stats')->willReturn($stats);
 
         return new Discord_Bot_JLG_Shortcode(DISCORD_BOT_JLG_OPTION_NAME, $api);
     }
@@ -100,5 +116,34 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertStringContainsString('width: 100%', $html);
         $this->assertStringContainsString('max-width: 600px', $html);
         $this->assertStringContainsString('width: 100%; max-width: 600px', $html);
+    }
+
+    public function test_enqueue_assets_preserves_media_query_css() {
+        $custom_css = "@media (min-width: 600px) {\n  .wrapper > .item { color: red; }\n}";
+        $shortcode = $this->get_shortcode_instance($custom_css);
+
+        $shortcode->render_shortcode(array());
+
+        $this->assertArrayHasKey('discord-bot-jlg-inline', $GLOBALS['wp_test_inline_styles']);
+        $this->assertNotEmpty($GLOBALS['wp_test_inline_styles']['discord-bot-jlg-inline']);
+
+        $injected_css = end($GLOBALS['wp_test_inline_styles']['discord-bot-jlg-inline']);
+        $this->assertSame(discord_bot_jlg_sanitize_custom_css($custom_css), $injected_css);
+    }
+
+    public function test_enqueue_assets_strips_script_payload_before_injection() {
+        $custom_css = "body { color: red; }\n<script>alert('hack');</script>";
+        $shortcode  = $this->get_shortcode_instance($custom_css);
+
+        $shortcode->render_shortcode(array());
+
+        $this->assertArrayHasKey('discord-bot-jlg-inline', $GLOBALS['wp_test_inline_styles']);
+        $this->assertNotEmpty($GLOBALS['wp_test_inline_styles']['discord-bot-jlg-inline']);
+
+        $injected_css = end($GLOBALS['wp_test_inline_styles']['discord-bot-jlg-inline']);
+
+        $this->assertSame(discord_bot_jlg_sanitize_custom_css($custom_css), $injected_css);
+        $this->assertStringNotContainsString('<script', $injected_css);
+        $this->assertStringNotContainsString('</', $injected_css);
     }
 }


### PR DESCRIPTION
## Summary
- add a helper that strips HTML/script tags from custom CSS while preserving valid CSS syntax
- reuse the sanitizer when saving options and before enqueueing inline styles in the shortcode
- extend PHPUnit coverage to assert safe media queries are kept and script payloads are cleaned

## Testing
- phpunit -c phpunit.xml.dist *(fails: phpunit not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd420e8028832e90a79a8eaf28bad9