### PR TITLE
Add configurable CTA button to Discord stats block

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -11,6 +11,12 @@
     --discord-logo-height: clamp(26px, 7vw, 36px);
     --discord-badge-scale: 1;
     --discord-avatar-size: clamp(52px, 14vw, 88px);
+    --discord-cta-bg: #5865F2;
+    --discord-cta-bg-hover: #4752c4;
+    --discord-cta-text: #ffffff;
+    --discord-cta-border: rgba(88, 101, 242, 0.45);
+    --discord-cta-outline-text: #5865F2;
+    --discord-cta-outline-hover-bg: rgba(88, 101, 242, 0.12);
 }
 
 .screen-reader-text {
@@ -46,6 +52,81 @@
 .discord-stats-container .discord-stats-wrapper {
     gap: var(--discord-gap);
     transition: opacity 0.2s ease, filter 0.2s ease;
+}
+
+.discord-stats-container .discord-cta-container {
+    display: flex;
+    flex: 0 0 100%;
+    margin-top: calc(var(--discord-gap) * 0.75);
+}
+
+.discord-stats-container.discord-align-center .discord-cta-container {
+    justify-content: center;
+    text-align: center;
+}
+
+.discord-stats-container.discord-align-right .discord-cta-container {
+    justify-content: flex-end;
+    text-align: right;
+}
+
+.discord-stats-container .discord-cta-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(10px, 2.8vw, 15px) clamp(18px, 5vw, 32px);
+    border-radius: calc(var(--discord-radius) * 0.9);
+    font-weight: 600;
+    font-size: clamp(14px, 3vw, 16px);
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+    min-width: clamp(160px, 40vw, 240px);
+    letter-spacing: 0.01em;
+}
+
+.discord-stats-container .discord-cta-button:hover,
+.discord-stats-container .discord-cta-button:focus-visible {
+    transform: translateY(-1px);
+}
+
+.discord-stats-container .discord-cta-button:focus-visible {
+    outline: 3px solid #ffd37a;
+    outline-offset: 3px;
+}
+
+.discord-stats-container .discord-cta-button--solid {
+    background: var(--discord-cta-bg);
+    color: var(--discord-cta-text);
+    border-color: transparent;
+}
+
+.discord-stats-container .discord-cta-button--solid:hover,
+.discord-stats-container .discord-cta-button--solid:focus-visible {
+    background: var(--discord-cta-bg-hover);
+    color: var(--discord-cta-text);
+}
+
+.discord-stats-container .discord-cta-button--outline {
+    background: transparent;
+    color: var(--discord-cta-outline-text);
+    border-color: var(--discord-cta-border);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
+}
+
+.discord-stats-container .discord-cta-button--outline:hover,
+.discord-stats-container .discord-cta-button--outline:focus-visible {
+    background: var(--discord-cta-outline-hover-bg);
+    color: var(--discord-cta-outline-text);
+    border-color: var(--discord-cta-outline-text);
+}
+
+.discord-stats-container .discord-cta-label {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35em;
 }
 
 .discord-stats-container .discord-stat {
@@ -160,12 +241,39 @@
     fill: #ffffff;
 }
 
+.discord-stats-container.discord-theme-dark {
+    --discord-cta-bg: #ffffff;
+    --discord-cta-bg-hover: #f4f5ff;
+    --discord-cta-text: #1f2233;
+    --discord-cta-border: rgba(255, 255, 255, 0.6);
+    --discord-cta-outline-text: #ffffff;
+    --discord-cta-outline-hover-bg: rgba(255, 255, 255, 0.16);
+}
+
 .discord-stats-container.discord-theme-light .discord-logo-svg {
     fill: #5865F2;
 }
 
