### PR TITLE
Add Site Health status check for Discord Bot JLG

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -135,6 +135,7 @@ require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-api.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-admin.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-shortcode.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-widget.php';
+require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-site-health.php';
 
 if (defined('WP_CLI') && WP_CLI) {
     require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-cli.php';
@@ -165,6 +166,7 @@ class DiscordServerStats {
     private $admin;
     private $shortcode;
     private $widget;
+    private $site_health;
 
     public function __construct() {
         $this->default_options = discord_bot_jlg_get_default_options();
@@ -173,6 +175,7 @@ class DiscordServerStats {
         $this->admin     = new Discord_Bot_JLG_Admin(DISCORD_BOT_JLG_OPTION_NAME, $this->api);
         $this->shortcode = new Discord_Bot_JLG_Shortcode(DISCORD_BOT_JLG_OPTION_NAME, $this->api);
         $this->widget    = new Discord_Bot_JLG_Widget();
+        $this->site_health = new Discord_Bot_JLG_Site_Health($this->api);
 
         add_filter('default_option_' . DISCORD_BOT_JLG_OPTION_NAME, array($this, 'provide_default_options'));
         add_filter('option_' . DISCORD_BOT_JLG_OPTION_NAME, array($this, 'merge_options_with_defaults'));

--- a/discord-bot-jlg/inc/class-discord-site-health.php
+++ b/discord-bot-jlg/inc/class-discord-site-health.php
@@ -1,0 +1,157 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Discord_Bot_JLG_Site_Health {
+
+    /**
+     * @var Discord_Bot_JLG_API
+     */
+    private $api;
+
+    /**
+     * Initialise le test de santé du site.
+     *
+     * @param Discord_Bot_JLG_API $api Instance utilisée pour vérifier l'état du plugin.
+     */
+    public function __construct(Discord_Bot_JLG_API $api) {
+        $this->api = $api;
+
+        add_filter('site_status_tests', array($this, 'register_tests'));
+    }
+
+    /**
+     * Enregistre le test dans le tableau des vérifications de santé WordPress.
+     *
+     * @param array $tests
+     *
+     * @return array
+     */
+    public function register_tests($tests) {
+        if (!is_array($tests)) {
+            $tests = array();
+        }
+
+        if (!isset($tests['direct']) || !is_array($tests['direct'])) {
+            $tests['direct'] = array();
+        }
+
+        $tests['direct']['discord_bot_jlg'] = array(
+            'label' => __('Statut du bot Discord', 'discord-bot-jlg'),
+            'test'  => array($this, 'run_site_health_test'),
+        );
+
+        return $tests;
+    }
+
+    /**
+     * Fournit le diagnostic affiché dans Site Health.
+     *
+     * @return array
+     */
+    public function run_site_health_test() {
+        $result = array(
+            'label'       => __('Statut du bot Discord', 'discord-bot-jlg'),
+            'status'      => 'good',
+            'badge'       => array(
+                'label' => __('Discord Bot JLG', 'discord-bot-jlg'),
+                'color' => 'blue',
+            ),
+            'description' => '',
+            'test'        => 'discord_bot_jlg_site_health',
+        );
+
+        $options = $this->api->get_plugin_options();
+        if (!is_array($options)) {
+            $options = array();
+        }
+
+        $server_id = isset($options['server_id']) ? trim((string) $options['server_id']) : '';
+        $demo_mode = !empty($options['demo_mode']);
+
+        if ('' === $server_id && false === $demo_mode) {
+            $result['status'] = 'critical';
+            $result['description'] = '<p>' . esc_html__("Aucun identifiant de serveur Discord n'est configuré. Veuillez renseigner vos identifiants dans les réglages du plugin.", 'discord-bot-jlg') . '</p>';
+
+            return $result;
+        }
+
+        if ($demo_mode) {
+            $result['status'] = 'recommended';
+            $result['description'] = '<p>' . esc_html__('Le plugin fonctionne actuellement en mode démonstration ; les données affichées ne proviennent pas de votre serveur Discord.', 'discord-bot-jlg') . '</p>';
+
+            return $result;
+        }
+
+        $fallback_details = $this->api->get_last_fallback_details();
+        if (is_array($fallback_details) && !empty($fallback_details)) {
+            $timestamp = isset($fallback_details['timestamp']) ? (int) $fallback_details['timestamp'] : 0;
+            if ($timestamp <= 0) {
+                $timestamp = current_time('timestamp', true);
+            }
+
+            $date_format = get_option('date_format');
+            if (!is_string($date_format) || '' === trim($date_format)) {
+                $date_format = 'Y-m-d';
+            }
+
+            $time_format = get_option('time_format');
+            if (!is_string($time_format) || '' === trim($time_format)) {
+                $time_format = 'H:i';
+            }
+
+            $formatted_time = discord_bot_jlg_format_datetime($date_format . ' ' . $time_format, $timestamp);
+
+            $message_parts = array(
+                sprintf(
+                    esc_html__('Statistiques de secours utilisées depuis le %s.', 'discord-bot-jlg'),
+                    esc_html($formatted_time)
+                ),
+            );
+
+            $reason = isset($fallback_details['reason']) ? trim((string) $fallback_details['reason']) : '';
+            if ('' !== $reason) {
+                $message_parts[] = sprintf(
+                    esc_html__('Dernière erreur signalée : %s.', 'discord-bot-jlg'),
+                    esc_html($reason)
+                );
+            }
+
+            $next_retry = isset($fallback_details['next_retry']) ? (int) $fallback_details['next_retry'] : 0;
+            if ($next_retry > 0) {
+                $retry_time = discord_bot_jlg_format_datetime($date_format . ' ' . $time_format, $next_retry);
+                $message_parts[] = sprintf(
+                    esc_html__('Nouvelle tentative planifiée vers %s.', 'discord-bot-jlg'),
+                    esc_html($retry_time)
+                );
+            } else {
+                $message_parts[] = esc_html__('Une nouvelle tentative sera effectuée automatiquement dès que possible.', 'discord-bot-jlg');
+            }
+
+            $result['status'] = 'recommended';
+            $result['description'] = '<p>' . implode(' ', $message_parts) . '</p>';
+
+            return $result;
+        }
+
+        $last_error = trim((string) $this->api->get_last_error_message());
+        if ('' !== $last_error) {
+            $result['status'] = 'recommended';
+            $result['description'] = sprintf(
+                '<p>%s</p>',
+                sprintf(
+                    esc_html__('Dernière erreur rencontrée : %s.', 'discord-bot-jlg'),
+                    esc_html($last_error)
+                )
+            );
+
+            return $result;
+        }
+
+        $result['description'] = '<p>' . esc_html__('La connexion au serveur Discord fonctionne normalement.', 'discord-bot-jlg') . '</p>';
+
+        return $result;
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Site_Health.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Site_Health.php
@@ -1,0 +1,153 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class Discord_Bot_JLG_API_Site_Health_Stub extends Discord_Bot_JLG_API {
+    private $mock_last_error;
+    private $has_mock_last_error = false;
+
+    public function set_mock_last_error_message($message) {
+        $this->mock_last_error     = $message;
+        $this->has_mock_last_error = true;
+    }
+
+    public function get_last_error_message() {
+        if (true === $this->has_mock_last_error) {
+            return $this->mock_last_error;
+        }
+
+        return parent::get_last_error_message();
+    }
+}
+
+class Test_Discord_Bot_JLG_Site_Health extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $GLOBALS['wp_test_options']    = array();
+        $GLOBALS['wp_test_transients'] = array();
+        $GLOBALS['wp_test_current_timestamp'] = 1700000000;
+        $GLOBALS['wp_test_timezone_string']   = 'UTC';
+    }
+
+    protected function tearDown(): void {
+        unset($GLOBALS['wp_test_current_timestamp'], $GLOBALS['wp_test_timezone_string']);
+
+        parent::tearDown();
+    }
+
+    private function create_api() {
+        return new Discord_Bot_JLG_API_Site_Health_Stub(
+            DISCORD_BOT_JLG_OPTION_NAME,
+            DISCORD_BOT_JLG_CACHE_KEY,
+            DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION
+        );
+    }
+
+    public function test_returns_critical_status_when_server_id_missing() {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array());
+
+        $api = $this->create_api();
+        $site_health = new Discord_Bot_JLG_Site_Health($api);
+
+        $result = $site_health->run_site_health_test();
+
+        $this->assertSame('critical', $result['status']);
+        $this->assertStringContainsString(
+            "Aucun identifiant de serveur Discord n'est configuré",
+            strip_tags($result['description'])
+        );
+    }
+
+    public function test_returns_recommended_status_when_demo_mode_enabled() {
+        update_option(
+            DISCORD_BOT_JLG_OPTION_NAME,
+            array(
+                'demo_mode' => 1,
+            )
+        );
+
+        $api = $this->create_api();
+        $site_health = new Discord_Bot_JLG_Site_Health($api);
+
+        $result = $site_health->run_site_health_test();
+
+        $this->assertSame('recommended', $result['status']);
+        $this->assertStringContainsString(
+            'Le plugin fonctionne actuellement en mode démonstration',
+            strip_tags($result['description'])
+        );
+    }
+
+    public function test_reports_recent_fallback_details() {
+        $timestamp = 1700000000;
+
+        update_option('date_format', 'Y-m-d');
+        update_option('time_format', 'H:i');
+        update_option(
+            DISCORD_BOT_JLG_OPTION_NAME,
+            array(
+                'server_id' => '123456789012345678',
+            )
+        );
+        update_option(
+            Discord_Bot_JLG_API::LAST_FALLBACK_OPTION,
+            array(
+                'timestamp' => $timestamp,
+                'reason'    => 'Widget indisponible',
+            )
+        );
+
+        $api = $this->create_api();
+        $site_health = new Discord_Bot_JLG_Site_Health($api);
+
+        $result = $site_health->run_site_health_test();
+        $description = strip_tags($result['description']);
+
+        $this->assertSame('recommended', $result['status']);
+        $this->assertStringContainsString('Statistiques de secours utilisées depuis le 2023-11-14 22:13.', $description);
+        $this->assertStringContainsString('Dernière erreur signalée : Widget indisponible.', $description);
+        $this->assertStringContainsString('Une nouvelle tentative sera effectuée automatiquement dès que possible.', $description);
+    }
+
+    public function test_reports_last_error_when_available() {
+        update_option(
+            DISCORD_BOT_JLG_OPTION_NAME,
+            array(
+                'server_id' => '123456789012345678',
+            )
+        );
+
+        $api = $this->create_api();
+        $api->set_mock_last_error_message('Erreur API 500');
+
+        $site_health = new Discord_Bot_JLG_Site_Health($api);
+        $result = $site_health->run_site_health_test();
+
+        $this->assertSame('recommended', $result['status']);
+        $this->assertStringContainsString('Dernière erreur rencontrée : Erreur API 500.', strip_tags($result['description']));
+    }
+
+    public function test_returns_good_status_when_everything_is_ok() {
+        update_option(
+            DISCORD_BOT_JLG_OPTION_NAME,
+            array(
+                'server_id' => '123456789012345678',
+            )
+        );
+
+        delete_option(Discord_Bot_JLG_API::LAST_FALLBACK_OPTION);
+
+        $api = $this->create_api();
+        $site_health = new Discord_Bot_JLG_Site_Health($api);
+
+        $result = $site_health->run_site_health_test();
+
+        $this->assertSame('good', $result['status']);
+        $this->assertStringContainsString(
+            'La connexion au serveur Discord fonctionne normalement.',
+            strip_tags($result['description'])
+        );
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -18,9 +18,18 @@ require_once __DIR__ . '/../../inc/class-discord-http.php';
 require_once __DIR__ . '/../../inc/class-discord-api.php';
 require_once __DIR__ . '/../../inc/class-discord-widget.php';
 require_once __DIR__ . '/../../inc/class-discord-shortcode.php';
+require_once __DIR__ . '/../../inc/class-discord-site-health.php';
 
 if (!defined('DISCORD_BOT_JLG_OPTION_NAME')) {
     define('DISCORD_BOT_JLG_OPTION_NAME', 'discord_server_stats_options');
+}
+
+if (!defined('DISCORD_BOT_JLG_CACHE_KEY')) {
+    define('DISCORD_BOT_JLG_CACHE_KEY', 'discord_server_stats_cache');
+}
+
+if (!defined('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION')) {
+    define('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION', 300);
 }
 
 if (!defined('DISCORD_BOT_JLG_PLUGIN_URL')) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
         <testsuite name="Discord Bot - JLG">
             <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Http_Client.php</file>
             <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php</file>
+            <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Site_Health.php</file>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
## Summary
- add a Site Health integration that reports the Discord Bot JLG configuration, recent errors, and fallback usage
- load the Site Health module from the main plugin bootstrap so the diagnostic is always available in the admin
- cover the new Site Health logic with PHPUnit scenarios and wire the new test into the suite

## Testing
- `./vendor/bin/phpunit -c phpunit.xml.dist` *(fails: phpunit binary is not available in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68de3e6b0bec832e95698901ba568387