### PR TITLE
Allow Discord invite button label to wrap on narrow layouts

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -409,11 +409,11 @@
     box-shadow: 0 4px 12px var(--discord-button-shadow, rgba(88, 101, 242, 0.35));
     transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
     line-height: 1.4;
-    white-space: nowrap;
+    white-space: normal;
     border: none;
     cursor: pointer;
     flex: 1 1 clamp(220px, 40vw, 320px);
-    min-width: min(240px, 100%);
+    min-width: 0;
     max-width: 100%;
 }
 
@@ -439,7 +439,7 @@
 .discord-stats-container .discord-invite-button--compact {
     padding: calc(var(--discord-padding) * 0.55) calc(var(--discord-padding) * 1.25);
     flex: 0 1 auto;
-    min-width: auto;
+    min-width: 0;
 }
 
 .discord-stats-container .discord-logo-container {

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -259,11 +259,11 @@
     box-shadow: 0 4px 12px var(--discord-button-shadow, rgba(88, 101, 242, 0.35));
     transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
     line-height: 1.4;
-    white-space: nowrap;
+    white-space: normal;
     border: none;
     cursor: pointer;
     flex: 1 1 clamp(220px, 40vw, 320px);
-    min-width: min(240px, 100%);
+    min-width: 0;
     max-width: 100%;
 }
 
@@ -289,7 +289,7 @@
 .discord-invite-button--compact {
     padding: calc(var(--discord-padding) * 0.55) calc(var(--discord-padding) * 1.25);
     flex: 0 1 auto;
-    min-width: auto;
+    min-width: 0;
 }
 
 .discord-stat {


### PR DESCRIPTION
## Summary
- allow the Discord invite button label to wrap by relaxing its whitespace and minimum width rules
- mirror the styling change in the inline shortcode stylesheet to keep frontend/backend parity

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df966281a0832e9b0c9ec590e36aa4