### PR TITLE
Add invite button validation and responsive styles

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -164,6 +164,11 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
     line-height: 1.4;
     white-space: nowrap;
+    border: none;
+    cursor: pointer;
+    flex: 1 1 clamp(220px, 40vw, 320px);
+    min-width: min(240px, 100%);
+    max-width: 100%;
 }
 
 .discord-stats-container .discord-invite-button:hover,
@@ -183,6 +188,12 @@
     align-items: center;
     gap: 0.35em;
     font-size: clamp(14px, 3.4vw, 18px);
+}
+
+.discord-stats-container .discord-invite-button--compact {
+    padding: calc(var(--discord-padding) * 0.55) calc(var(--discord-padding) * 1.25);
+    flex: 0 1 auto;
+    min-width: auto;
 }
 
 .discord-stats-container .discord-logo-container {
@@ -484,6 +495,8 @@
         width: 100%;
         white-space: normal;
         padding: clamp(12px, 4.5vw, 18px);
+        flex: 1 1 auto;
+        min-width: 0;
     }
 
     .discord-stats-container .discord-refresh-status {

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -120,6 +120,11 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
     line-height: 1.4;
     white-space: nowrap;
+    border: none;
+    cursor: pointer;
+    flex: 1 1 clamp(220px, 40vw, 320px);
+    min-width: min(240px, 100%);
+    max-width: 100%;
 }
 
 .discord-invite-button:hover,
@@ -139,6 +144,12 @@
     align-items: center;
     gap: 0.35em;
     font-size: clamp(14px, 3.4vw, 18px);
+}
+
+.discord-invite-button--compact {
+    padding: calc(var(--discord-padding) * 0.55) calc(var(--discord-padding) * 1.25);
+    flex: 0 1 auto;
+    min-width: auto;
 }
 
 .discord-stat {
@@ -231,6 +242,8 @@
         width: 100%;
         white-space: normal;
         padding: clamp(12px, 4.5vw, 18px);
+        flex: 1 1 auto;
+        min-width: 0;
     }
 
     .discord-refresh-status {

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -371,8 +371,14 @@ class Discord_Bot_JLG_Admin {
                 $sanitized['invite_url'] = '';
             } else {
                 $invite_url = esc_url_raw($raw_invite_url);
+                $http_validator_available = function_exists('wp_http_validate_url');
+                $is_valid_invite_url = (
+                    '' !== $invite_url
+                    && preg_match('#^https?://#i', $invite_url)
+                    && (!$http_validator_available || wp_http_validate_url($invite_url))
+                );
 
-                if ('' !== $invite_url) {
+                if ($is_valid_invite_url) {
                     $sanitized['invite_url'] = $invite_url;
                 } else {
                     add_settings_error(

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -462,9 +462,23 @@ class Discord_Bot_JLG_Shortcode {
             </div>
         </div>
 
-        <?php if ('' !== $invite_url) : ?>
+        <?php if ('' !== $invite_url) :
+            $invite_button_classes = array('discord-invite-button', 'wp-element-button');
+
+            if ($compact) {
+                $invite_button_classes[] = 'discord-invite-button--compact';
+            }
+
+            $invite_rel_value = implode(' ', array('noopener', 'noreferrer', 'nofollow'));
+            $invite_link_attributes = array(
+                sprintf('class="%s"', esc_attr(implode(' ', $invite_button_classes))),
+                sprintf('href="%s"', esc_url($invite_url)),
+                'target="_blank"',
+                sprintf('rel="%s"', esc_attr($invite_rel_value)),
+            );
+        ?>
         <div class="discord-invite">
-            <a class="discord-invite-button" href="<?php echo esc_url($invite_url); ?>" target="_blank" rel="noopener noreferrer nofollow">
+            <a <?php echo implode(' ', $invite_link_attributes); ?>>
                 <span class="discord-invite-button__label"><?php echo esc_html($invite_label); ?></span>
             </a>
         </div>


### PR DESCRIPTION
## Summary
- validate stored invite URLs to ensure they use HTTP(S) before saving plugin settings
- render the invite button with utility classes and safe rel/target attributes from shortcode output
- refresh the front-end styles so the invite button is responsive and compact-aware across both bundled stylesheets

## Testing
- php -l discord-bot-jlg/inc/class-discord-admin.php
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68de9f245cbc832eba77e56356532ef8