### PR TITLE
Add configurable Discord invite button to block and shortcode

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -132,6 +132,59 @@
     min-width: 0;
 }
 
+.discord-stats-container .discord-invite {
+    margin-top: calc(var(--discord-gap) * 0.75);
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--discord-gap) * 0.25);
+}
+
+.discord-stats-container.discord-align-center .discord-invite {
+    justify-content: center;
+    text-align: center;
+}
+
+.discord-stats-container.discord-align-right .discord-invite {
+    justify-content: flex-end;
+    text-align: right;
+}
+
+.discord-stats-container .discord-invite-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: calc(var(--discord-padding) * 0.75) calc(var(--discord-padding) * 1.6);
+    border-radius: calc(var(--discord-radius) * 1.25);
+    background: linear-gradient(135deg, #5865F2, #4750c7);
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    box-shadow: 0 4px 12px rgba(88, 101, 242, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    line-height: 1.4;
+    white-space: nowrap;
+}
+
+.discord-stats-container .discord-invite-button:hover,
+.discord-stats-container .discord-invite-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(88, 101, 242, 0.4);
+    filter: brightness(1.05);
+}
+
+.discord-stats-container .discord-invite-button:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.85);
+    outline-offset: 3px;
+}
+
+.discord-stats-container .discord-invite-button__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    font-size: clamp(14px, 3.4vw, 18px);
+}
+
 .discord-stats-container .discord-logo-container {
     flex-shrink: 0;
 }
@@ -421,6 +474,16 @@
     .discord-stats-container .discord-stat {
         flex: 1 1 100%;
         width: 100%;
+    }
+
+    .discord-stats-container .discord-invite {
+        width: 100%;
+    }
+
+    .discord-stats-container .discord-invite-button {
+        width: 100%;
+        white-space: normal;
+        padding: clamp(12px, 4.5vw, 18px);
     }
 
     .discord-stats-container .discord-refresh-status {

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -88,6 +88,59 @@
     min-width: 0;
 }
 
