### PR TITLE
Enable Gutenberg alignment and custom class support for Discord stats block

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -70,6 +70,7 @@
         align: 'left',
         width: '',
         class: '',
+        className: '',
         icon_online: '🟢',
         icon_total: '👥',
         label_online: 'En ligne',
@@ -200,7 +201,17 @@
         edit: function (props) {
             var attributes = props.attributes || {};
             var setAttributes = props.setAttributes;
-            var blockProps = useBlockProps ? useBlockProps() : {};
+            var blockProps = useBlockProps
+                ? useBlockProps()
+                : { className: props.className || '' };
+
+            if (!blockProps) {
+                blockProps = {};
+            }
+
+            if (setAttributes && attributes.class && !attributes.className) {
+                setAttributes({ className: attributes.class });
+            }
 
             var preview = ServerSideRender
                 ? createElement(ServerSideRender, {
@@ -313,11 +324,6 @@
                             value: attributes.width,
                             onChange: updateAttribute(setAttributes, 'width'),
                             help: __('Utilisez une valeur CSS valide, ex. 100% ou 320px.', 'discord-bot-jlg')
-                        }),
-                        createElement(TextControl, {
-                            label: __('Classe(s) supplémentaire(s)', 'discord-bot-jlg'),
-                            value: attributes.class,
-                            onChange: updateAttribute(setAttributes, 'class')
                         }),
                         createElement(ToggleControl, {
                             label: __('Mode compact', 'discord-bot-jlg'),

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -16,7 +16,11 @@
     "style": "discord-bot-jlg-inline",
     "supports": {
         "html": false,
-        "customClassName": false
+        "customClassName": true,
+        "align": [
+            "wide",
+            "full"
+        ]
     },
     "attributes": {
         "layout": {

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -102,6 +102,7 @@ class Discord_Bot_JLG_Shortcode {
                 'align'                => 'left',
                 'width'                => '',
                 'class'                => '',
+                'className'            => '',
                 'icon_online'          => '🟢',
                 'icon_total'           => '👥',
                 'label_online'         => __('En ligne', 'discord-bot-jlg'),
@@ -287,15 +288,37 @@ class Discord_Bot_JLG_Shortcode {
             $container_classes[] = 'discord-total-missing';
         }
 
-        if (!empty($atts['class'])) {
-            $custom_classes = preg_split('/\s+/', $atts['class'], -1, PREG_SPLIT_NO_EMPTY);
+        $custom_class_sources = array();
 
-            if (!empty($custom_classes)) {
+        if (!empty($atts['className'])) {
+            $custom_class_sources[] = $atts['className'];
+        }
+
+        if (!empty($atts['class'])) {
+            $custom_class_sources[] = $atts['class'];
+        }
+
+        if (!empty($custom_class_sources)) {
+            $collected_custom_classes = array();
+
+            foreach ($custom_class_sources as $custom_class_value) {
+                $custom_classes = preg_split('/\s+/', $custom_class_value, -1, PREG_SPLIT_NO_EMPTY);
+
+                if (empty($custom_classes)) {
+                    continue;
+                }
+
                 $custom_classes = array_filter(array_map('sanitize_html_class', $custom_classes));
 
-                if (!empty($custom_classes)) {
-                    $container_classes = array_merge($container_classes, $custom_classes);
+                if (empty($custom_classes)) {
+                    continue;
                 }
+
+                $collected_custom_classes = array_merge($collected_custom_classes, $custom_classes);
+            }
+
+            if (!empty($collected_custom_classes)) {
+                $container_classes = array_merge($container_classes, array_unique($collected_custom_classes));
             }
         }
 


### PR DESCRIPTION
## Summary
- allow the Discord stats block to expose Gutenberg alignment controls and custom class support
- remove the bespoke class text field in the editor while keeping legacy class values in sync with the new className attribute
- update the shortcode renderer to merge className and legacy class attributes when building the container classes

## Testing
- not run (WordPress environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68debe36e78c832e9f2d5cecc04d254e