### PR TITLE
Support Gutenberg className and alignment options

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -70,8 +70,6 @@
         compact: false,
         align: 'left',
         width: '',
-        class: '',
-        className: '',
         icon_online: '🟢',
         icon_total: '👥',
         label_online: 'En ligne',
@@ -163,6 +161,33 @@
             pairs.push(key + '="' + normalized + '"');
         }
 
+        var normalizedClassName = '';
+
+        if (
+            attributes
+            && Object.prototype.hasOwnProperty.call(attributes, 'className')
+            && attributes.className
+        ) {
+            normalizedClassName = String(attributes.className);
+        }
+
+        if (
+            !normalizedClassName
+            && attributes
+            && Object.prototype.hasOwnProperty.call(attributes, 'class')
+            && attributes.class
+        ) {
+            normalizedClassName = String(attributes.class);
+        }
+
+        if (normalizedClassName) {
+            var sanitizedClassName = normalizedClassName.trim();
+
+            if (sanitizedClassName) {
+                pairs.push('className="' + sanitizedClassName.replace(/"/g, '&quot;') + '"');
+            }
+        }
+
         return '[discord_stats' + (pairs.length ? ' ' + pairs.join(' ') : '') + ']';
     }
 
@@ -210,7 +235,13 @@
                 blockProps = {};
             }
 
-            if (setAttributes && attributes.class && !attributes.className) {
+            var hasClassNameAttribute = Object.prototype.hasOwnProperty.call(attributes, 'className');
+
+            if (
+                setAttributes
+                && attributes.class
+                && (!hasClassNameAttribute || typeof attributes.className === 'undefined')
+            ) {
                 setAttributes({ className: attributes.class });
             }
 

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -15,12 +15,12 @@
     "editorStyle": "discord-bot-jlg-block-editor-style",
     "style": "discord-bot-jlg-inline",
     "supports": {
-        "html": false,
-        "customClassName": true,
         "align": [
             "wide",
             "full"
-        ]
+        ],
+        "customClassName": true,
+        "html": false
     },
     "attributes": {
         "layout": {

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -290,12 +290,26 @@ class Discord_Bot_JLG_Shortcode {
 
         $custom_class_sources = array();
 
-        if (!empty($atts['className'])) {
-            $custom_class_sources[] = $atts['className'];
+        $class_name_attribute = '';
+        if (array_key_exists('className', $received_atts)) {
+            $class_name_attribute = is_string($atts['className']) ? trim($atts['className']) : '';
+        } elseif (!empty($atts['className'])) {
+            $class_name_attribute = is_string($atts['className']) ? trim($atts['className']) : '';
         }
 
-        if (!empty($atts['class'])) {
-            $custom_class_sources[] = $atts['class'];
+        if ('' !== $class_name_attribute) {
+            $custom_class_sources[] = $class_name_attribute;
+        }
+
+        $legacy_class_attribute = '';
+        if (array_key_exists('class', $received_atts)) {
+            $legacy_class_attribute = is_string($atts['class']) ? trim($atts['class']) : '';
+        } elseif (!empty($atts['class'])) {
+            $legacy_class_attribute = is_string($atts['class']) ? trim($atts['class']) : '';
+        }
+
+        if ('' === $class_name_attribute && '' !== $legacy_class_attribute) {
+            $custom_class_sources[] = $legacy_class_attribute;
         }
 
         if (!empty($custom_class_sources)) {


### PR DESCRIPTION
## Summary
- ensure the Discord stats block declares wide/full alignment support alongside custom class names
- update the block editor script to drop the legacy `class` default, emit `className` in the shortcode output, and migrate existing content safely
- have the shortcode renderer prefer the Gutenberg-provided `className` attribute while retaining the legacy `class` fallback

## Testing
- not run (WordPress environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68dedf7b00dc832e986f359c009ba1ef