### PR TITLE
Add configurable Discord metric cards and styling

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -104,6 +104,104 @@
     margin-left: 5px;
 }
 
+.discord-stats-container .discord-stat.discord-approximate-members,
+.discord-stats-container .discord-stat.discord-premium-subscriptions {
+    flex: 1 1 clamp(200px, 32vw, 260px);
+}
+
+.discord-stats-container .discord-stat.discord-presence-breakdown {
+    align-items: flex-start;
+    gap: calc(var(--discord-gap) * 0.6);
+    flex: 1 1 clamp(260px, 50vw, 420px);
+}
+
+.discord-stats-container .discord-presence-breakdown .discord-icon {
+    align-self: flex-start;
+}
+
+.discord-stats-container .discord-presence-content {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--discord-gap) * 0.45);
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.discord-stats-container .discord-presence-summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: calc(var(--discord-gap) * 0.35);
+}
+
+.discord-stats-container .discord-presence-summary .discord-label {
+    margin-left: 0;
+}
+
+.discord-stats-container .discord-presence-list {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: calc(var(--discord-gap) * 0.35);
+    margin: calc(var(--discord-gap) * 0.4) 0 0;
+    padding: 0;
+    width: 100%;
+}
+
+.discord-stats-container .discord-presence-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: calc(var(--discord-gap) * 0.35);
+    padding: 0.15em 0;
+    min-width: 0;
+    font-size: calc(var(--discord-label-size) * 0.95);
+}
+
+.discord-stats-container .discord-presence-dot {
+    width: 0.65em;
+    height: 0.65em;
+    border-radius: 50%;
+    flex: 0 0 auto;
+    background: currentColor;
+    opacity: 0.9;
+}
+
+.discord-stats-container .discord-presence-item-label {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.discord-stats-container .discord-presence-item-value {
+    flex: 0 0 auto;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.discord-stats-container .discord-presence-online .discord-presence-dot {
+    color: #57f287;
+}
+
+.discord-stats-container .discord-presence-idle .discord-presence-dot {
+    color: #fee75c;
+}
+
+.discord-stats-container .discord-presence-dnd .discord-presence-dot {
+    color: #ed4245;
+}
+
+.discord-stats-container .discord-presence-offline .discord-presence-dot {
+    color: #99aab5;
+}
+
+.discord-stats-container .discord-presence-streaming .discord-presence-dot {
+    color: #593695;
+}
+
+.discord-stats-container .discord-presence-other .discord-presence-dot {
+    color: #00aff4;
+}
+
 .discord-stats-container .discord-stat:hover,
 .discord-stats-container .discord-stat:focus-visible {
     transform: translateY(-2px);
@@ -273,6 +371,10 @@
     .discord-stats-container .discord-cta-button {
         width: 100%;
         max-width: 100%;
+    }
+
+    .discord-stats-container .discord-presence-list {
+        grid-template-columns: repeat(1, minmax(0, 1fr));
     }
 }
 

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -338,6 +338,104 @@
     margin-left: 5px;
 }
 
+.discord-stat.discord-approximate-members,
+.discord-stat.discord-premium-subscriptions {
+    flex: 1 1 clamp(200px, 32vw, 260px);
+}
+
+.discord-stat.discord-presence-breakdown {
+    align-items: flex-start;
+    gap: calc(var(--discord-gap) * 0.6);
+    flex: 1 1 clamp(260px, 50vw, 420px);
+}
+
+.discord-presence-breakdown .discord-icon {
+    align-self: flex-start;
+}
+
+.discord-presence-content {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--discord-gap) * 0.45);
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.discord-presence-summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: calc(var(--discord-gap) * 0.35);
+}
+
+.discord-presence-summary .discord-label {
+    margin-left: 0;
+}
+
+.discord-presence-list {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: calc(var(--discord-gap) * 0.35);
+    margin: calc(var(--discord-gap) * 0.4) 0 0;
+    padding: 0;
+    width: 100%;
+}
+
+.discord-presence-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: calc(var(--discord-gap) * 0.35);
+    padding: 0.15em 0;
+    min-width: 0;
+    font-size: calc(var(--discord-label-size) * 0.95);
+}
+
+.discord-presence-dot {
+    width: 0.65em;
+    height: 0.65em;
+    border-radius: 50%;
+    flex: 0 0 auto;
+    background: currentColor;
+    opacity: 0.9;
+}
+
+.discord-presence-item-label {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.discord-presence-item-value {
+    flex: 0 0 auto;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.discord-presence-online .discord-presence-dot {
+    color: #57f287;
+}
+
+.discord-presence-idle .discord-presence-dot {
+    color: #fee75c;
+}
+
+.discord-presence-dnd .discord-presence-dot {
+    color: #ed4245;
+}
+
+.discord-presence-offline .discord-presence-dot {
+    color: #99aab5;
+}
+
+.discord-presence-streaming .discord-presence-dot {
+    color: #593695;
+}
+
+.discord-presence-other .discord-presence-dot {
+    color: #00aff4;
+}
+
 
 .discord-stats-error {
     background: var(--discord-error-background, #f44336);
@@ -380,6 +478,15 @@
     justify-content: center;
 }
 
+.widget .discord-presence-breakdown {
+    justify-content: flex-start;
+    align-items: flex-start;
+}
+
+.widget .discord-presence-list {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
 @media (max-width: 600px) {
     .discord-stats-container {
         --discord-gap: clamp(10px, 5vw, 16px);
@@ -399,6 +506,10 @@
     .discord-stat {
         flex: 1 1 100%;
         width: 100%;
+    }
+
+    .discord-presence-list {
+        grid-template-columns: repeat(1, minmax(0, 1fr));
     }
 
     .discord-invite {

--- a/discord-bot-jlg/block/discord-stats/block.json
+++ b/discord-bot-jlg/block/discord-stats/block.json
@@ -35,6 +35,18 @@
             "type": "boolean",
             "default": true
         },
+        "show_presence_breakdown": {
+            "type": "boolean",
+            "default": false
+        },
+        "show_approximate_member_count": {
+            "type": "boolean",
+            "default": false
+        },
+        "show_premium_subscriptions": {
+            "type": "boolean",
+            "default": false
+        },
         "show_title": {
             "type": "boolean",
             "default": false
@@ -83,6 +95,18 @@
             "type": "string",
             "default": "\ud83d\udc65"
         },
+        "icon_presence": {
+            "type": "string",
+            "default": "\ud83d\udcca"
+        },
+        "icon_approximate": {
+            "type": "string",
+            "default": "\ud83d\udcc8"
+        },
+        "icon_premium": {
+            "type": "string",
+            "default": "\ud83d\udc8e"
+        },
         "label_online": {
             "type": "string",
             "default": "En ligne"
@@ -90,6 +114,50 @@
         "label_total": {
             "type": "string",
             "default": "Membres"
+        },
+        "label_presence": {
+            "type": "string",
+            "default": "Présence par statut"
+        },
+        "label_presence_online": {
+            "type": "string",
+            "default": "En ligne"
+        },
+        "label_presence_idle": {
+            "type": "string",
+            "default": "Inactif"
+        },
+        "label_presence_dnd": {
+            "type": "string",
+            "default": "Ne pas déranger"
+        },
+        "label_presence_offline": {
+            "type": "string",
+            "default": "Hors ligne"
+        },
+        "label_presence_streaming": {
+            "type": "string",
+            "default": "En direct"
+        },
+        "label_presence_other": {
+            "type": "string",
+            "default": "Autres"
+        },
+        "label_approximate": {
+            "type": "string",
+            "default": "Membres (approx.)"
+        },
+        "label_premium": {
+            "type": "string",
+            "default": "Boosts serveur"
+        },
+        "label_premium_singular": {
+            "type": "string",
+            "default": "Boost serveur"
+        },
+        "label_premium_plural": {
+            "type": "string",
+            "default": "Boosts serveur"
         },
         "hide_labels": {
             "type": "boolean",

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -148,6 +148,30 @@ class Discord_Bot_JLG_Admin {
         );
 
         add_settings_field(
+            'show_presence_breakdown',
+            __('Afficher la répartition des présences', 'discord-bot-jlg'),
+            array($this, 'show_presence_breakdown_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
+            'show_approximate_member_count',
+            __('Afficher le total approximatif', 'discord-bot-jlg'),
+            array($this, 'show_approximate_member_count_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
+            'show_premium_subscriptions',
+            __('Afficher les boosts Nitro', 'discord-bot-jlg'),
+            array($this, 'show_premium_subscriptions_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
             'show_server_name',
             __('Afficher le nom du serveur', 'discord-bot-jlg'),
             array($this, 'show_server_name_render'),
@@ -371,6 +395,9 @@ class Discord_Bot_JLG_Admin {
         $sanitized['demo_mode']              = !empty($input['demo_mode']) ? 1 : 0;
         $sanitized['show_online']            = !empty($input['show_online']) ? 1 : 0;
         $sanitized['show_total']             = !empty($input['show_total']) ? 1 : 0;
+        $sanitized['show_presence_breakdown'] = !empty($input['show_presence_breakdown']) ? 1 : 0;
+        $sanitized['show_approximate_member_count'] = !empty($input['show_approximate_member_count']) ? 1 : 0;
+        $sanitized['show_premium_subscriptions'] = !empty($input['show_premium_subscriptions']) ? 1 : 0;
         $sanitized['show_server_name']       = !empty($input['show_server_name']) ? 1 : 0;
         $sanitized['show_server_avatar']     = !empty($input['show_server_avatar']) ? 1 : 0;
         $sanitized['default_refresh_enabled'] = !empty($input['default_refresh_enabled']) ? 1 : 0;
@@ -1059,6 +1086,38 @@ class Discord_Bot_JLG_Admin {
         <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_total]"
                value="1" <?php checked($value, 1); ?> />
         <label><?php esc_html_e('Afficher le nombre total de membres', 'discord-bot-jlg'); ?></label>
+        <?php
+    }
+
+    public function show_presence_breakdown_render() {
+        $options = get_option($this->option_name);
+        $value   = isset($options['show_presence_breakdown']) ? (int) $options['show_presence_breakdown'] : 0;
+        ?>
+        <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_presence_breakdown]"
+               value="1" <?php checked($value, 1); ?> />
+        <label><?php esc_html_e('Afficher la répartition des statuts (en ligne, inactif, DnD, etc.)', 'discord-bot-jlg'); ?></label>
+        <p class="description"><?php esc_html_e('Active une carte dédiée lorsque les données du widget ou de l’API bot sont disponibles.', 'discord-bot-jlg'); ?></p>
+        <?php
+    }
+
+    public function show_approximate_member_count_render() {
+        $options = get_option($this->option_name);
+        $value   = isset($options['show_approximate_member_count']) ? (int) $options['show_approximate_member_count'] : 0;
+        ?>
+        <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_approximate_member_count]"
+               value="1" <?php checked($value, 1); ?> />
+        <label><?php esc_html_e('Afficher le total approximatif fourni par l’API', 'discord-bot-jlg'); ?></label>
+        <p class="description"><?php esc_html_e('Affiche une seconde carte dédiée au compteur approximate_member_count lorsque le total exact est indisponible.', 'discord-bot-jlg'); ?></p>
+        <?php
+    }
+
+    public function show_premium_subscriptions_render() {
+        $options = get_option($this->option_name);
+        $value   = isset($options['show_premium_subscriptions']) ? (int) $options['show_premium_subscriptions'] : 0;
+        ?>
+        <input type="checkbox" name="<?php echo esc_attr($this->option_name); ?>[show_premium_subscriptions]"
+               value="1" <?php checked($value, 1); ?> />
+        <label><?php esc_html_e('Afficher le nombre de boosts Nitro (premium_subscription_count)', 'discord-bot-jlg'); ?></label>
         <?php
     }
 

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -67,6 +67,9 @@ class Discord_Stats_Widget extends WP_Widget {
             'layout'               => $layout,
             'show_online'          => !empty($instance['show_online']) ? 'true' : 'false',
             'show_total'           => !empty($instance['show_total']) ? 'true' : 'false',
+            'show_presence_breakdown' => !empty($instance['show_presence_breakdown']) ? 'true' : 'false',
+            'show_approximate_member_count' => !empty($instance['show_approximate_member_count']) ? 'true' : 'false',
+            'show_premium_subscriptions' => !empty($instance['show_premium_subscriptions']) ? 'true' : 'false',
             'compact'              => !empty($instance['compact']) ? 'true' : 'false',
             'hide_labels'          => !empty($instance['hide_labels']) ? 'true' : 'false',
             'hide_icons'           => !empty($instance['hide_icons']) ? 'true' : 'false',
@@ -134,6 +137,9 @@ class Discord_Stats_Widget extends WP_Widget {
 
         $instance['show_online'] = !empty($new_instance['show_online']) ? 1 : 0;
         $instance['show_total']  = !empty($new_instance['show_total']) ? 1 : 0;
+        $instance['show_presence_breakdown'] = !empty($new_instance['show_presence_breakdown']) ? 1 : 0;
+        $instance['show_approximate_member_count'] = !empty($new_instance['show_approximate_member_count']) ? 1 : 0;
+        $instance['show_premium_subscriptions'] = !empty($new_instance['show_premium_subscriptions']) ? 1 : 0;
         $instance['compact']     = !empty($new_instance['compact']) ? 1 : 0;
         $instance['hide_labels'] = !empty($new_instance['hide_labels']) ? 1 : 0;
         $instance['hide_icons']  = !empty($new_instance['hide_icons']) ? 1 : 0;
@@ -208,6 +214,24 @@ class Discord_Stats_Widget extends WP_Widget {
             <input type="checkbox" id="<?php echo esc_attr($this->get_field_id('show_total')); ?>"
                    name="<?php echo esc_attr($this->get_field_name('show_total')); ?>" value="1" <?php checked($instance['show_total'], 1); ?> />
             <label for="<?php echo esc_attr($this->get_field_id('show_total')); ?>"><?php esc_html_e('Afficher le total des membres', 'discord-bot-jlg'); ?></label>
+        </p>
+
+        <p>
+            <input type="checkbox" id="<?php echo esc_attr($this->get_field_id('show_presence_breakdown')); ?>"
+                   name="<?php echo esc_attr($this->get_field_name('show_presence_breakdown')); ?>" value="1" <?php checked($instance['show_presence_breakdown'], 1); ?> />
+            <label for="<?php echo esc_attr($this->get_field_id('show_presence_breakdown')); ?>"><?php esc_html_e('Afficher le détail par statut de présence', 'discord-bot-jlg'); ?></label>
+        </p>
+
+        <p>
+            <input type="checkbox" id="<?php echo esc_attr($this->get_field_id('show_approximate_member_count')); ?>"
+                   name="<?php echo esc_attr($this->get_field_name('show_approximate_member_count')); ?>" value="1" <?php checked($instance['show_approximate_member_count'], 1); ?> />
+            <label for="<?php echo esc_attr($this->get_field_id('show_approximate_member_count')); ?>"><?php esc_html_e('Afficher le total approximatif des membres', 'discord-bot-jlg'); ?></label>
+        </p>
+
+        <p>
+            <input type="checkbox" id="<?php echo esc_attr($this->get_field_id('show_premium_subscriptions')); ?>"
+                   name="<?php echo esc_attr($this->get_field_name('show_premium_subscriptions')); ?>" value="1" <?php checked($instance['show_premium_subscriptions'], 1); ?> />
+            <label for="<?php echo esc_attr($this->get_field_id('show_premium_subscriptions')); ?>"><?php esc_html_e('Afficher le nombre de boosts Nitro', 'discord-bot-jlg'); ?></label>
         </p>
 
         <p>
@@ -372,6 +396,9 @@ class Discord_Stats_Widget extends WP_Widget {
             'layout'               => 'horizontal',
             'show_online'          => !empty($options['show_online']) ? 1 : 0,
             'show_total'           => !empty($options['show_total']) ? 1 : 0,
+            'show_presence_breakdown' => !empty($options['show_presence_breakdown']) ? 1 : 0,
+            'show_approximate_member_count' => !empty($options['show_approximate_member_count']) ? 1 : 0,
+            'show_premium_subscriptions' => !empty($options['show_premium_subscriptions']) ? 1 : 0,
             'compact'              => 0,
             'hide_labels'          => 0,
             'hide_icons'           => 0,

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -58,6 +58,9 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             'demo_mode'      => 1,
             'show_online'    => 1,
             'show_total'     => 1,
+            'show_presence_breakdown' => 1,
+            'show_approximate_member_count' => 1,
+            'show_premium_subscriptions' => 0,
             'widget_title'   => 'Existing title',
             'cache_duration' => 450,
             'custom_css'     => '.existing { color: blue; }',
@@ -174,6 +177,18 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                     'show_server_name'       => 1,
                     'show_server_avatar'     => 1,
                     'default_refresh_enabled'=> 1,
+                ),
+            ),
+            'metric-checkboxes' => array(
+                array(
+                    'show_presence_breakdown'       => 'on',
+                    'show_approximate_member_count' => 'yes',
+                    'show_premium_subscriptions'    => '1',
+                ),
+                array(
+                    'show_presence_breakdown'       => 1,
+                    'show_approximate_member_count' => 1,
+                    'show_premium_subscriptions'    => 1,
                 ),
             ),
             'default-theme-valid' => array(
@@ -514,6 +529,9 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             'demo_mode'      => 0,
             'show_online'    => 0,
             'show_total'     => 0,
+            'show_presence_breakdown' => 0,
+            'show_approximate_member_count' => 0,
+            'show_premium_subscriptions' => 0,
             'show_server_name'   => 0,
             'show_server_avatar' => 0,
             'default_refresh_enabled' => 0,

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
@@ -62,6 +62,22 @@ class Test_Discord_Stats_Widget extends TestCase {
         $this->assertSame('token', $updated['bot_token_override']);
     }
 
+    public function test_update_handles_metric_toggles() {
+        $widget = new Discord_Stats_Widget();
+
+        $new_instance = array(
+            'show_presence_breakdown'       => '1',
+            'show_approximate_member_count' => 'yes',
+            'show_premium_subscriptions'    => 'on',
+        );
+
+        $updated = $widget->update($new_instance, array());
+
+        $this->assertSame(1, $updated['show_presence_breakdown']);
+        $this->assertSame(1, $updated['show_approximate_member_count']);
+        $this->assertSame(1, $updated['show_premium_subscriptions']);
+    }
+
     public function test_widget_shortcode_includes_connection_overrides() {
         $widget = new Discord_Stats_Widget();
 
@@ -86,5 +102,31 @@ class Test_Discord_Stats_Widget extends TestCase {
         $this->assertStringContainsString('profile="profil-special"', $GLOBALS['discord_bot_jlg_last_shortcode']);
         $this->assertStringContainsString('server_id="987654321"', $GLOBALS['discord_bot_jlg_last_shortcode']);
         $this->assertStringContainsString('bot_token="widget-token"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+    }
+
+    public function test_widget_shortcode_includes_metric_toggles() {
+        $widget = new Discord_Stats_Widget();
+
+        $args = array(
+            'before_widget' => '',
+            'after_widget'  => '',
+            'before_title'  => '',
+            'after_title'   => '',
+        );
+
+        $instance = array(
+            'show_presence_breakdown'       => 1,
+            'show_approximate_member_count' => 1,
+            'show_premium_subscriptions'    => 1,
+        );
+
+        ob_start();
+        $widget->widget($args, $instance);
+        ob_end_clean();
+
+        $this->assertNotNull($GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('show_presence_breakdown="true"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('show_approximate_member_count="true"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringContainsString('show_premium_subscriptions="true"', $GLOBALS['discord_bot_jlg_last_shortcode']);
     }
 }


### PR DESCRIPTION
## Summary
- extend the Discord API integration to expose presence breakdown, approximate member totals, and premium subscription counts across the shortcode, block, and widget
- add Gutenberg inspector toggles, widget controls, and admin settings to enable or disable each new metric card without editing attributes manually
- update front-end markup, responsive styles, and PHPUnit coverage to handle the additional stat cards and ensure the widget persists the new options

## Testing
- `phpunit -c phpunit.xml.dist` *(fails: phpunit command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68defb8e8d4c832e9ddb5e6f2b280bef