### PR TITLE
Add override-aware refresh handling and widget options

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -57,6 +57,33 @@
         { label: __('Contour', 'discord-bot-jlg'), value: 'outline' }
     ];
 
+    var blockConfig = window.discordBotJlgBlockConfig || {};
+    var profileChoices = Array.isArray(blockConfig.profiles) ? blockConfig.profiles : [];
+    var profileOptions = profileChoices.map(function (choice) {
+        if (!choice || typeof choice !== 'object') {
+            return { label: '', value: '' };
+        }
+
+        var value = choice.key || '';
+        var baseLabel = choice.label || '';
+        var serverId = choice.server_id || '';
+        var computedLabel = baseLabel || serverId || value;
+
+        if (serverId) {
+            computedLabel += ' (' + serverId + ')';
+        }
+
+        return {
+            label: computedLabel,
+            value: value
+        };
+    });
+
+    profileOptions.unshift({
+        label: __('Configuration globale', 'discord-bot-jlg'),
+        value: ''
+    });
+
     var defaultAttributes = {
         layout: 'horizontal',
         show_online: true,
@@ -97,7 +124,10 @@
         cta_url: '',
         cta_style: 'solid',
         cta_new_tab: true,
-        cta_tooltip: ''
+        cta_tooltip: '',
+        profile: '',
+        server_id: '',
+        bot_token: ''
     };
 
     var REFRESH_INTERVAL_MIN = 10;
@@ -918,6 +948,32 @@
                             max: REFRESH_INTERVAL_MAX,
                             step: 5,
                             help: __('Minimum 10 secondes afin d’éviter les limitations de Discord.', 'discord-bot-jlg')
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Connexion au serveur', 'discord-bot-jlg'), initialOpen: false },
+                        createElement(SelectControl, {
+                            label: __('Profil enregistré', 'discord-bot-jlg'),
+                            value: attributes.profile || '',
+                            options: profileOptions,
+                            onChange: updateAttribute(setAttributes, 'profile'),
+                            help: profileOptions.length > 1
+                                ? __('Sélectionnez un profil sauvegardé pour utiliser ses identifiants.', 'discord-bot-jlg')
+                                : __('Gérez vos profils depuis la page d’administration du plugin.', 'discord-bot-jlg')
+                        }),
+                        createElement(TextControl, {
+                            label: __('ID du serveur (prioritaire)', 'discord-bot-jlg'),
+                            value: attributes.server_id || '',
+                            onChange: updateAttribute(setAttributes, 'server_id'),
+                            help: __('Remplace l’ID défini globalement ou dans le profil sélectionné.', 'discord-bot-jlg')
+                        }),
+                        createElement(TextControl, {
+                            label: __('Token du bot (prioritaire)', 'discord-bot-jlg'),
+                            type: 'password',
+                            value: attributes.bot_token || '',
+                            onChange: updateAttribute(setAttributes, 'bot_token'),
+                            help: __('Laisser vide pour conserver le token fourni par le profil ou la configuration globale.', 'discord-bot-jlg')
                         })
                     ),
                     createElement(

--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -35,6 +35,50 @@
         return fallback;
     }
 
