### PR TITLE
Add admin defaults for server header and refresh options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Accédez à la page **Discord Bot** dans l’administration pour :
 - Saisir le token de votre bot Discord ;
 - Indiquer l’ID du serveur à surveiller ;
 - Définir la durée du cache des statistiques ;
+- Choisir les éléments affichés par défaut (nom/avatar du serveur, rafraîchissement automatique, thème) ;
 - Ajouter du CSS personnalisé.
 
 ### Définir le token via une constante
@@ -50,6 +51,8 @@ Pour activer l'auto-actualisation, utilisez par exemple :
 ```
 [discord_stats refresh="true" refresh_interval="60"]
 ```
+
+💡 Les cases à cocher et listes de la page **Configuration** servent de pré-sélection lors de l’insertion du shortcode, du bloc ou du widget. Par exemple, « Afficher le nom du serveur » force `show_server_name="true"` tant que l’attribut n’est pas surchargé manuellement. Le thème par défaut et l’intervalle d’auto-rafraîchissement sont également appliqués aux nouveaux blocs Gutenberg.
 
 L'attribut optionnel `width` accepte uniquement des longueurs CSS valides comme `320px`, `75%`, `42rem`, ainsi que les mots-clés `auto`, `fit-content`, `min-content` et `max-content`. Les expressions `calc(...)` sont prises en charge lorsqu'elles ne contiennent que des nombres, des unités usuelles et les opérateurs arithmétiques de base. Toute valeur non conforme est ignorée afin d'éviter l'injection de styles indésirables.
 

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -39,6 +39,32 @@ class Discord_Bot_JLG_Shortcode {
     public function render_shortcode($atts) {
         $options = $this->api->get_plugin_options();
 
+        $default_theme = 'discord';
+        if (
+            isset($options['default_theme'])
+            && discord_bot_jlg_is_allowed_theme($options['default_theme'])
+        ) {
+            $default_theme = $options['default_theme'];
+        }
+
+        $min_refresh_option = defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
+            ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
+            : 10;
+        $max_refresh_option = 3600;
+
+        $default_refresh_interval = isset($options['default_refresh_interval'])
+            ? absint($options['default_refresh_interval'])
+            : 60;
+
+        if ($default_refresh_interval <= 0) {
+            $default_refresh_interval = 60;
+        }
+
+        $default_refresh_interval = max(
+            $min_refresh_option,
+            min($max_refresh_option, $default_refresh_interval)
+        );
+
         $atts = shortcode_atts(
             array(
                 'layout'               => 'horizontal',
@@ -46,10 +72,10 @@ class Discord_Bot_JLG_Shortcode {
                 'show_total'           => !empty($options['show_total']),
                 'show_title'           => false,
                 'title'                => isset($options['widget_title']) ? $options['widget_title'] : '',
-                'theme'                => 'discord',
+                'theme'                => $default_theme,
                 'animated'             => true,
-                'refresh'              => false,
-                'refresh_interval'     => '60',
+                'refresh'              => !empty($options['default_refresh_enabled']),
+                'refresh_interval'     => (string) $default_refresh_interval,
                 'compact'              => false,
                 'align'                => 'left',
                 'width'                => '',
@@ -66,8 +92,8 @@ class Discord_Bot_JLG_Shortcode {
                 'demo'                 => false,
                 'show_discord_icon'    => false,
                 'discord_icon_position'=> 'left',
-                'show_server_name'     => false,
-                'show_server_avatar'   => false,
+                'show_server_name'     => !empty($options['show_server_name']),
+                'show_server_avatar'   => !empty($options['show_server_avatar']),
                 'avatar_size'          => '128',
             ),
             $atts,
@@ -249,9 +275,7 @@ class Discord_Bot_JLG_Shortcode {
         }
 
         $refresh_interval = 0;
-        $min_refresh_interval = defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
-            ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
-            : 10;
+        $min_refresh_interval = $min_refresh_option;
 
         if ($refresh && (!$is_demo || $is_fallback_demo)) {
             $refresh_interval = max($min_refresh_interval, intval($atts['refresh_interval']));

--- a/discord-bot-jlg/inc/helpers.php
+++ b/discord-bot-jlg/inc/helpers.php
@@ -7,6 +7,49 @@ if (!defined('DISCORD_BOT_JLG_SECRET_PREFIX')) {
     define('DISCORD_BOT_JLG_SECRET_PREFIX', 'dbjlg_enc_v1:');
 }
 
+if (!function_exists('discord_bot_jlg_get_available_themes')) {
+    /**
+     * Returns the list of allowed themes for the public components.
+     *
+     * @return string[]
+     */
+    function discord_bot_jlg_get_available_themes() {
+        $themes = array('discord', 'dark', 'light', 'minimal');
+
+        if (function_exists('apply_filters')) {
+            $filtered = apply_filters('discord_bot_jlg_available_themes', $themes);
+
+            if (is_array($filtered)) {
+                $themes = $filtered;
+            }
+        }
+
+        $themes = array_map('strval', $themes);
+        $themes = array_filter($themes, function ($theme) {
+            return '' !== $theme;
+        });
+
+        return array_values(array_unique($themes));
+    }
+}
+
+if (!function_exists('discord_bot_jlg_is_allowed_theme')) {
+    /**
+     * Checks whether the provided theme identifier is part of the allowed list.
+     *
+     * @param string $theme Theme identifier to validate.
+     *
+     * @return bool
+     */
+    function discord_bot_jlg_is_allowed_theme($theme) {
+        if (!is_string($theme) || '' === $theme) {
+            return false;
+        }
+
+        return in_array($theme, discord_bot_jlg_get_available_themes(), true);
+    }
+}
+
 if (!function_exists('discord_bot_jlg_validate_bool')) {
     /**
      * Normalizes a value to a boolean, falling back when wp_validate_boolean() is unavailable.

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -61,6 +61,8 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             'widget_title'   => 'Existing title',
             'cache_duration' => 450,
             'custom_css'     => '.existing { color: blue; }',
+            'default_theme'  => 'dark',
+            'default_refresh_interval' => 120,
         );
 
         update_option(DISCORD_BOT_JLG_OPTION_NAME, $this->saved_options);
@@ -155,6 +157,66 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                 ),
                 array(
                     'custom_css' => $sanitized_css,
+                ),
+            ),
+            'server-header-checkboxes' => array(
+                array(
+                    'show_server_name'       => 'yes',
+                    'show_server_avatar'     => '1',
+                    'default_refresh_enabled'=> 'on',
+                ),
+                array(
+                    'show_server_name'       => 1,
+                    'show_server_avatar'     => 1,
+                    'default_refresh_enabled'=> 1,
+                ),
+            ),
+            'default-theme-valid' => array(
+                array(
+                    'default_theme' => 'light',
+                ),
+                array(
+                    'default_theme' => 'light',
+                ),
+            ),
+            'default-theme-empty' => array(
+                array(
+                    'default_theme' => '',
+                ),
+                array(
+                    'default_theme' => 'dark',
+                ),
+            ),
+            'default-theme-invalid' => array(
+                array(
+                    'default_theme' => 'neon',
+                ),
+                array(
+                    'default_theme' => 'discord',
+                ),
+            ),
+            'refresh-interval-below-min' => array(
+                array(
+                    'default_refresh_interval' => '5',
+                ),
+                array(
+                    'default_refresh_interval' => Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                ),
+            ),
+            'refresh-interval-above-max' => array(
+                array(
+                    'default_refresh_interval' => 7200,
+                ),
+                array(
+                    'default_refresh_interval' => 3600,
+                ),
+            ),
+            'refresh-interval-empty-fallback' => array(
+                array(
+                    'default_refresh_interval' => '',
+                ),
+                array(
+                    'default_refresh_interval' => 120,
                 ),
             ),
         );
@@ -360,12 +422,20 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             'demo_mode'      => 0,
             'show_online'    => 0,
             'show_total'     => 0,
+            'show_server_name'   => 0,
+            'show_server_avatar' => 0,
+            'default_refresh_enabled' => 0,
+            'default_theme'   => 'dark',
             'widget_title'   => '',
             'cache_duration' => max(
                 Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
                 min(3600, (int) $this->saved_options['cache_duration'])
             ),
             'custom_css'     => '',
+            'default_refresh_interval' => max(
+                Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                min(3600, (int) $this->saved_options['default_refresh_interval'])
+            ),
         );
     }
 }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -38,6 +38,11 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
             'show_total'    => true,
             'widget_title'  => 'Mon serveur',
             'custom_css'    => $custom_css,
+            'show_server_name' => true,
+            'show_server_avatar' => true,
+            'default_refresh_enabled' => true,
+            'default_refresh_interval' => 45,
+            'default_theme' => 'dark',
         );
 
         $stats = array(
@@ -48,6 +53,9 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
             'stale'                => false,
             'fallback_demo'        => false,
             'is_demo'              => false,
+            'server_name'          => 'Test Guild',
+            'server_avatar_base_url' => 'https://cdn.discordapp.com/icons/123456789/abcdef.png',
+            'server_avatar_url'    => 'https://cdn.discordapp.com/icons/123456789/abcdef.png?size=64',
         );
 
         $api->method('get_plugin_options')->willReturn($options);
@@ -145,5 +153,18 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertSame(discord_bot_jlg_sanitize_custom_css($custom_css), $injected_css);
         $this->assertStringNotContainsString('<script', $injected_css);
         $this->assertStringNotContainsString('</', $injected_css);
+    }
+
+    public function test_render_shortcode_inherits_defaults_from_options() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array());
+
+        $this->assertStringContainsString('discord-theme-dark', $html);
+        $this->assertStringContainsString('data-refresh="45"', $html);
+        $this->assertStringContainsString('data-show-server-name="true"', $html);
+        $this->assertStringContainsString('data-show-server-avatar="true"', $html);
+        $this->assertStringContainsString('data-server-name="Test Guild"', $html);
+        $this->assertStringContainsString('data-server-avatar-url="https://cdn.discordapp.com/icons/123456789/abcdef.png?size=128"', $html);
     }
 }


### PR DESCRIPTION
## Summary
- add admin settings fields to toggle server name/avatar, default theme and auto-refresh interval
- sanitize and persist the new options and feed them into the shortcode defaults
- document the new presets in the README and guide, and extend the unit tests for admin sanitization and shortcode defaults

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: command not found)*
- ./vendor/bin/phpunit --testsuite discord-bot-jlg *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de666e0278832e832b6068b814d5ea