### PR TITLE
Normalize refresh interval control

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Pour activer l'auto-actualisation, utilisez par exemple :
 
 L'attribut optionnel `width` accepte uniquement des longueurs CSS valides comme `320px`, `75%`, `42rem`, ainsi que les mots-clés `auto`, `fit-content`, `min-content` et `max-content`. Les expressions `calc(...)` sont prises en charge lorsqu'elles ne contiennent que des nombres, des unités usuelles et les opérateurs arithmétiques de base. Toute valeur non conforme est ignorée afin d'éviter l'injection de styles indésirables.
 
-Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moins 10 secondes (10 000 ms). Toute valeur plus basse est automatiquement portée à 10 secondes pour éviter les erreurs 429 de Discord. L’interface du bloc Gutenberg impose également cette limite via un curseur (pas de saisie libre en dessous de 10).
+Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moins 10 secondes (10 000 ms). Toute valeur plus basse est automatiquement portée à 10 secondes pour éviter les erreurs 429 de Discord. L’interface du bloc Gutenberg impose également cette limite via un champ numérique (incréments de 5, valeur minimale : 10).
 
 Pendant une requête d'actualisation, le conteneur affiche désormais un indicateur d'état (`role="status"`) et applique l'attribut `data-refreshing="true"`. Cela réduit temporairement l'opacité des statistiques et signale l'opération en cours, avant de revenir automatiquement à l'état normal (attribut `data-refreshing="false"`).
 

--- a/tests/js/discord-bot-jlg.test.js
+++ b/tests/js/discord-bot-jlg.test.js
@@ -839,7 +839,8 @@ describe('discord-bot-jlg block editor', () => {
                 ToggleControl: function ToggleControl() { return null; },
                 TextControl: function TextControl() { return null; },
                 SelectControl: function SelectControl() { return null; },
-                RangeControl: function RangeControl() { return null; }
+                RangeControl: function RangeControl() { return null; },
+                NumberControl: function NumberControl() { return null; }
             },
             blockEditor: {
                 InspectorControls: function InspectorControls() { return null; },
@@ -870,7 +871,7 @@ describe('discord-bot-jlg block editor', () => {
         const shortcode = settings.save({
             attributes: {
                 refresh: true,
-                refresh_interval: '5'
+                refresh_interval: 5
             }
         });
 


### PR DESCRIPTION
## Summary
- switch the refresh interval inspector field to a numeric control and clamp the value between 10s and 1h
- centralize refresh interval normalisation so saved attributes and UI both enforce the backend limits
- document the constraint in the README and adjust the block test to cover numeric values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd7ef1d5d8832eab2ac1efa5d7268e