+    function collectConnectionOverrides(container, config) {
+        var overrides = {
+            profileKey: '',
+            serverId: '',
+            botToken: ''
+        };
+
+        if (config && typeof config === 'object') {
+            if (typeof config.profileKey === 'string' && config.profileKey) {
+                overrides.profileKey = config.profileKey;
+            }
+
+            if (typeof config.serverId === 'string' && config.serverId) {
+                overrides.serverId = config.serverId;
+            }
+
+            if (typeof config.botToken === 'string' && config.botToken) {
+                overrides.botToken = config.botToken;
+            }
+        }
+
+        var dataset = container && container.dataset ? container.dataset : null;
+
+        if (dataset) {
+            if (typeof dataset.profileKey === 'string' && dataset.profileKey) {
+                overrides.profileKey = dataset.profileKey;
+            }
+
+            if (typeof dataset.serverIdOverride === 'string' && dataset.serverIdOverride) {
+                overrides.serverId = dataset.serverIdOverride;
+            }
+
+            if (typeof dataset.botTokenOverride === 'string' && dataset.botTokenOverride) {
+                overrides.botToken = dataset.botTokenOverride;
+            }
+        }
+
+        overrides.profileKey = overrides.profileKey ? String(overrides.profileKey).trim() : '';
+        overrides.serverId = overrides.serverId ? String(overrides.serverId).trim() : '';
+        overrides.botToken = overrides.botToken ? String(overrides.botToken).trim() : '';
+
+        return overrides;
+    }
+
     function getOrCreateErrorMessageElement(container) {
         if (!container) {
             return null;
@@ -881,6 +925,20 @@
 
         if (config.requiresNonce && config.nonce) {
             formData.append('_ajax_nonce', config.nonce);
+        }
+
+        var overrides = collectConnectionOverrides(container, config);
+
+        if (overrides.profileKey) {
+            formData.append('profile_key', overrides.profileKey);
+        }
+
+        if (overrides.serverId) {
+            formData.append('server_id', overrides.serverId);
+        }
+
+        if (overrides.botToken) {
+            formData.append('bot_token', overrides.botToken);
         }
 
         var requestPromise = fetch(config.ajaxUrl, {

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -186,6 +186,18 @@
         "cta_tooltip": {
             "type": "string",
             "default": ""
+        },
+        "profile": {
+            "type": "string",
+            "default": ""
+        },
+        "server_id": {
+            "type": "string",
+            "default": ""
+        },
+        "bot_token": {
+            "type": "string",
+            "default": ""
         }
     }
 }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
@@ -45,4 +45,46 @@ class Test_Discord_Stats_Widget extends TestCase {
         $this->assertNotNull($GLOBALS['discord_bot_jlg_last_shortcode']);
         $this->assertStringContainsString('theme="minimal"', $GLOBALS['discord_bot_jlg_last_shortcode']);
     }
+
+    public function test_update_sanitizes_connection_overrides() {
+        $widget = new Discord_Stats_Widget();
+
+        $new_instance = array(
+            'profile_key'        => 'Profil Personnel',
+            'server_id_override' => 'abc123456',
+            'bot_token_override' => " token\n",
+        );
+
+        $updated = $widget->update($new_instance, array());
+
+        $this->assertSame('profil-personnel', $updated['profile_key']);
+        $this->assertSame('123456', $updated['server_id_override']);
+        $this->assertSame('token', $updated['bot_token_override']);
+    }
+
+    public function test_widget_shortcode_includes_connection_overrides() {
+        $widget = new Discord_Stats_Widget();
+
+        $args = array(
+            'before_widget' => '',
+            'after_widget'  => '',
+            'before_title'  => '',
+            'after_title'   => '',
+        );
+
+        $instance = array(
+            'profile_key'        => 'profil-special',
+            'server_id_override' => '987654321',
+            'bot_token_override' => 'widget-token',
+        );
+
+        ob_start();
+        $widget->widget($args, $instance);
+        ob_end_clean();
+
+        $this->assertNotNull($GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('profile="profil-special"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('server_id="987654321"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('bot_token="widget-token"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+    }
 }


### PR DESCRIPTION
## Summary
- finalize the override-aware `ajax_refresh_stats()` flow so context cache keys, rate limits, and fallbacks work with profile, server, or token overrides
- propagate per-request overrides to the front-end fetch logic and expose profile/override controls in the legacy widget
- expand the test suite to cover server profile sanitization, widget override handling, and distinct cache keys for override contexts

## Testing
- ⚠️ `php /tmp/phpunit.phar -c discord-bot-jlg/phpunit.xml.dist` *(failed: unable to download phpunit due to 403 CONNECT tunnel response)*

------
https://chatgpt.com/codex/tasks/task_e_68dee50233c4832e847d9c9c493a2b6e