### PR TITLE
Add Discord status breakdown cards and block controls

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -301,6 +301,7 @@
     display: flex;
     align-items: center;
     gap: calc(var(--discord-gap) * 0.5);
+    flex: 1 1 clamp(160px, 28vw, 240px);
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     box-shadow: var(--discord-surface-shadow, 0 2px 4px rgba(0, 0, 0, 0.12));
     transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -336,6 +337,9 @@
     font-size: var(--discord-label-size);
     opacity: 0.9;
     margin-left: 5px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
 }
 
 

--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -1171,6 +1171,138 @@
                     }
                 }
 
+                var statusCountsData = (data.data && data.data.status_counts && typeof data.data.status_counts === 'object')
+                    ? data.data.status_counts
+                    : null;
+
+                if (statusCountsData) {
+                    if (typeof statusCountsData.idle !== 'undefined') {
+                        var idleNumber = parseInt(statusCountsData.idle, 10);
+                        if (!isNaN(idleNumber)) {
+                            updateStatElement(container, '.discord-idle .discord-number', idleNumber, formatter);
+                            var idleElement = container.querySelector('.discord-idle');
+                            if (idleElement && idleElement.dataset) {
+                                idleElement.dataset.value = idleNumber;
+                            }
+                        }
+                    }
+
+                    if (typeof statusCountsData.dnd !== 'undefined') {
+                        var dndNumber = parseInt(statusCountsData.dnd, 10);
+                        if (!isNaN(dndNumber)) {
+                            updateStatElement(container, '.discord-dnd .discord-number', dndNumber, formatter);
+                            var dndElement = container.querySelector('.discord-dnd');
+                            if (dndElement && dndElement.dataset) {
+                                dndElement.dataset.value = dndNumber;
+                            }
+                        }
+                    }
+                }
+
+                var offlineElement = container.querySelector('.discord-offline');
+                if (offlineElement) {
+                    var offlineCountValue = null;
+                    if (data.data && typeof data.data.offline_count !== 'undefined') {
+                        offlineCountValue = parseInt(data.data.offline_count, 10);
+                    } else if (statusCountsData && typeof statusCountsData.offline !== 'undefined') {
+                        offlineCountValue = parseInt(statusCountsData.offline, 10);
+                    }
+
+                    if (!isNaN(offlineCountValue) && offlineCountValue !== null) {
+                        updateStatElement(container, '.discord-offline .discord-number', offlineCountValue, formatter);
+                        if (offlineElement.dataset) {
+                            offlineElement.dataset.value = offlineCountValue;
+                        }
+                    }
+
+                    var offlineIndicator = offlineElement.querySelector('.discord-approx-indicator');
+                    var offlineIsApproximate = !!(data.data && data.data.offline_is_approximate);
+                    if (offlineIndicator) {
+                        offlineIndicator.hidden = !offlineIsApproximate;
+                    }
+
+                    var offlineLabelExtra = offlineElement.querySelector('.discord-label-extra');
+                    if (offlineLabelExtra) {
+                        var approxLabelText = offlineElement.dataset && offlineElement.dataset.labelApprox
+                            ? offlineElement.dataset.labelApprox
+                            : '';
+                        offlineLabelExtra.textContent = offlineIsApproximate ? approxLabelText : '';
+                    }
+
+                    if (offlineElement.dataset) {
+                        offlineElement.dataset.approximate = offlineIsApproximate ? 'true' : 'false';
+                    }
+                }
+
+                var voiceElement = container.querySelector('.discord-voice');
+                if (voiceElement) {
+                    var voiceParticipantsValue = null;
+                    var voiceChannelsValue = null;
+
+                    if (data.data) {
+                        if (typeof data.data.voice_participants !== 'undefined') {
+                            voiceParticipantsValue = parseInt(data.data.voice_participants, 10);
+                        }
+
+                        if (typeof data.data.voice_channels_active !== 'undefined') {
+                            voiceChannelsValue = parseInt(data.data.voice_channels_active, 10);
+                        }
+
+                        if (voiceChannelsValue === null && data.data.voice_stats && typeof data.data.voice_stats.channels !== 'undefined') {
+                            voiceChannelsValue = parseInt(data.data.voice_stats.channels, 10);
+                        }
+
+                        if (voiceParticipantsValue === null && data.data.voice_stats && typeof data.data.voice_stats.participants !== 'undefined') {
+                            voiceParticipantsValue = parseInt(data.data.voice_stats.participants, 10);
+                        }
+                    }
+
+                    if (!isNaN(voiceParticipantsValue) && voiceParticipantsValue !== null) {
+                        updateStatElement(container, '.discord-voice .discord-number', voiceParticipantsValue, formatter);
+                        if (voiceElement.dataset) {
+                            voiceElement.dataset.value = voiceParticipantsValue;
+                        }
+                    }
+
+                    if (isNaN(voiceChannelsValue) || voiceChannelsValue === null) {
+                        voiceChannelsValue = null;
+                    }
+
+                    if (voiceChannelsValue !== null) {
+                        if (voiceElement.dataset) {
+                            voiceElement.dataset.voiceChannels = voiceChannelsValue;
+                        }
+
+                        var voiceExtraElement = voiceElement.querySelector('[data-role="discord-voice-extra"]');
+                        if (voiceExtraElement) {
+                            var voiceSingular = voiceElement.dataset && voiceElement.dataset.labelVoiceExtraSingular
+                                ? voiceElement.dataset.labelVoiceExtraSingular
+                                : '%d salon actif';
+                            var voicePlural = voiceElement.dataset && voiceElement.dataset.labelVoiceExtraPlural
+                                ? voiceElement.dataset.labelVoiceExtraPlural
+                                : '%d salons actifs';
+
+                            if (voiceChannelsValue > 0) {
+                                var template = voiceChannelsValue === 1 ? voiceSingular : voicePlural;
+                                voiceExtraElement.textContent = template.replace('%d', voiceChannelsValue);
+                            } else {
+                                voiceExtraElement.textContent = '';
+                            }
+                        }
+                    }
+                }
+
+                var boostElement = container.querySelector('.discord-boosts');
+                if (boostElement && data.data && typeof data.data.boost_count !== 'undefined') {
+                    var boostValue = parseInt(data.data.boost_count, 10);
+                    if (!isNaN(boostValue)) {
+                        updateStatElement(container, '.discord-boosts .discord-number', boostValue, formatter);
+                        if (boostElement.dataset) {
+                            boostElement.dataset.value = boostValue;
+                        }
+                    }
+                }
+
                 resultInfo.success = true;
 
                 return resultInfo;

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -35,6 +35,26 @@
             "type": "boolean",
             "default": true
         },
