### PR TITLE
Add invite button support to Discord stats displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ L'attribut optionnel `width` accepte uniquement des longueurs CSS valides comme 
 
 Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moins 10 secondes (10 000 ms). Toute valeur plus basse est automatiquement portée à 10 secondes pour éviter les erreurs 429 de Discord.
 
+Pour afficher un appel à l'action menant vers votre serveur, ajoutez `show_invite_button="true"`. Le libellé du bouton peut être personnalisé via `invite_label` et l'URL peut être forcée grâce à `invite_url`. Sans URL personnalisée, le plugin utilise automatiquement l'invitation instantanée exposée par l'API Discord lorsqu'elle est disponible.
+
 Les rafraîchissements publics (visiteurs non connectés) n'exigent plus de nonce WordPress ; seuls les administrateurs connectés utilisent un jeton de sécurité pour l'action AJAX `refresh_discord_stats`.
 
 ### Ré-initialisation manuelle du widget

--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -139,6 +139,77 @@
     font-size: 16px;
 }
 
+.discord-stats-container .discord-invite-cta {
+    margin-top: var(--discord-gap, 20px);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.discord-stats-container.discord-compact .discord-invite-cta {
+    margin-top: calc(var(--discord-gap, 20px) * 0.6);
+}
+
+.discord-stats-container.discord-align-center .discord-invite-cta {
+    justify-content: center;
+}
+
+.discord-stats-container.discord-align-right .discord-invite-cta {
+    justify-content: flex-end;
+}
+
+.discord-stats-container .discord-invite-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75em 1.5em;
+    border-radius: 999px;
+    background: #5865F2;
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.discord-stats-container.discord-theme-light .discord-invite-button {
+    background: #4752C4;
+    color: #ffffff;
+}
+
+.discord-stats-container.discord-theme-minimal .discord-invite-button {
+    background: currentColor;
+    color: inherit;
+}
+
+.discord-stats-container .discord-invite-button:hover {
+    background: #4752C4;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    transform: translateY(-1px);
+}
+
+.discord-stats-container.discord-theme-minimal .discord-invite-button:hover {
+    background: currentColor;
+}
+
+.discord-stats-container .discord-invite-button:focus,
+.discord-stats-container .discord-invite-button:focus-visible {
+    outline: 3px solid rgba(88, 101, 242, 0.45);
+    outline-offset: 2px;
+}
+
+.discord-stats-container.discord-theme-minimal .discord-invite-button:focus,
+.discord-stats-container.discord-theme-minimal .discord-invite-button:focus-visible {
+    outline-color: currentColor;
+}
+
+.discord-invite-button__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .discord-stats-container.discord-theme-dark .discord-stat {
     background: #2c2f33;
     color: #ffffff;

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -67,6 +67,62 @@
     justify-content: center;
 }
 
+.discord-stats-container .discord-invite-cta {
+    margin-top: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.discord-stats-container.discord-compact .discord-invite-cta {
+    margin-top: 12px;
+}
+
+.discord-stats-container.discord-align-center .discord-invite-cta {
+    justify-content: center;
+}
+
+.discord-stats-container.discord-align-right .discord-invite-cta {
+    justify-content: flex-end;
+}
+
+.discord-stats-container .discord-invite-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: #5865F2;
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: none;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.discord-stats-container .discord-invite-button:hover {
+    background: #4752C4;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    transform: translateY(-1px);
+}
+
+.discord-stats-container .discord-invite-button:focus,
+.discord-stats-container .discord-invite-button:focus-visible {
+    outline: 3px solid rgba(88, 101, 242, 0.45);
+    outline-offset: 2px;
+}
+
+.discord-stats-container .discord-invite-button:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.discord-invite-button__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
 @media (max-width: 600px) {
     .discord-stats-wrapper {
         flex-direction: column;

--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -72,7 +72,10 @@
         demo: false,
         show_discord_icon: false,
         discord_icon_position: 'left',
-        show_server_name: false
+        show_server_name: false,
+        show_invite_button: false,
+        invite_label: __('Rejoindre le serveur', 'discord-bot-jlg'),
+        invite_url: ''
     };
 
     function attributesToShortcode(attributes) {
@@ -188,6 +191,22 @@
                             value: attributes.discord_icon_position,
                             options: iconPositionOptions,
                             onChange: updateAttribute(setAttributes, 'discord_icon_position')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher le bouton d\'invitation', 'discord-bot-jlg'),
+                            checked: !!attributes.show_invite_button,
+                            onChange: updateAttribute(setAttributes, 'show_invite_button')
+                        }),
+                        !!attributes.show_invite_button && createElement(TextControl, {
+                            label: __('Texte du bouton', 'discord-bot-jlg'),
+                            value: attributes.invite_label,
+                            onChange: updateAttribute(setAttributes, 'invite_label')
+                        }),
+                        !!attributes.show_invite_button && createElement(TextControl, {
+                            label: __('URL d\'invitation personnalisée', 'discord-bot-jlg'),
+                            value: attributes.invite_url,
+                            onChange: updateAttribute(setAttributes, 'invite_url'),
+                            help: __('Laissez vide pour utiliser l\'invitation instantanée détectée automatiquement.', 'discord-bot-jlg')
                         }),
                         createElement(RangeControl, {
                             label: __('Rayon des bords (px)', 'discord-bot-jlg'),

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -122,6 +122,18 @@
         "show_server_name": {
             "type": "boolean",
             "default": false
+        },
+        "show_invite_button": {
+            "type": "boolean",
+            "default": false
+        },
+        "invite_label": {
+            "type": "string",
+            "default": "Rejoindre le serveur"
+        },
+        "invite_url": {
+            "type": "string",
+            "default": ""
         }
     }
 }

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -193,6 +193,7 @@ class Discord_Bot_JLG_API {
                             : (isset($bot_stats['server_name']) ? $bot_stats['server_name'] : ''),
                         'has_total'            => $has_total,
                         'total_is_approximate' => $total_approximate,
+                        'instant_invite'       => isset($widget_stats['instant_invite']) ? $widget_stats['instant_invite'] : '',
                     );
                 } elseif (false === $stats) {
                     $stats = $bot_stats;
@@ -1114,6 +1115,7 @@ class Discord_Bot_JLG_API {
             'fallback_demo'        => (bool) $is_fallback,
             'has_total'            => true,
             'total_is_approximate' => false,
+            'instant_invite'       => '',
         );
     }
 
