### PR TITLE
Add WordPress-style screen reader fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moi
 
 Les rafraîchissements publics (visiteurs non connectés) n'exigent plus de nonce WordPress ; seuls les administrateurs connectés utilisent un jeton de sécurité pour l'action AJAX `refresh_discord_stats`.
 
+### Accessibilité
+
+Le plugin embarque sa propre définition `.screen-reader-text`, incluse à la fois dans les feuilles de style principales et inline chargées par le shortcode. Ce fallback reprend le pattern WordPress (position absolue, dimensions réduites à 1px, `clip-path: inset(50%)`, etc.) afin que les libellés masqués restent interprétables par les lecteurs d'écran même si le thème actif ne fournit pas cette classe utilitaire.
+
 ### Ré-initialisation manuelle du widget
 
 Si vous chargez dynamiquement du HTML contenant de nouveaux conteneurs `.discord-stats-container`, vous pouvez relancer l'initialisation automatique en appelant l'API publique exposée par le script côté client :

--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -12,6 +12,36 @@
     --discord-badge-scale: 1;
 }
 
+.screen-reader-text {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
+.screen-reader-text:focus {
+    position: static !important;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 15px 23px 14px;
+    clip: auto;
+    clip-path: none;
+    overflow: visible;
+    white-space: normal;
+    border-radius: 3px;
+    background: #1d2327;
+    color: #f1f1f1;
+    z-index: 100000;
+    box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+}
+
 .discord-stats-container .discord-stats-wrapper {
     gap: var(--discord-gap);
 }

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -10,6 +10,36 @@
     --discord-label-size: clamp(12px, 2.6vw, 16px);
 }
 
+.screen-reader-text {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
+.screen-reader-text:focus {
+    position: static !important;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 15px 23px 14px;
+    clip: auto;
+    clip-path: none;
+    overflow: visible;
+    white-space: normal;
+    border-radius: 3px;
+    background: #1d2327;
+    color: #f1f1f1;
+    z-index: 100000; /* Above WP toolbar. */
+    box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+}
+
 .discord-stats-wrapper {
     display: flex;
     gap: var(--discord-gap);


### PR DESCRIPTION
## Summary
- add a WordPress-style `.screen-reader-text` helper to both shipped stylesheets so labels remain accessible without theme support
- document the accessibility fallback in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd6987f55c832e9ea4206430cbc783