### PR TITLE
Add invite button support to Discord stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Accédez à la page **Discord Bot** dans l’administration pour :
 - Saisir le token de votre bot Discord ;
 - Indiquer l’ID du serveur à surveiller ;
 - Définir la durée du cache des statistiques ;
+- Activer et personnaliser le bouton d’invitation ;
 - Ajouter du CSS personnalisé.
 
 ### Définir le token via une constante
@@ -45,6 +46,11 @@ Le callback reçoit la valeur par défaut (1 048 576), l’URL ciblée et le c
 ```
 Options disponibles : `layout`, `theme`, `demo`, `refresh`, etc.
 
+Nouveaux attributs utiles pour l’invitation :
+
+- `show_invite_button="true"` affiche un bouton « Rejoindre » lorsque le widget Discord expose un lien `instant_invite`.
+- `invite_label="Rejoindre notre communauté"` remplace le libellé par défaut du bouton.
+
 Pour activer l'auto-actualisation, utilisez par exemple :
 
 ```
@@ -58,6 +64,8 @@ Le paramètre `refresh_interval` est exprimé en secondes et doit être d'au moi
 Pendant une requête d'actualisation, le conteneur affiche désormais un indicateur d'état (`role="status"`) et applique l'attribut `data-refreshing="true"`. L'opacité des statistiques diminue légèrement, les interactions sont bloquées et une pastille sombre (contraste élevé) accompagnée d'un spinner discret signalent l'opération. Dès que la réponse est reçue — succès ou erreur — l'indicateur est retiré et `data-refreshing` repasse automatiquement à `false`. L'animation est désactivée lorsque le visiteur préfère réduire les mouvements (`prefers-reduced-motion`).
 
 Les rafraîchissements publics (visiteurs non connectés) n'exigent plus de nonce WordPress ; seuls les administrateurs connectés utilisent un jeton de sécurité pour l'action AJAX `refresh_discord_stats`.
+
+Chaque clic sur le bouton d’invitation déclenche également l’évènement `discordBotJlg:inviteClick` sur `window`, ce qui facilite l’intégration avec vos outils d’analytics ou de tracking.
 
 ### Accessibilité
 
@@ -80,6 +88,7 @@ Un widget « Discord Bot - JLG » est disponible via le menu « Widgets ».
 
 ## Fonctionnalités
 - Affichage du nombre de membres en ligne et du total ;
+- Bouton d’invitation optionnel avec libellé personnalisable ;
 - Mise en cache des statistiques ;
 - Journalisation des erreurs de communication avec l'API Discord (accessible via `WP_DEBUG_LOG`) ;
 - Page de démonstration intégrée.

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -118,6 +118,54 @@
     justify-content: center;
 }
 
+.discord-invite-action {
+    margin-top: var(--discord-gap, 20px);
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--discord-gap, 20px) * 0.5);
+}
+
+.discord-align-center .discord-invite-action {
+    justify-content: center;
+}
+
+.discord-align-right .discord-invite-action {
+    justify-content: flex-end;
+}
+
+.discord-invite-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    padding: 0.65em 1.4em;
+    border-radius: calc(var(--discord-radius, 8px) * 1.1);
+    background: #5865f2;
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: clamp(14px, 3vw, 16px);
+    box-shadow: 0 6px 12px rgba(88, 101, 242, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    position: relative;
+}
+
+.discord-invite-button:hover,
+.discord-invite-button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(88, 101, 242, 0.45);
+    background: #4752c4;
+}
+
+.discord-invite-button:focus-visible {
+    outline: 3px solid #ffd37a;
+    outline-offset: 3px;
+}
+
+.discord-invite-button__label {
+    line-height: 1.3;
+}
+
 @media (max-width: 600px) {
     .discord-stats-container {
         --discord-gap: clamp(10px, 5vw, 16px);

--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -74,7 +74,9 @@
         demo: false,
         show_discord_icon: false,
         discord_icon_position: 'left',
-        show_server_name: false
+        show_server_name: false,
+        show_invite_button: false,
+        invite_label: ''
     };
 
     var REFRESH_INTERVAL_MIN = 10;
@@ -293,6 +295,17 @@
                             label: __('Afficher le nom du serveur', 'discord-bot-jlg'),
                             checked: !!attributes.show_server_name,
                             onChange: updateAttribute(setAttributes, 'show_server_name')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher le bouton d\'invitation', 'discord-bot-jlg'),