@@ -1452,12 +1454,19 @@ class Discord_Bot_JLG_API {
 
         $server_name = isset($data['name']) ? $data['name'] : '';
 
+        $instant_invite = '';
+
+        if (!empty($data['instant_invite']) && is_string($data['instant_invite'])) {
+            $instant_invite = trim((string) $data['instant_invite']);
+        }
+
         $stats = array(
             'online'               => $online,
             'total'                => null,
             'server_name'          => $server_name,
             'has_total'            => false,
             'total_is_approximate' => false,
+            'instant_invite'       => $instant_invite,
         );
 
         if (isset($data['member_count'])) {
@@ -1757,6 +1766,26 @@ class Discord_Bot_JLG_API {
         if (!isset($stats['total_is_approximate'])) {
             $stats['total_is_approximate'] = false;
         }
+
+        $instant_invite = isset($stats['instant_invite']) ? $stats['instant_invite'] : '';
+
+        if (!is_string($instant_invite)) {
+            $instant_invite = '';
+        }
+
+        $instant_invite = trim($instant_invite);
+
+        if ('' !== $instant_invite && function_exists('esc_url_raw')) {
+            $sanitized_invite = esc_url_raw($instant_invite);
+
+            if (is_string($sanitized_invite)) {
+                $instant_invite = $sanitized_invite;
+            } else {
+                $instant_invite = '';
+            }
+        }
+
+        $stats['instant_invite'] = $instant_invite;
 
         return $stats;
     }

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -75,6 +75,7 @@ class Discord_Stats_Widget extends WP_Widget {
             'theme'                => $theme,
             'refresh'              => !empty($instance['refresh']) ? 'true' : 'false',
             'show_title'           => !empty($instance['show_card_title']) ? 'true' : 'false',
+            'show_invite_button'   => !empty($instance['show_invite_button']) ? 'true' : 'false',
         );
 
         if (!empty($instance['refresh'])) {
@@ -83,6 +84,16 @@ class Discord_Stats_Widget extends WP_Widget {
 
         if (!empty($instance['show_card_title'])) {
             $shortcode_atts['title'] = $card_title;
+        }
+
+        if (!empty($instance['show_invite_button'])) {
+            if (!empty($instance['invite_label'])) {
+                $shortcode_atts['invite_label'] = $instance['invite_label'];
+            }
+
+            if (!empty($instance['invite_url'])) {
+                $shortcode_atts['invite_url'] = $instance['invite_url'];
+            }
         }
 
         $attr_parts = array();
@@ -138,6 +149,23 @@ class Discord_Stats_Widget extends WP_Widget {
 
         $instance['show_card_title'] = !empty($new_instance['show_card_title']) ? 1 : 0;
         $instance['card_title']      = isset($new_instance['card_title']) ? sanitize_text_field($new_instance['card_title']) : '';
+
+        $instance['show_invite_button'] = !empty($new_instance['show_invite_button']) ? 1 : 0;
+        $instance['invite_label']       = isset($new_instance['invite_label']) ? sanitize_text_field($new_instance['invite_label']) : '';
+
+        $instance['invite_url'] = '';
+        if (isset($new_instance['invite_url'])) {
+            $raw_url = trim((string) $new_instance['invite_url']);
+
+            if ('' !== $raw_url) {
+                if (function_exists('esc_url_raw')) {
+                    $sanitized_url = esc_url_raw($raw_url);
+                    $instance['invite_url'] = is_string($sanitized_url) ? $sanitized_url : '';
+                } else {
+                    $instance['invite_url'] = $raw_url;
+                }
+            }
+        }
 
         return $instance;
     }
@@ -249,6 +277,27 @@ class Discord_Stats_Widget extends WP_Widget {
                    name="<?php echo esc_attr($this->get_field_name('card_title')); ?>" type="text"
                    value="<?php echo esc_attr($instance['card_title']); ?>" />
         </p>
+
+        <p>
+            <input type="checkbox" id="<?php echo esc_attr($this->get_field_id('show_invite_button')); ?>"
+                   name="<?php echo esc_attr($this->get_field_name('show_invite_button')); ?>" value="1" <?php checked($instance['show_invite_button'], 1); ?> />
+            <label for="<?php echo esc_attr($this->get_field_id('show_invite_button')); ?>"><?php esc_html_e('Afficher un bouton d\'invitation', 'discord-bot-jlg'); ?></label>
+        </p>
+
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('invite_label')); ?>"><?php esc_html_e('Texte du bouton', 'discord-bot-jlg'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('invite_label')); ?>"
+                   name="<?php echo esc_attr($this->get_field_name('invite_label')); ?>" type="text"
+                   value="<?php echo esc_attr($instance['invite_label']); ?>" />
+        </p>
+
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('invite_url')); ?>"><?php esc_html_e('URL d\'invitation personnalisée', 'discord-bot-jlg'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('invite_url')); ?>"
+                   name="<?php echo esc_attr($this->get_field_name('invite_url')); ?>" type="url"
+                   value="<?php echo esc_attr($instance['invite_url']); ?>" />
+            <span class="description"><?php esc_html_e('Laissez vide pour utiliser l\'invitation instantanée fournie par Discord.', 'discord-bot-jlg'); ?></span>
+        </p>
         <?php
     }
 
@@ -288,6 +337,9 @@ class Discord_Stats_Widget extends WP_Widget {
             'refresh_interval'     => $cache_duration,
             'show_card_title'      => 0,
             'card_title'           => '',
+            'show_invite_button'   => 0,
+            'invite_label'         => '',
+            'invite_url'           => '',
         );
     }
 }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -30,6 +30,7 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
                     'stale'              => false,
                     'fallback_demo'      => false,
                     'is_demo'            => false,