+.discord-stats-container.discord-theme-light {
+    --discord-cta-bg: #4752c4;
+    --discord-cta-bg-hover: #3a43a9;
+    --discord-cta-text: #ffffff;
+    --discord-cta-border: rgba(71, 82, 196, 0.4);
+    --discord-cta-outline-text: #4752c4;
+    --discord-cta-outline-hover-bg: rgba(71, 82, 196, 0.16);
+}
+
 .discord-stats-container.discord-theme-minimal .discord-logo-svg {
     fill: currentColor;
+}
+
+.discord-stats-container.discord-theme-minimal {
+    --discord-cta-bg: currentColor;
+    --discord-cta-bg-hover: rgba(0, 0, 0, 0.85);
+    --discord-cta-text: #ffffff;
+    --discord-cta-border: currentColor;
+    --discord-cta-outline-text: currentColor;
+    --discord-cta-outline-hover-bg: rgba(0, 0, 0, 0.08);
 }
 
 .discord-stats-container.discord-animated .discord-logo-svg:hover {
@@ -421,6 +529,15 @@
         flex: 1 1 100%;
         width: 100%;
     }
+
+    .discord-stats-container .discord-cta-container {
+        justify-content: center !important;
+    }
+
+    .discord-stats-container .discord-cta-button {
+        width: 100%;
+        min-width: 0;
+    }
 }
 
 @media (max-width: 480px) {
@@ -450,5 +567,10 @@
 
     .discord-stats-container .discord-label {
         font-size: var(--discord-label-size);
+    }
+
+    .discord-stats-container .discord-cta-button {
+        font-size: clamp(14px, 4.6vw, 16px);
+        padding: clamp(12px, 6vw, 18px);
     }
 }

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -9,6 +9,12 @@
     --discord-number-size: clamp(20px, 4vw, 32px);
     --discord-label-size: clamp(12px, 2.6vw, 16px);
     --discord-avatar-size: clamp(52px, 14vw, 88px);
+    --discord-cta-bg: #5865F2;
+    --discord-cta-bg-hover: #4752c4;
+    --discord-cta-text: #ffffff;
+    --discord-cta-border: rgba(88, 101, 242, 0.45);
+    --discord-cta-outline-text: #5865F2;
+    --discord-cta-outline-hover-bg: rgba(88, 101, 242, 0.12);
 }
 
 .screen-reader-text {
@@ -133,6 +139,75 @@
     margin-left: 5px;
 }
 
+.discord-cta-container {
+    flex: 0 0 100%;
+    display: flex;
+    margin-top: calc(var(--discord-gap) * 0.75);
+}
+
+.discord-align-center .discord-cta-container {
+    justify-content: center;
+}
+
+.discord-align-right .discord-cta-container {
+    justify-content: flex-end;
+}
+
+.discord-cta-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(10px, 2.8vw, 15px) clamp(18px, 5vw, 32px);
+    border-radius: calc(var(--discord-radius) * 0.9);
+    font-weight: 600;
+    font-size: clamp(14px, 3vw, 16px);
+    text-decoration: none;
+    border: 1px solid transparent;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    color: var(--discord-cta-text);
+    background: var(--discord-cta-bg);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    letter-spacing: 0.01em;
+}
+
+.discord-cta-button--solid {
+    background: var(--discord-cta-bg);
+    color: var(--discord-cta-text);
+}
+
+.discord-cta-button:hover,
+.discord-cta-button:focus-visible {
+    transform: translateY(-1px);
+    background: var(--discord-cta-bg-hover);
+    color: var(--discord-cta-text);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+.discord-cta-button:focus-visible {
+    outline: 3px solid #ffd37a;
+    outline-offset: 3px;
+}
+
+.discord-cta-button--outline {
+    background: transparent;
+    color: var(--discord-cta-outline-text);
+    border-color: var(--discord-cta-border);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
+}
+
+.discord-cta-button--outline:hover,
+.discord-cta-button--outline:focus-visible {
+    background: var(--discord-cta-outline-hover-bg);
+    color: var(--discord-cta-outline-text);
+    border-color: var(--discord-cta-outline-text);
+}
+
+.discord-cta-button .discord-cta-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+}
+
 
 .discord-stats-error {
     background: #f44336;
@@ -168,6 +243,14 @@
         flex: 1 1 100%;
         width: 100%;
     }
