### PR TITLE
Clarify admin defaults mapping to shortcode attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Pour activer l'auto-actualisation, utilisez par exemple :
 [discord_stats refresh="true" refresh_interval="60"]
 ```
 
-💡 Les cases à cocher et listes de la page **Configuration** servent de pré-sélection lors de l’insertion du shortcode, du bloc ou du widget. Par exemple, « Afficher le nom du serveur » force `show_server_name="true"` tant que l’attribut n’est pas surchargé manuellement. Le thème par défaut et l’intervalle d’auto-rafraîchissement sont également appliqués aux nouveaux blocs Gutenberg.
+💡 Les cases à cocher et listes de la page **Configuration** servent de pré-sélection lors de l’insertion du shortcode, du bloc ou du widget. Cocher « Afficher le nom du serveur » ou « Afficher l’avatar » renseigne automatiquement `show_server_name="true"` et `show_server_avatar="true"`. Le sélecteur de thème alimente l’attribut `theme`, tandis que l’option « Rafraîchissement auto par défaut » coche `refresh="true"` et initialise `refresh_interval` avec l’intervalle numérique défini.
 
 L'attribut optionnel `width` accepte uniquement des longueurs CSS valides comme `320px`, `75%`, `42rem`, ainsi que les mots-clés `auto`, `fit-content`, `min-content` et `max-content`. Les expressions `calc(...)` sont prises en charge lorsqu'elles ne contiennent que des nombres, des unités usuelles et les opérateurs arithmétiques de base. Toute valeur non conforme est ignorée afin d'éviter l'injection de styles indésirables.
 

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -1170,6 +1170,12 @@ class Discord_Bot_JLG_Admin {
             <h2><?php esc_html_e('📖 Guide d\'utilisation', 'discord-bot-jlg'); ?></h2>
 
             <p><?php echo wp_kses_post(__('Les choix effectués dans l\'onglet <strong>Configuration</strong> (nom/avatar du serveur, thème, auto-rafraîchissement) remplissent automatiquement les attributs équivalents du shortcode, du bloc et du widget. Vous pouvez toujours les modifier manuellement pour un cas précis.', 'discord-bot-jlg')); ?></p>
+            <ul>
+                <li><?php echo wp_kses_post(__('« Afficher le nom du serveur » pré-renseigne <code>show_server_name="true"</code>.', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('« Afficher l\'avatar » active <code>show_server_avatar="true"</code> et ajuste la taille depuis la barre latérale du bloc.', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('Le thème choisi devient la valeur par défaut de l\'attribut <code>theme</code>.', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('En cochant « Rafraîchissement auto », le shortcode/ bloc utilise <code>refresh="true"</code> et l\'intervalle numérique saisi pour <code>refresh_interval</code>.', 'discord-bot-jlg')); ?></li>
+            </ul>
 
             <h3><?php esc_html_e('Option 1 : Shortcode (avec paramètres)', 'discord-bot-jlg'); ?></h3>
             <p><?php esc_html_e('Copiez ce code dans n\'importe quelle page ou article :', 'discord-bot-jlg'); ?></p>


### PR DESCRIPTION
## Summary
- document how the configuration toggles prefill shortcode and block attributes
- extend the guide page with an explicit mapping of admin options to shortcode parameters

## Testing
- `phpunit --testsuite discord-bot-jlg` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de9f718884832eb44b203fe25d6bf5