+                    'instant_invite'     => 'https://discord.gg/example',
                 );
             }
 
@@ -100,5 +101,19 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertStringContainsString('width: 100%', $html);
         $this->assertStringContainsString('max-width: 600px', $html);
         $this->assertStringContainsString('width: 100%; max-width: 600px', $html);
+    }
+
+    public function test_render_shortcode_outputs_invite_button_when_enabled() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array(
+            'show_invite_button' => 'true',
+            'invite_label'       => '<strong>Rejoindre</strong>',
+        ));
+
+        $this->assertStringContainsString('discord-invite-button', $html);
+        $this->assertStringContainsString('role="button"', $html);
+        $this->assertStringContainsString('href="https://discord.gg/example"', $html);
+        $this->assertStringContainsString('>Rejoindre<', $html);
     }
 }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
@@ -45,4 +45,30 @@ class Test_Discord_Stats_Widget extends TestCase {
         $this->assertNotNull($GLOBALS['discord_bot_jlg_last_shortcode']);
         $this->assertStringContainsString('theme="minimal"', $GLOBALS['discord_bot_jlg_last_shortcode']);
     }
+
+    public function test_widget_shortcode_includes_invite_button_attributes() {
+        $widget = new Discord_Stats_Widget();
+
+        $args = array(
+            'before_widget' => '',
+            'after_widget'  => '',
+            'before_title'  => '',
+            'after_title'   => '',
+        );
+
+        $instance = array(
+            'show_invite_button' => 1,
+            'invite_label'       => 'Rejoignez-nous',
+            'invite_url'         => 'https://discord.gg/widget',
+        );
+
+        ob_start();
+        $widget->widget($args, $instance);
+        ob_end_clean();
+
+        $this->assertNotNull($GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('show_invite_button="true"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('invite_label="Rejoignez-nous"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('invite_url="https://discord.gg/widget"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+    }
 }

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -73,6 +73,32 @@ if (!function_exists('esc_attr')) {
     }
 }
 
+if (!function_exists('esc_url_raw')) {
+    function esc_url_raw($url, $protocols = null) {
+        if (!is_string($url)) {
+            return '';
+        }
+
+        $url = trim($url);
+
+        if ('' === $url) {
+            return '';
+        }
+
+        $sanitized = filter_var($url, FILTER_VALIDATE_URL);
+
+        return false === $sanitized ? '' : $sanitized;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($url, $protocols = null, $_context = 'display') {
+        $sanitized = esc_url_raw($url, $protocols);
+
+        return is_string($sanitized) ? $sanitized : '';
+    }
+}
+
 if (!function_exists('do_shortcode')) {
     function do_shortcode($shortcode) {
         $GLOBALS['discord_bot_jlg_last_shortcode'] = $shortcode;
@@ -230,7 +256,14 @@ function sanitize_text_field($value) {
         return array_map('sanitize_text_field', $value);
     }
 
-    return is_string($value) ? trim($value) : $value;
+    if (!is_string($value)) {
+        return $value;
+    }
+
+    $value = strip_tags($value);
+    $value = preg_replace('/[\r\n\t ]+/', ' ', $value);
+
+    return trim($value);
 }
 
 function sanitize_key($key) {


### PR DESCRIPTION
## Summary
- surface the Discord widget instant invite in the API stats payload and normalize it for downstream consumers
- add shortcode, block, and widget options for rendering an invite call-to-action with accessible markup and updated styling
- document the new attributes and cover the invite button behaviour with PHPUnit tests

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4216a0a8832eb3a1aeea90508357