+
+    .discord-cta-container {
+        justify-content: center !important;
+    }
+
+    .discord-cta-button {
+        width: 100%;
+    }
 }
 
 @media (max-width: 480px) {
@@ -186,5 +269,10 @@
 
     .discord-number {
         word-break: break-word;
+    }
+
+    .discord-cta-button {
+        font-size: clamp(14px, 4.6vw, 16px);
+        padding: clamp(12px, 6vw, 18px);
     }
 }

--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -48,6 +48,11 @@
         { label: __('À droite', 'discord-bot-jlg'), value: 'right' }
     ];
 
+    var ctaStyleOptions = [
+        { label: __('Style plein', 'discord-bot-jlg'), value: 'solid' },
+        { label: __('Style contour', 'discord-bot-jlg'), value: 'outline' }
+    ];
+
     var defaultAttributes = {
         layout: 'horizontal',
         show_online: true,
@@ -76,7 +81,12 @@
         discord_icon_position: 'left',
         show_server_name: false,
         show_server_avatar: false,
-        avatar_size: 128
+        avatar_size: 128,
+        cta_enabled: false,
+        cta_label: __('Rejoindre notre serveur Discord', 'discord-bot-jlg'),
+        cta_url: '',
+        cta_style: 'solid',
+        cta_new_tab: true
     };
 
     var REFRESH_INTERVAL_MIN = 10;
@@ -330,6 +340,36 @@
                                 updateAttribute(setAttributes, 'avatar_size')(value);
                             },
                             help: __('Utilisez une puissance de deux (ex. 128, 256, 512) pour une image nette.', 'discord-bot-jlg')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher le bouton d\'appel à l\'action', 'discord-bot-jlg'),
+                            checked: !!attributes.cta_enabled,
+                            onChange: updateAttribute(setAttributes, 'cta_enabled')
+                        }),
+                        !!attributes.cta_enabled && createElement(TextControl, {
+                            label: __('Libellé du bouton', 'discord-bot-jlg'),
+                            value: attributes.cta_label,
+                            onChange: updateAttribute(setAttributes, 'cta_label'),
+                            placeholder: __('Rejoindre notre serveur Discord', 'discord-bot-jlg')
+                        }),
+                        !!attributes.cta_enabled && createElement(TextControl, {
+                            label: __('URL du bouton', 'discord-bot-jlg'),
+                            value: attributes.cta_url,
+                            onChange: updateAttribute(setAttributes, 'cta_url'),
+                            placeholder: __('https://discord.gg/votre-invitation', 'discord-bot-jlg'),
+                            help: __('Utilisez une URL d\'invitation valide vers votre serveur Discord.', 'discord-bot-jlg')
+                        }),
+                        !!attributes.cta_enabled && createElement(SelectControl, {
+                            label: __('Style du bouton', 'discord-bot-jlg'),
+                            value: attributes.cta_style,
+                            options: ctaStyleOptions,
+                            onChange: updateAttribute(setAttributes, 'cta_style')
+                        }),
+                        !!attributes.cta_enabled && createElement(ToggleControl, {
+                            label: __('Ouvrir le lien dans un nouvel onglet', 'discord-bot-jlg'),
+                            checked: !!attributes.cta_new_tab,
+                            onChange: updateAttribute(setAttributes, 'cta_new_tab'),
+                            help: __('Ajoute l\'attribut target="_blank" (recommandé pour les liens externes).', 'discord-bot-jlg')
                         })
                     ),
                     createElement(

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -130,6 +130,26 @@
         "avatar_size": {
             "type": "number",
             "default": 128
+        },
+        "cta_enabled": {
+            "type": "boolean",
+            "default": false
+        },
+        "cta_label": {
+            "type": "string",
+            "default": "Rejoindre notre serveur Discord"
+        },
+        "cta_url": {
+            "type": "string",
+            "default": ""
+        },
+        "cta_style": {
+            "type": "string",
+            "default": "solid"
+        },
+        "cta_new_tab": {
+            "type": "boolean",
+            "default": true
         }
     }
 }

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -69,6 +69,11 @@ class Discord_Bot_JLG_Shortcode {
                 'show_server_name'     => false,
                 'show_server_avatar'   => false,
                 'avatar_size'          => '128',
+                'cta_enabled'          => false,
+                'cta_label'            => __('Rejoindre notre serveur Discord', 'discord-bot-jlg'),
+                'cta_url'              => '',
+                'cta_style'            => 'solid',
+                'cta_new_tab'          => true,
             ),
             $atts,
             'discord_stats'
