### PR TITLE
Ensure refresh overlay padding applies only when needed

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -463,6 +463,9 @@
         --discord-gap: clamp(10px, 5vw, 16px);
         --discord-padding: clamp(10px, 4vw, 18px);
         --discord-avatar-size: clamp(46px, 20vw, 72px);
+    }
+
+    .discord-stats-container.has-refresh-overlay {
         padding-bottom: calc(var(--discord-padding) * 2.5 + 48px);
     }
 
@@ -520,6 +523,9 @@
         --discord-logo-height: clamp(20px, 12vw, 26px);
         --discord-badge-scale: 0.85;
         --discord-avatar-size: clamp(42px, 24vw, 64px);
+    }
+
+    .discord-stats-container.has-refresh-overlay {
         padding-bottom: calc(var(--discord-padding) * 3 + 58px);
     }
 

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -210,6 +210,9 @@
         --discord-gap: clamp(10px, 5vw, 16px);
         --discord-padding: clamp(10px, 4vw, 18px);
         --discord-avatar-size: clamp(46px, 20vw, 72px);
+    }
+
+    .discord-stats-container.has-refresh-overlay {
         padding-bottom: calc(var(--discord-padding) * 2.5 + 48px);
     }
 
@@ -264,6 +267,9 @@
         --discord-number-size: clamp(18px, 7vw, 22px);
         --discord-label-size: clamp(12px, 5vw, 14px);
         --discord-avatar-size: clamp(42px, 24vw, 64px);
+    }
+
+    .discord-stats-container.has-refresh-overlay {
         padding-bottom: calc(var(--discord-padding) * 3 + 58px);
     }
 

--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -5,6 +5,8 @@
     var ERROR_MESSAGE_CLASS = 'discord-error-message';
     var STALE_NOTICE_CLASS = 'discord-stale-notice';
     var REFRESH_STATUS_CLASS = 'discord-refresh-status';
+    var REFRESH_OVERLAY_CLASS = 'has-refresh-overlay';
+    var DEMO_BADGE_CLASS = 'discord-demo-badge';
     var globalConfig = {};
     var SERVER_NAME_SELECTOR = '[data-role="discord-server-name"]';
     var SERVER_NAME_CLASS = 'discord-server-name';
@@ -730,7 +732,7 @@
             return container.dataset.demoBadgeLabel || fallbackLabel;
         }
 
-        var existingBadge = container.querySelector('.discord-demo-badge');
+        var existingBadge = container.querySelector('.' + DEMO_BADGE_CLASS);
         if (existingBadge && existingBadge.textContent) {
             var label = existingBadge.textContent;
             if (container.dataset) {
@@ -748,23 +750,35 @@
         return defaultLabel;
     }
 
+    function syncRefreshOverlayClass(container) {
+        if (!container || !container.classList) {
+            return;
+        }
+
+        var hasRefreshStatus = !!container.querySelector('.' + REFRESH_STATUS_CLASS);
+        var hasDemoBadge = !!container.querySelector('.' + DEMO_BADGE_CLASS);
+
+        container.classList.toggle(REFRESH_OVERLAY_CLASS, hasRefreshStatus || hasDemoBadge);
+    }
+
     function updateDemoBadge(container, shouldShow) {
         if (!container) {
             return;
         }
 
-        var badge = container.querySelector('.discord-demo-badge');
+        var badge = container.querySelector('.' + DEMO_BADGE_CLASS);
 
         if (shouldShow) {
             if (!badge) {
                 badge = document.createElement('div');
-                badge.className = 'discord-demo-badge';
+                badge.className = DEMO_BADGE_CLASS;
                 badge.textContent = getDemoBadgeLabel(container);
                 container.insertBefore(badge, container.firstChild);
             } else if (!badge.textContent) {
                 badge.textContent = getDemoBadgeLabel(container);
             }
 
+            syncRefreshOverlayClass(container);
             return;
         }
 
@@ -775,6 +789,8 @@
 
             badge.parentNode.removeChild(badge);
         }
+
+        syncRefreshOverlayClass(container);
     }
 
     function showRefreshIndicator(container) {
@@ -799,6 +815,8 @@
         } else {
             status.textContent = label;
         }
+
+        syncRefreshOverlayClass(container);
     }
 
     function hideRefreshIndicator(container) {
@@ -814,6 +832,8 @@
         if (status && status.parentNode) {
             status.parentNode.removeChild(status);
         }
+
+        syncRefreshOverlayClass(container);
     }
 
     function applyDemoState(container, isDemo, isFallbackDemo) {
@@ -1242,10 +1262,27 @@
         return requestPromise;
     }
 
+    function applyInitialOverlayClasses() {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        var containers = document.querySelectorAll('.discord-stats-container');
+        if (!containers.length) {
+            return;
+        }
+
+        Array.prototype.forEach.call(containers, function (container) {
+            syncRefreshOverlayClass(container);
+        });
+    }
+
     function initializeDiscordBot() {
         var config = window.discordBotJlg || {};
         globalConfig = config;
         var missingFeatures = [];
+
+        applyInitialOverlayClasses();
 
         if (typeof window.fetch !== 'function') {
             missingFeatures.push('fetch');


### PR DESCRIPTION
## Summary
- gate the mobile padding adjustments behind a has-refresh-overlay marker so spacing only appears when overlays are present
- add JavaScript helpers to toggle the has-refresh-overlay class whenever the refresh indicator or demo badge is shown or hidden
- initialize overlay state on load so pre-rendered badges or indicators also receive the correct spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9f278044832ead07fa777a142d51