+                            checked: !!attributes.show_invite_button,
+                            onChange: updateAttribute(setAttributes, 'show_invite_button')
+                        }),
+                        !!attributes.show_invite_button && createElement(TextControl, {
+                            label: __('Libellé du bouton d\'invitation', 'discord-bot-jlg'),
+                            value: attributes.invite_label,
+                            onChange: updateAttribute(setAttributes, 'invite_label'),
+                            placeholder: __('Rejoindre le serveur', 'discord-bot-jlg')
                         })
                     ),
                     createElement(

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -122,6 +122,14 @@
         "show_server_name": {
             "type": "boolean",
             "default": false
+        },
+        "show_invite_button": {
+            "type": "boolean",
+            "default": false
+        },
+        "invite_label": {
+            "type": "string",
+            "default": ""
         }
     }
 }

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -133,6 +133,22 @@ class Discord_Bot_JLG_Admin {
         );
 
         add_settings_field(
+            'show_invite_button',
+            __('Afficher le bouton d\'invitation', 'discord-bot-jlg'),
+            array($this, 'show_invite_button_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
+            'invite_button_label',
+            __('Libellé du bouton d\'invitation', 'discord-bot-jlg'),
+            array($this, 'invite_button_label_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
             'widget_title',
             __('Titre du widget', 'discord-bot-jlg'),
             array($this, 'widget_title_render'),
@@ -185,6 +201,10 @@ class Discord_Bot_JLG_Admin {
                 ? (int) $current_options['cache_duration']
                 : 300,
             'custom_css'     => '',
+            'show_invite_button' => 0,
+            'invite_button_label' => isset($current_options['invite_button_label'])
+                ? sanitize_text_field($current_options['invite_button_label'])
+                : '',
         );
 
         if (isset($input['server_id'])) {
@@ -246,9 +266,14 @@ class Discord_Bot_JLG_Admin {
         $sanitized['demo_mode']   = !empty($input['demo_mode']) ? 1 : 0;
         $sanitized['show_online'] = !empty($input['show_online']) ? 1 : 0;
         $sanitized['show_total']  = !empty($input['show_total']) ? 1 : 0;
+        $sanitized['show_invite_button'] = !empty($input['show_invite_button']) ? 1 : 0;
 
         if (isset($input['widget_title'])) {
             $sanitized['widget_title'] = sanitize_text_field($input['widget_title']);
+        }
+
+        if (array_key_exists('invite_button_label', $input)) {
+            $sanitized['invite_button_label'] = sanitize_text_field($input['invite_button_label']);
         }
 
         if (array_key_exists('cache_duration', $input)) {
@@ -558,6 +583,36 @@ class Discord_Bot_JLG_Admin {
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_total]"
                value="1" <?php checked($value, 1); ?> />
         <label><?php esc_html_e('Afficher le nombre total de membres', 'discord-bot-jlg'); ?></label>
+        <?php
+    }
+
+    /**
+     * Rend la case à cocher pour activer l'affichage du bouton d'invitation.
+     *
+     * @return void
+     */
+    public function show_invite_button_render() {
+        $options = get_option($this->option_name);
+        $value   = isset($options['show_invite_button']) ? (int) $options['show_invite_button'] : 0;
+        ?>
+        <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_invite_button]"
+               value="1" <?php checked($value, 1); ?> />
+        <label><?php esc_html_e('Afficher un bouton d\'invitation si un lien est disponible', 'discord-bot-jlg'); ?></label>
+        <?php
+    }
+
+    /**
+     * Rend le champ texte configurant le libellé du bouton d'invitation.
+     *
+     * @return void
+     */
+    public function invite_button_label_render() {
+        $options = get_option($this->option_name);
+        $value   = isset($options['invite_button_label']) ? $options['invite_button_label'] : '';
+        ?>
+        <input type="text" name="<?php echo esc_attr($this->option_name); ?>[invite_button_label]"
+               value="<?php echo esc_attr($value); ?>" class="regular-text" />
+        <p class="description"><?php esc_html_e('Texte affiché sur le bouton d\'invitation.', 'discord-bot-jlg'); ?></p>
         <?php
     }
 

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -58,6 +58,8 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             'demo_mode'      => 1,
             'show_online'    => 1,
             'show_total'     => 1,
+            'show_invite_button' => 1,
+            'invite_button_label' => 'Rejoins-nous !',
             'widget_title'   => 'Existing title',
             'cache_duration' => 450,
             'custom_css'     => '.existing { color: blue; }',
@@ -155,6 +157,16 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                 ),
                 array(
                     'custom_css' => $sanitized_css,
+                ),
+            ),
+            'invite-button-options' => array(
+                array(
+                    'show_invite_button'   => '1',
+                    'invite_button_label'  => '  <strong>Rejoindre</strong> ',
+                ),
+                array(
+                    'show_invite_button'   => 1,
+                    'invite_button_label'  => sanitize_text_field('  <strong>Rejoindre</strong> '),
                 ),
             ),
         );
@@ -360,12 +372,14 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             'demo_mode'      => 0,
             'show_online'    => 0,
             'show_total'     => 0,
+            'show_invite_button' => 0,
             'widget_title'   => '',
             'cache_duration' => max(
                 Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
                 min(3600, (int) $this->saved_options['cache_duration'])
             ),
             'custom_css'     => '',
+            'invite_button_label' => sanitize_text_field($this->saved_options['invite_button_label']),
         );
     }
 }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -38,6 +38,8 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
             'show_total'    => true,
             'widget_title'  => 'Mon serveur',
             'custom_css'    => $custom_css,
+            'show_invite_button' => true,
+            'invite_button_label' => 'Rejoindre',
         );
 
         $stats = array(
@@ -48,6 +50,8 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
             'stale'                => false,
             'fallback_demo'        => false,
             'is_demo'              => false,
+            'instant_invite'       => 'https://discord.gg/example',
+            'invite_label'         => 'Rejoindre le serveur',
         );
 
         $api->method('get_plugin_options')->willReturn($options);
@@ -116,6 +120,25 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertStringContainsString('width: 100%', $html);
         $this->assertStringContainsString('max-width: 600px', $html);
         $this->assertStringContainsString('width: 100%; max-width: 600px', $html);
+    }
+
+    public function test_render_shortcode_outputs_invite_button_when_enabled() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array());
+
+        $this->assertStringContainsString('<a class="discord-invite-button"', $html);
+        $this->assertStringContainsString('https://discord.gg/example', $html);
+    }
+
+    public function test_render_shortcode_hides_invite_button_when_disabled() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array(
+            'show_invite_button' => 'false',
+        ));
+
+        $this->assertStringNotContainsString('<a class="discord-invite-button"', $html);
     }
 
     public function test_enqueue_assets_preserves_media_query_css() {


### PR DESCRIPTION
## Summary
- expose widget invite metadata through the API and normalization helpers so stats payloads carry the invite URL and label
- add shortcode, block, and admin options to toggle an invite button with configurable text, and render the styled button when available
- style and wire the invite button on the frontend, including analytics-friendly events and updated documentation/tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd9193ad30832e9df576a813811db9