### PR TITLE
Add configurable CTA button to Discord stats block

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -132,6 +132,119 @@
     min-width: 0;
 }
 
+.discord-stats-container .discord-cta {
+    margin-top: calc(var(--discord-gap) * 0.75);
+    display: flex;
+    flex: 0 0 100%;
+}
+
+.discord-stats-container.discord-align-center .discord-cta {
+    justify-content: center;
+    text-align: center;
+}
+
+.discord-stats-container.discord-align-right .discord-cta {
+    justify-content: flex-end;
+    text-align: right;
+}
+
+.discord-stats-container .discord-cta-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    padding: calc(var(--discord-padding) * 0.75) calc(var(--discord-padding) * 1.5);
+    border-radius: calc(var(--discord-radius) * 1.3);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    line-height: 1.35;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    min-width: 0;
+    border: 2px solid transparent;
+}
+
+.discord-stats-container .discord-cta-button:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.85);
+    outline-offset: 3px;
+}
+
+.discord-stats-container .discord-cta-button--solid {
+    color: #ffffff;
+    background: linear-gradient(135deg, #5865f2, #4750c7);
+    box-shadow: 0 4px 12px rgba(88, 101, 242, 0.35);
+}
+
+.discord-stats-container .discord-cta-button--solid:hover,
+.discord-stats-container .discord-cta-button--solid:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(88, 101, 242, 0.4);
+    filter: brightness(1.05);
+}
+
+.discord-stats-container .discord-cta-button--outline {
+    background: transparent;
+    color: #4750c7;
+    border-color: currentColor;
+    box-shadow: none;
+}
+
+.discord-stats-container .discord-cta-button--outline:hover,
+.discord-stats-container .discord-cta-button--outline:focus-visible {
+    transform: translateY(-1px);
+    color: #2f3aa8;
+    border-color: #2f3aa8;
+}
+
+.discord-theme-dark .discord-cta-button--outline {
+    color: #d6dcff;
+    border-color: rgba(214, 220, 255, 0.7);
+}
+
+.discord-theme-dark .discord-cta-button--outline:hover,
+.discord-theme-dark .discord-cta-button--outline:focus-visible {
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.85);
+}
+
+.discord-theme-light .discord-cta-button--solid,
+.discord-theme-minimal .discord-cta-button--solid {
+    background: linear-gradient(135deg, #5561ec, #3941b4);
+}
+
+.discord-theme-light .discord-cta-button--outline,
+.discord-theme-minimal .discord-cta-button--outline {
+    color: #3b4acb;
+    border-color: rgba(59, 74, 203, 0.85);
+}
+
+.discord-stats-container.discord-compact .discord-cta-button {
+    padding: calc(var(--discord-padding) * 0.6) calc(var(--discord-padding) * 1.2);
+}
+
+.discord-stats-container.discord-compact .discord-cta {
+    margin-top: calc(var(--discord-gap) * 0.5);
+}
+
+.discord-stats-container .discord-cta-button__label {
+    font-size: clamp(14px, 3.4vw, 18px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35em;
+}
+
+@media (max-width: 600px) {
+    .discord-stats-container .discord-cta {
+        justify-content: flex-start;
+    }
+
+    .discord-stats-container .discord-cta-button {
+        width: 100%;
+        max-width: 100%;
+    }
+}
+
 .discord-stats-container .discord-invite {
     margin-top: calc(var(--discord-gap) * 0.75);
     display: flex;

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -88,6 +88,119 @@
     min-width: 0;
 }
 
+.discord-cta {
+    margin-top: calc(var(--discord-gap) * 0.75);
+    display: flex;
+    flex: 0 0 100%;
+}
+
+.discord-align-center .discord-cta {
+    justify-content: center;
+    text-align: center;
+}
+
+.discord-align-right .discord-cta {
+    justify-content: flex-end;
+    text-align: right;
+}
+
+.discord-cta-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    padding: calc(var(--discord-padding) * 0.75) calc(var(--discord-padding) * 1.5);
+    border-radius: calc(var(--discord-radius) * 1.3);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    line-height: 1.35;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    min-width: 0;
+    border: 2px solid transparent;
+}
+
+.discord-cta-button:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.85);
+    outline-offset: 3px;
+}
+
+.discord-cta-button--solid {
+    color: #ffffff;
+    background: linear-gradient(135deg, #5865f2, #4750c7);
+    box-shadow: 0 4px 12px rgba(88, 101, 242, 0.35);
+}
+
+.discord-cta-button--solid:hover,
+.discord-cta-button--solid:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(88, 101, 242, 0.4);
+    filter: brightness(1.05);
+}
+
+.discord-cta-button--outline {
+    background: transparent;
+    color: #4750c7;
+    border-color: currentColor;
+    box-shadow: none;
+}
+
+.discord-cta-button--outline:hover,
+.discord-cta-button--outline:focus-visible {
+    transform: translateY(-1px);
+    color: #2f3aa8;
+    border-color: #2f3aa8;
+}
+
+.discord-theme-dark .discord-cta-button--outline {
+    color: #d6dcff;
+    border-color: rgba(214, 220, 255, 0.7);
+}
+
+.discord-theme-dark .discord-cta-button--outline:hover,
+.discord-theme-dark .discord-cta-button--outline:focus-visible {
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.85);
+}
+
+.discord-theme-light .discord-cta-button--solid,
+.discord-theme-minimal .discord-cta-button--solid {
+    background: linear-gradient(135deg, #5561ec, #3941b4);
+}
+
+.discord-theme-light .discord-cta-button--outline,
+.discord-theme-minimal .discord-cta-button--outline {
+    color: #3b4acb;
+    border-color: rgba(59, 74, 203, 0.85);
+}
+
+.discord-cta-button__label {
+    font-size: clamp(14px, 3.4vw, 18px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35em;
+}
+
+.discord-compact .discord-cta-button {
+    padding: calc(var(--discord-padding) * 0.6) calc(var(--discord-padding) * 1.2);
+}
+
+.discord-compact .discord-cta {
+    margin-top: calc(var(--discord-gap) * 0.5);
+}
+
+@media (max-width: 600px) {
+    .discord-cta {
+        justify-content: flex-start;
+    }
+
+    .discord-cta-button {
+        width: 100%;
+        max-width: 100%;
+    }
+}
+
 .discord-invite {
     margin-top: calc(var(--discord-gap) * 0.75);
     display: flex;

--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -48,6 +48,11 @@
         { label: __('À droite', 'discord-bot-jlg'), value: 'right' }
     ];
 
+    var ctaStyleOptions = [
+        { label: __('Plein', 'discord-bot-jlg'), value: 'solid' },
+        { label: __('Contour', 'discord-bot-jlg'), value: 'outline' }
+    ];
+
     var defaultAttributes = {
         layout: 'horizontal',
         show_online: true,
@@ -78,7 +83,13 @@
         show_server_avatar: false,
         avatar_size: 128,
         invite_url: '',
-        invite_label: ''
+        invite_label: '',
+        cta_enabled: false,
+        cta_label: '',
+        cta_url: '',
+        cta_style: 'solid',
+        cta_new_tab: true,
+        cta_tooltip: ''
     };
 
     var REFRESH_INTERVAL_MIN = 10;
@@ -332,6 +343,43 @@
                                 updateAttribute(setAttributes, 'avatar_size')(value);
                             },
                             help: __('Utilisez une puissance de deux (ex. 128, 256, 512) pour une image nette.', 'discord-bot-jlg')
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher le bouton d\'action', 'discord-bot-jlg'),
+                            checked: !!attributes.cta_enabled,
+                            onChange: updateAttribute(setAttributes, 'cta_enabled')
+                        }),
+                        !!attributes.cta_enabled && createElement(TextControl, {
+                            label: __('Libellé du bouton', 'discord-bot-jlg'),
+                            value: attributes.cta_label,
+                            onChange: updateAttribute(setAttributes, 'cta_label'),
+                            placeholder: __('Rejoindre la communauté', 'discord-bot-jlg')
+                        }),
+                        !!attributes.cta_enabled && createElement(TextControl, {
+                            label: __('URL du bouton', 'discord-bot-jlg'),
+                            value: attributes.cta_url,
+                            onChange: updateAttribute(setAttributes, 'cta_url'),
+                            type: 'url',
+                            placeholder: 'https://discord.gg/xxxx',
+                            help: __('Incluez l’URL complète (avec https://).', 'discord-bot-jlg')
+                        }),
+                        !!attributes.cta_enabled && createElement(SelectControl, {
+                            label: __('Style du bouton', 'discord-bot-jlg'),
+                            value: attributes.cta_style,
+                            options: ctaStyleOptions,
+                            onChange: updateAttribute(setAttributes, 'cta_style')
+                        }),
+                        !!attributes.cta_enabled && createElement(ToggleControl, {
+                            label: __('Ouvrir dans un nouvel onglet', 'discord-bot-jlg'),
+                            checked: !!attributes.cta_new_tab,
+                            onChange: updateAttribute(setAttributes, 'cta_new_tab'),
+                            help: __('Ajoute les attributs target="_blank" et rel="noopener".', 'discord-bot-jlg')
+                        }),
+                        !!attributes.cta_enabled && createElement(TextControl, {
+                            label: __('Info-bulle (optionnel)', 'discord-bot-jlg'),
+                            value: attributes.cta_tooltip,
+                            onChange: updateAttribute(setAttributes, 'cta_tooltip'),
+                            placeholder: __('Découvrir le serveur Discord', 'discord-bot-jlg')
                         })
                     ),
                     createElement(

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -138,6 +138,30 @@
         "invite_label": {
             "type": "string",
             "default": ""
+        },
+        "cta_enabled": {
+            "type": "boolean",
+            "default": false
+        },
+        "cta_label": {
+            "type": "string",
+            "default": ""
+        },
+        "cta_url": {
+            "type": "string",
+            "default": ""
+        },
+        "cta_style": {
+            "type": "string",
+            "default": "solid"
+        },
+        "cta_new_tab": {
+            "type": "boolean",
+            "default": true
+        },
+        "cta_tooltip": {
+            "type": "string",
+            "default": ""
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the Discord stats block with CTA attributes and editor controls
- render and sanitize the CTA markup within the shortcode output
- add responsive styling for solid and outline CTA variants in the frontend stylesheets

## Testing
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68de9f6fe068832e87eb542c07e986a1