+.discord-invite {
+    margin-top: calc(var(--discord-gap) * 0.75);
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--discord-gap) * 0.25);
+}
+
+.discord-align-center .discord-invite {
+    justify-content: center;
+    text-align: center;
+}
+
+.discord-align-right .discord-invite {
+    justify-content: flex-end;
+    text-align: right;
+}
+
+.discord-invite-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: calc(var(--discord-padding) * 0.75) calc(var(--discord-padding) * 1.6);
+    border-radius: calc(var(--discord-radius) * 1.25);
+    background: linear-gradient(135deg, #5865F2, #4750c7);
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    box-shadow: 0 4px 12px rgba(88, 101, 242, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    line-height: 1.4;
+    white-space: nowrap;
+}
+
+.discord-invite-button:hover,
+.discord-invite-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(88, 101, 242, 0.4);
+    filter: brightness(1.05);
+}
+
+.discord-invite-button:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.85);
+    outline-offset: 3px;
+}
+
+.discord-invite-button__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    font-size: clamp(14px, 3.4vw, 18px);
+}
+
 .discord-stat {
     background: #4a53c2;
     color: #ffffff;
@@ -168,6 +221,16 @@
     .discord-stat {
         flex: 1 1 100%;
         width: 100%;
+    }
+
+    .discord-invite {
+        width: 100%;
+    }
+
+    .discord-invite-button {
+        width: 100%;
+        white-space: normal;
+        padding: clamp(12px, 4.5vw, 18px);
     }
 
     .discord-refresh-status {

--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -76,7 +76,9 @@
         discord_icon_position: 'left',
         show_server_name: false,
         show_server_avatar: false,
-        avatar_size: 128
+        avatar_size: 128,
+        invite_url: '',
+        invite_label: ''
     };
 
     var REFRESH_INTERVAL_MIN = 10;
@@ -330,6 +332,23 @@
                                 updateAttribute(setAttributes, 'avatar_size')(value);
                             },
                             help: __('Utilisez une puissance de deux (ex. 128, 256, 512) pour une image nette.', 'discord-bot-jlg')
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Invitation', 'discord-bot-jlg'), initialOpen: false },
+                        createElement(TextControl, {
+                            label: __('URL d\'invitation', 'discord-bot-jlg'),
+                            value: attributes.invite_url,
+                            onChange: updateAttribute(setAttributes, 'invite_url'),
+                            type: 'url',
+                            placeholder: 'https://discord.gg/xxxx'
+                        }),
+                        createElement(TextControl, {
+                            label: __('Libellé du bouton', 'discord-bot-jlg'),
+                            value: attributes.invite_label,
+                            onChange: updateAttribute(setAttributes, 'invite_label'),
+                            placeholder: __('Rejoindre le serveur', 'discord-bot-jlg')
                         })
                     ),
                     createElement(

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -130,6 +130,14 @@
         "avatar_size": {
             "type": "number",
             "default": 128
+        },
+        "invite_url": {
+            "type": "string",
+            "default": ""
+        },
+        "invite_label": {
+            "type": "string",
+            "default": ""
         }
     }
 }

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -181,6 +181,22 @@ class Discord_Bot_JLG_Admin {
         );
 
         add_settings_field(
+            'invite_url',
+            __('URL d\'invitation Discord', 'discord-bot-jlg'),
+            array($this, 'invite_url_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
+            'invite_label',
+            __('Libellé du bouton d\'invitation', 'discord-bot-jlg'),
+            array($this, 'invite_label_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
             'cache_duration',
             __('Durée du cache (secondes)', 'discord-bot-jlg'),
             array($this, 'cache_duration_render'),
@@ -252,6 +268,12 @@ class Discord_Bot_JLG_Admin {
             'default_refresh_enabled' => 0,
             'default_theme'   => $current_theme,
             'widget_title'   => '',
+            'invite_url'     => isset($current_options['invite_url'])
+                ? esc_url_raw($current_options['invite_url'])
+                : '',
+            'invite_label'   => isset($current_options['invite_label'])
+                ? sanitize_text_field($current_options['invite_label'])
+                : '',
             'cache_duration' => isset($current_options['cache_duration'])
                 ? (int) $current_options['cache_duration']
                 : 300,
@@ -338,6 +360,33 @@ class Discord_Bot_JLG_Admin {
 
         if (isset($input['widget_title'])) {
             $sanitized['widget_title'] = sanitize_text_field($input['widget_title']);
+        }
+
+        if (array_key_exists('invite_url', $input)) {
+            $raw_invite_url = is_string($input['invite_url'])
+                ? trim($input['invite_url'])
+                : '';
+
+            if ('' === $raw_invite_url) {
+                $sanitized['invite_url'] = '';
+            } else {
+                $invite_url = esc_url_raw($raw_invite_url);
+
+                if ('' !== $invite_url) {
+                    $sanitized['invite_url'] = $invite_url;
+                } else {
+                    add_settings_error(
+                        'discord_stats_settings',
+                        'discord_bot_jlg_invite_url_invalid',
+                        esc_html__('L\'URL d\'invitation Discord semble invalide. Veuillez saisir une URL complète commençant par http ou https.', 'discord-bot-jlg'),
+                        'error'
+                    );
+                }
+            }
+        }
+
+        if (isset($input['invite_label'])) {
+            $sanitized['invite_label'] = sanitize_text_field($input['invite_label']);
         }
 
         if (array_key_exists('cache_duration', $input)) {
@@ -797,6 +846,36 @@ class Discord_Bot_JLG_Admin {
         <input type="text" name="<?php echo esc_attr($this->option_name); ?>[widget_title]"
                value="<?php echo esc_attr(isset($options['widget_title']) ? $options['widget_title'] : ''); ?>"
                class="regular-text" />
+        <?php
+    }
+
+    /**
+     * Rend le champ de saisie de l'URL d'invitation Discord.
+     */
+    public function invite_url_render() {
+        $options = get_option($this->option_name);
+        $value   = isset($options['invite_url']) ? esc_url($options['invite_url']) : '';
+        ?>
+        <input type="url" name="<?php echo esc_attr($this->option_name); ?>[invite_url]"
+               value="<?php echo esc_attr($value); ?>"
+               class="regular-text"
+               placeholder="https://discord.gg/xxxx" />
+        <p class="description"><?php esc_html_e('Lien d\'invitation utilisé pour le bouton d\'appel à l\'action.', 'discord-bot-jlg'); ?></p>
+        <?php
+    }
+
+    /**
+     * Rend le champ texte pour personnaliser le libellé du bouton d'invitation.
+     */
+    public function invite_label_render() {
+        $options = get_option($this->option_name);
+        $value   = isset($options['invite_label']) ? $options['invite_label'] : '';
+        ?>
+        <input type="text" name="<?php echo esc_attr($this->option_name); ?>[invite_label]"
+               value="<?php echo esc_attr($value); ?>"
+               class="regular-text"
+               placeholder="<?php echo esc_attr__('Rejoindre le serveur', 'discord-bot-jlg'); ?>" />
+        <p class="description"><?php esc_html_e('Texte du bouton permettant aux visiteurs de rejoindre votre serveur.', 'discord-bot-jlg'); ?></p>
         <?php
     }
 

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -47,6 +47,15 @@ class Discord_Bot_JLG_Shortcode {
             $default_theme = $options['default_theme'];
         }
 
+        $default_invite_url = isset($options['invite_url']) ? esc_url_raw($options['invite_url']) : '';
+        $default_invite_label = isset($options['invite_label'])
+            ? sanitize_text_field($options['invite_label'])
+            : '';
+
+        if ('' === $default_invite_label) {
+            $default_invite_label = __('Rejoindre le serveur', 'discord-bot-jlg');
+        }
+
         $min_refresh_option = defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
             ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
             : 10;
@@ -95,6 +104,8 @@ class Discord_Bot_JLG_Shortcode {
                 'show_server_name'     => !empty($options['show_server_name']),
                 'show_server_avatar'   => !empty($options['show_server_avatar']),
                 'avatar_size'          => '128',
+                'invite_url'           => $default_invite_url,
+                'invite_label'         => $default_invite_label,
             ),
             $atts,
             'discord_stats'
@@ -113,6 +124,12 @@ class Discord_Bot_JLG_Shortcode {
         $show_server_name   = filter_var($atts['show_server_name'], FILTER_VALIDATE_BOOLEAN);
         $show_server_avatar = filter_var($atts['show_server_avatar'], FILTER_VALIDATE_BOOLEAN);
         $avatar_size        = $this->sanitize_avatar_size($atts['avatar_size']);
+        $invite_url         = esc_url_raw(is_string($atts['invite_url']) ? trim($atts['invite_url']) : '');
+        $invite_label       = isset($atts['invite_label']) ? sanitize_text_field($atts['invite_label']) : '';
+
+        if ('' === $invite_label) {
+            $invite_label = __('Rejoindre le serveur', 'discord-bot-jlg');
+        }
 
         if ($force_demo) {
             $stats = $this->api->get_demo_stats();
@@ -177,6 +194,10 @@ class Discord_Bot_JLG_Shortcode {
 
         if ($is_demo) {
             $container_classes[] = 'discord-demo-mode';
+        }
+
+        if ('' !== $invite_url) {
+            $container_classes[] = 'discord-has-invite';
         }
 
         $logo_position_class = '';
@@ -440,6 +461,14 @@ class Discord_Bot_JLG_Shortcode {
                 <?php endif; ?>
             </div>
         </div>
+
+        <?php if ('' !== $invite_url) : ?>
+        <div class="discord-invite">
+            <a class="discord-invite-button" href="<?php echo esc_url($invite_url); ?>" target="_blank" rel="noopener noreferrer nofollow">
+                <span class="discord-invite-button__label"><?php echo esc_html($invite_label); ?></span>
+            </a>
+        </div>
+        <?php endif; ?>
 
         <?php
         return ob_get_clean();


### PR DESCRIPTION
## Summary
- add admin fields and sanitization for configuring an invite URL and button label
- render the invite button from shortcode/block attributes and expose controls in the editor
- style the invite call-to-action for responsiveness in both bundled and inline styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de8ad09be8832ebf46927ba15ddbb6