+        "show_idle": {
+            "type": "boolean",
+            "default": false
+        },
+        "show_dnd": {
+            "type": "boolean",
+            "default": false
+        },
+        "show_offline": {
+            "type": "boolean",
+            "default": false
+        },
+        "show_voice": {
+            "type": "boolean",
+            "default": false
+        },
+        "show_boosts": {
+            "type": "boolean",
+            "default": false
+        },
         "show_title": {
             "type": "boolean",
             "default": false
@@ -83,6 +103,26 @@
             "type": "string",
             "default": "\ud83d\udc65"
         },
+        "icon_idle": {
+            "type": "string",
+            "default": "\ud83c\udf19"
+        },
+        "icon_dnd": {
+            "type": "string",
+            "default": "\u26d4\ufe0f"
+        },
+        "icon_offline": {
+            "type": "string",
+            "default": "\u26aa\ufe0f"
+        },
+        "icon_voice": {
+            "type": "string",
+            "default": "\ud83c\udfa7"
+        },
+        "icon_boosts": {
+            "type": "string",
+            "default": "\ud83d\ude80"
+        },
         "label_online": {
             "type": "string",
             "default": "En ligne"
@@ -90,6 +130,26 @@
         "label_total": {
             "type": "string",
             "default": "Membres"
+        },
+        "label_idle": {
+            "type": "string",
+            "default": "Inactifs"
+        },
+        "label_dnd": {
+            "type": "string",
+            "default": "Ne pas déranger"
+        },
+        "label_offline": {
+            "type": "string",
+            "default": "Hors ligne"
+        },
+        "label_voice": {
+            "type": "string",
+            "default": "En vocal"
+        },
+        "label_boosts": {
+            "type": "string",
+            "default": "Boosts"
         },
         "hide_labels": {
             "type": "boolean",


### PR DESCRIPTION
## Summary
- extend the Discord API layer to expose presence breakdown, boosters, and active voice channel metadata with normalized keys
- add shortcode attributes and block toggles for idle, DND, offline, voice, and boost cards with accessible markup
- update editor preview, frontend refresh logic, and styles so the new cards render consistently

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dee5074a8c832e84a13ccd90ff0bcb