@@ -87,6 +92,21 @@ class Discord_Bot_JLG_Shortcode {
         $show_server_name   = filter_var($atts['show_server_name'], FILTER_VALIDATE_BOOLEAN);
         $show_server_avatar = filter_var($atts['show_server_avatar'], FILTER_VALIDATE_BOOLEAN);
         $avatar_size        = $this->sanitize_avatar_size($atts['avatar_size']);
+        $cta_enabled        = filter_var($atts['cta_enabled'], FILTER_VALIDATE_BOOLEAN);
+        $cta_new_tab        = filter_var($atts['cta_new_tab'], FILTER_VALIDATE_BOOLEAN);
+
+        $cta_label = sanitize_text_field($atts['cta_label']);
+        if ('' === $cta_label) {
+            $cta_label = __('Rejoindre notre serveur Discord', 'discord-bot-jlg');
+        }
+
+        $cta_url = esc_url_raw($atts['cta_url']);
+
+        $allowed_cta_styles = array('solid', 'outline');
+        $cta_style = sanitize_text_field($atts['cta_style']);
+        if (!in_array($cta_style, $allowed_cta_styles, true)) {
+            $cta_style = 'solid';
+        }
 
         if ($force_demo) {
             $stats = $this->api->get_demo_stats();
@@ -185,6 +205,10 @@ class Discord_Bot_JLG_Shortcode {
             if ('' !== $server_avatar_url) {
                 $container_classes[] = 'discord-has-server-avatar';
             }
+        }
+
+        if ($cta_enabled && '' !== $cta_url) {
+            $container_classes[] = 'discord-has-cta';
         }
 
         $style_declarations = array(
@@ -294,6 +318,20 @@ class Discord_Bot_JLG_Shortcode {
         }
 
         $discord_svg = '<svg class="discord-logo-svg" aria-hidden="true" focusable="false" viewBox="0 0 127.14 96.36" xmlns="http://www.w3.org/2000/svg"><path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/></svg>';
+
+        $cta_should_render = ($cta_enabled && '' !== $cta_url);
+        $cta_button_classes = array('discord-cta-button');
+        if ($cta_should_render) {
+            $cta_button_classes[] = 'discord-cta-button--' . $cta_style;
+        }
+
+        $cta_rel = '';
+        $cta_target = '';
+
+        if ($cta_should_render && $cta_new_tab) {
+            $cta_target = ' target="_blank"';
+            $cta_rel    = ' rel="noopener"';
+        }
 
         ob_start();
         ?>
@@ -408,6 +446,14 @@ class Discord_Bot_JLG_Shortcode {
                     </div>
                     <?php endif; ?>
                 </div>
+
+                <?php if ($cta_should_render) : ?>
+                <div class="discord-cta-container">
+                    <a class="<?php echo esc_attr(implode(' ', $cta_button_classes)); ?>" href="<?php echo esc_url($cta_url); ?>"<?php echo $cta_target; ?><?php echo $cta_rel; ?>>
+                        <span class="discord-cta-label"><?php echo esc_html($cta_label); ?></span>
+                    </a>
+                </div>
+                <?php endif; ?>
 
                 <?php if ($show_discord_icon && $logo_position_class === 'right'): ?>
                 <div class="discord-logo-container">


### PR DESCRIPTION
## Summary
- add configurable call-to-action attributes to the Discord stats block and expose controls in the editor
- render and sanitize the CTA button server side with theme-aware styling for solid and outline variants
- extend front-end styles for responsive CTA presentation and mobile-friendly layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de666c9598832e9a14174205f2f57b