### PR TITLE
Expose configurable defaults for Discord stat icons and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Accédez à la page **Discord Bot** dans l’administration pour :
 - Indiquer l’ID du serveur à surveiller ;
 - Définir la durée du cache des statistiques ;
 - Choisir les éléments affichés par défaut (nom/avatar du serveur, rafraîchissement automatique, thème) ;
+- Personnaliser les icônes et libellés proposés par défaut (cartes principales, répartition des présences, boosts) ;
 - Ajouter du CSS personnalisé.
 
 ### Définir le token via une constante
@@ -52,7 +53,7 @@ Pour activer l'auto-actualisation, utilisez par exemple :
 [discord_stats refresh="true" refresh_interval="60"]
 ```
 
-💡 Les cases à cocher et listes de la page **Configuration** servent de pré-sélection lors de l’insertion du shortcode, du bloc ou du widget. Cocher « Afficher le nom du serveur » ou « Afficher l’avatar » renseigne automatiquement `show_server_name="true"` et `show_server_avatar="true"`. Le sélecteur de thème alimente l’attribut `theme`, tandis que l’option « Rafraîchissement auto par défaut » coche `refresh="true"` et initialise `refresh_interval` avec l’intervalle numérique défini.
+💡 Les cases à cocher et listes de la page **Configuration** servent de pré-sélection lors de l’insertion du shortcode, du bloc ou du widget. Cocher « Afficher le nom du serveur » ou « Afficher l’avatar » renseigne automatiquement `show_server_name="true"` et `show_server_avatar="true"`. Le sélecteur de thème alimente l’attribut `theme`, tandis que l’option « Rafraîchissement auto par défaut » coche `refresh="true"` et initialise `refresh_interval` avec l’intervalle numérique défini. Les nouveaux panneaux « Icônes » et « Libellés par défaut » remplissent les attributs `icon_*` et `label_*` du bloc, du widget et du shortcode afin d’éviter de retaper vos émojis et textes favoris.
 
 L'attribut optionnel `width` accepte uniquement des longueurs CSS valides comme `320px`, `75%`, `42rem`, ainsi que les mots-clés `auto`, `fit-content`, `min-content` et `max-content`. Les expressions `calc(...)` sont prises en charge lorsqu'elles ne contiennent que des nombres, des unités usuelles et les opérateurs arithmétiques de base. Toute valeur non conforme est ignorée afin d'éviter l'injection de styles indésirables.
 

--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -58,6 +58,22 @@
     ];
 
     var blockConfig = window.discordBotJlgBlockConfig || {};
+    var globalDefaults = blockConfig.defaults || {};
+
+    function pickDefault(key, fallback) {
+        if (!globalDefaults || typeof globalDefaults !== 'object') {
+            return fallback;
+        }
+
+        var value = globalDefaults[key];
+
+        if (typeof value === 'undefined' || value === null || value === '') {
+            return fallback;
+        }
+
+        return value;
+    }
+
     var profileChoices = Array.isArray(blockConfig.profiles) ? blockConfig.profiles : [];
     var profileOptions = profileChoices.map(function (choice) {
         if (!choice || typeof choice !== 'object') {
@@ -100,24 +116,24 @@
         compact: false,
         align: 'left',
         width: '',
-        icon_online: '🟢',
-        icon_total: '👥',
-        icon_presence: '📊',
-        icon_approximate: '📈',
-        icon_premium: '💎',
-        label_online: 'En ligne',
-        label_total: 'Membres',
-        label_presence: 'Présence par statut',
-        label_presence_online: 'En ligne',
-        label_presence_idle: 'Inactif',
-        label_presence_dnd: 'Ne pas déranger',
-        label_presence_offline: 'Hors ligne',
-        label_presence_streaming: 'En direct',
-        label_presence_other: 'Autres',
-        label_approximate: 'Membres (approx.)',
-        label_premium: 'Boosts serveur',
-        label_premium_singular: 'Boost serveur',
-        label_premium_plural: 'Boosts serveur',
+        icon_online: pickDefault('icon_online', '🟢'),
+        icon_total: pickDefault('icon_total', '👥'),
+        icon_presence: pickDefault('icon_presence', '📊'),
+        icon_approximate: pickDefault('icon_approximate', '📈'),
+        icon_premium: pickDefault('icon_premium', '💎'),
+        label_online: pickDefault('label_online', __('En ligne', 'discord-bot-jlg')),
+        label_total: pickDefault('label_total', __('Membres', 'discord-bot-jlg')),
+        label_presence: pickDefault('label_presence', __('Présence par statut', 'discord-bot-jlg')),
+        label_presence_online: pickDefault('label_presence_online', __('En ligne', 'discord-bot-jlg')),
+        label_presence_idle: pickDefault('label_presence_idle', __('Inactif', 'discord-bot-jlg')),
+        label_presence_dnd: pickDefault('label_presence_dnd', __('Ne pas déranger', 'discord-bot-jlg')),
+        label_presence_offline: pickDefault('label_presence_offline', __('Hors ligne', 'discord-bot-jlg')),
+        label_presence_streaming: pickDefault('label_presence_streaming', __('En direct', 'discord-bot-jlg')),
+        label_presence_other: pickDefault('label_presence_other', __('Autres', 'discord-bot-jlg')),
+        label_approximate: pickDefault('label_approximate', __('Membres (approx.)', 'discord-bot-jlg')),
+        label_premium: pickDefault('label_premium', __('Boosts serveur', 'discord-bot-jlg')),
+        label_premium_singular: pickDefault('label_premium_singular', __('Boost serveur', 'discord-bot-jlg')),
+        label_premium_plural: pickDefault('label_premium_plural', __('Boosts serveur', 'discord-bot-jlg')),
         hide_labels: false,
         hide_icons: false,
         border_radius: 8,

--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -258,11 +258,38 @@ class DiscordServerStats {
             }
         }
 
+        $options_for_defaults = $this->api->get_plugin_options();
+        if (!is_array($options_for_defaults)) {
+            $options_for_defaults = array();
+        }
+
+        $block_display_defaults = array(
+            'icon_online'          => isset($options_for_defaults['default_icon_online']) ? sanitize_text_field($options_for_defaults['default_icon_online']) : '',
+            'icon_total'           => isset($options_for_defaults['default_icon_total']) ? sanitize_text_field($options_for_defaults['default_icon_total']) : '',
+            'icon_presence'        => isset($options_for_defaults['default_icon_presence']) ? sanitize_text_field($options_for_defaults['default_icon_presence']) : '',
+            'icon_approximate'     => isset($options_for_defaults['default_icon_approximate']) ? sanitize_text_field($options_for_defaults['default_icon_approximate']) : '',
+            'icon_premium'         => isset($options_for_defaults['default_icon_premium']) ? sanitize_text_field($options_for_defaults['default_icon_premium']) : '',
+            'label_online'         => isset($options_for_defaults['default_label_online']) ? sanitize_text_field($options_for_defaults['default_label_online']) : '',
+            'label_total'          => isset($options_for_defaults['default_label_total']) ? sanitize_text_field($options_for_defaults['default_label_total']) : '',
+            'label_presence'       => isset($options_for_defaults['default_label_presence']) ? sanitize_text_field($options_for_defaults['default_label_presence']) : '',
+            'label_presence_online'=> isset($options_for_defaults['default_label_presence_online']) ? sanitize_text_field($options_for_defaults['default_label_presence_online']) : '',
+            'label_presence_idle'  => isset($options_for_defaults['default_label_presence_idle']) ? sanitize_text_field($options_for_defaults['default_label_presence_idle']) : '',
+            'label_presence_dnd'   => isset($options_for_defaults['default_label_presence_dnd']) ? sanitize_text_field($options_for_defaults['default_label_presence_dnd']) : '',
+            'label_presence_offline'=> isset($options_for_defaults['default_label_presence_offline']) ? sanitize_text_field($options_for_defaults['default_label_presence_offline']) : '',
+            'label_presence_streaming'=> isset($options_for_defaults['default_label_presence_streaming']) ? sanitize_text_field($options_for_defaults['default_label_presence_streaming']) : '',
+            'label_presence_other' => isset($options_for_defaults['default_label_presence_other']) ? sanitize_text_field($options_for_defaults['default_label_presence_other']) : '',
+            'label_approximate'    => isset($options_for_defaults['default_label_approximate']) ? sanitize_text_field($options_for_defaults['default_label_approximate']) : '',
+            'label_premium'        => isset($options_for_defaults['default_label_premium']) ? sanitize_text_field($options_for_defaults['default_label_premium']) : '',
+            'label_premium_singular' => isset($options_for_defaults['default_label_premium_singular']) ? sanitize_text_field($options_for_defaults['default_label_premium_singular']) : '',
+            'label_premium_plural' => isset($options_for_defaults['default_label_premium_plural']) ? sanitize_text_field($options_for_defaults['default_label_premium_plural']) : '',
+        );
+
         wp_localize_script(
             $script_handle,
             'discordBotJlgBlockConfig',
             array(
                 'profiles' => $profiles_for_block,
+                'defaults' => $block_display_defaults,
             )
         );
 

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -188,6 +188,22 @@ class Discord_Bot_JLG_Admin {
         );
 
         add_settings_field(
+            'default_stat_icons',
+            __('Icônes par défaut', 'discord-bot-jlg'),
+            array($this, 'default_stat_icons_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
+            'default_stat_labels',
+            __('Libellés par défaut', 'discord-bot-jlg'),
+            array($this, 'default_stat_labels_render'),
+            'discord_stats_settings',
+            'discord_stats_display_section'
+        );
+
+        add_settings_field(
             'default_theme',
             __('Thème par défaut', 'discord-bot-jlg'),
             array($this, 'default_theme_render'),
@@ -334,6 +350,60 @@ class Discord_Bot_JLG_Admin {
             'accent_color'       => $existing_colors['accent_color'],
             'accent_color_alt'   => $existing_colors['accent_color_alt'],
             'accent_text_color'  => $existing_colors['accent_text_color'],
+            'default_icon_online'      => isset($current_options['default_icon_online'])
+                ? sanitize_text_field($current_options['default_icon_online'])
+                : '',
+            'default_icon_total'       => isset($current_options['default_icon_total'])
+                ? sanitize_text_field($current_options['default_icon_total'])
+                : '',
+            'default_icon_presence'    => isset($current_options['default_icon_presence'])
+                ? sanitize_text_field($current_options['default_icon_presence'])
+                : '',
+            'default_icon_approximate' => isset($current_options['default_icon_approximate'])
+                ? sanitize_text_field($current_options['default_icon_approximate'])
+                : '',
+            'default_icon_premium'     => isset($current_options['default_icon_premium'])
+                ? sanitize_text_field($current_options['default_icon_premium'])
+                : '',
+            'default_label_online'            => isset($current_options['default_label_online'])
+                ? sanitize_text_field($current_options['default_label_online'])
+                : '',
+            'default_label_total'             => isset($current_options['default_label_total'])
+                ? sanitize_text_field($current_options['default_label_total'])
+                : '',
+            'default_label_presence'          => isset($current_options['default_label_presence'])
+                ? sanitize_text_field($current_options['default_label_presence'])
+                : '',
+            'default_label_presence_online'   => isset($current_options['default_label_presence_online'])
+                ? sanitize_text_field($current_options['default_label_presence_online'])
+                : '',
+            'default_label_presence_idle'     => isset($current_options['default_label_presence_idle'])
+                ? sanitize_text_field($current_options['default_label_presence_idle'])
+                : '',
+            'default_label_presence_dnd'      => isset($current_options['default_label_presence_dnd'])
+                ? sanitize_text_field($current_options['default_label_presence_dnd'])
+                : '',
+            'default_label_presence_offline'  => isset($current_options['default_label_presence_offline'])
+                ? sanitize_text_field($current_options['default_label_presence_offline'])
+                : '',
+            'default_label_presence_streaming'=> isset($current_options['default_label_presence_streaming'])
+                ? sanitize_text_field($current_options['default_label_presence_streaming'])
+                : '',
+            'default_label_presence_other'    => isset($current_options['default_label_presence_other'])
+                ? sanitize_text_field($current_options['default_label_presence_other'])
+                : '',
+            'default_label_approximate'       => isset($current_options['default_label_approximate'])
+                ? sanitize_text_field($current_options['default_label_approximate'])
+                : '',
+            'default_label_premium'           => isset($current_options['default_label_premium'])
+                ? sanitize_text_field($current_options['default_label_premium'])
+                : '',
+            'default_label_premium_singular'  => isset($current_options['default_label_premium_singular'])
+                ? sanitize_text_field($current_options['default_label_premium_singular'])
+                : '',
+            'default_label_premium_plural'    => isset($current_options['default_label_premium_plural'])
+                ? sanitize_text_field($current_options['default_label_premium_plural'])
+                : '',
         );
 
         if (isset($input['server_id'])) {
@@ -496,6 +566,42 @@ class Discord_Bot_JLG_Admin {
             $sanitized_color = discord_bot_jlg_sanitize_color($raw_color);
 
             $sanitized[$color_field] = $sanitized_color;
+        }
+
+        $text_fields = array(
+            'default_icon_online',
+            'default_icon_total',
+            'default_icon_presence',
+            'default_icon_approximate',
+            'default_icon_premium',
+            'default_label_online',
+            'default_label_total',
+            'default_label_presence',
+            'default_label_presence_online',
+            'default_label_presence_idle',
+            'default_label_presence_dnd',
+            'default_label_presence_offline',
+            'default_label_presence_streaming',
+            'default_label_presence_other',
+            'default_label_approximate',
+            'default_label_premium',
+            'default_label_premium_singular',
+            'default_label_premium_plural',
+        );
+
+        foreach ($text_fields as $text_field) {
+            if (!array_key_exists($text_field, $input)) {
+                continue;
+            }
+
+            $raw_value = is_string($input[$text_field]) ? trim($input[$text_field]) : '';
+
+            if ('' === $raw_value) {
+                $sanitized[$text_field] = '';
+                continue;
+            }
+
+            $sanitized[$text_field] = sanitize_text_field($raw_value);
         }
 
         $existing_profiles = isset($current_options['server_profiles']) && is_array($current_options['server_profiles'])
@@ -1149,6 +1255,106 @@ class Discord_Bot_JLG_Admin {
         <?php
     }
 
+    public function default_stat_icons_render() {
+        $options = get_option($this->option_name);
+        if (!is_array($options)) {
+            $options = array();
+        }
+
+        $defaults = array(
+            'default_icon_online'      => array('label' => __('Membres en ligne', 'discord-bot-jlg'), 'placeholder' => '🟢'),
+            'default_icon_total'       => array('label' => __('Total des membres', 'discord-bot-jlg'), 'placeholder' => '👥'),
+            'default_icon_presence'    => array('label' => __('Répartition des présences', 'discord-bot-jlg'), 'placeholder' => '📊'),
+            'default_icon_approximate' => array('label' => __('Total approximatif', 'discord-bot-jlg'), 'placeholder' => '📈'),
+            'default_icon_premium'     => array('label' => __('Boosts Nitro', 'discord-bot-jlg'), 'placeholder' => '💎'),
+        );
+
+        ?>
+        <fieldset>
+            <legend class="screen-reader-text"><?php esc_html_e('Icônes par défaut', 'discord-bot-jlg'); ?></legend>
+            <p class="description"><?php esc_html_e('Définissez des icônes ou émojis proposés par défaut dans le shortcode, le bloc et le widget.', 'discord-bot-jlg'); ?></p>
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; max-width: 720px;">
+                <?php foreach ($defaults as $option_key => $metadata) :
+                    $current_value = isset($options[$option_key]) ? $options[$option_key] : '';
+                    ?>
+                    <label style="display: flex; flex-direction: column; gap: 4px;">
+                        <span><?php echo esc_html($metadata['label']); ?></span>
+                        <input type="text"
+                               name="<?php echo esc_attr($this->option_name); ?>[<?php echo esc_attr($option_key); ?>]"
+                               value="<?php echo esc_attr($current_value); ?>"
+                               class="regular-text"
+                               style="max-width: 120px;"
+                               placeholder="<?php echo esc_attr($metadata['placeholder']); ?>" />
+                    </label>
+                <?php endforeach; ?>
+            </div>
+        </fieldset>
+        <?php
+    }
+
+    public function default_stat_labels_render() {
+        $options = get_option($this->option_name);
+        if (!is_array($options)) {
+            $options = array();
+        }
+
+        $main_labels = array(
+            'default_label_online'      => array('label' => __('Membres en ligne', 'discord-bot-jlg'), 'placeholder' => __('En ligne', 'discord-bot-jlg')),
+            'default_label_total'       => array('label' => __('Total des membres', 'discord-bot-jlg'), 'placeholder' => __('Membres', 'discord-bot-jlg')),
+            'default_label_presence'    => array('label' => __('Titre de la répartition', 'discord-bot-jlg'), 'placeholder' => __('Présence par statut', 'discord-bot-jlg')),
+            'default_label_approximate' => array('label' => __('Total approximatif', 'discord-bot-jlg'), 'placeholder' => __('Membres (approx.)', 'discord-bot-jlg')),
+            'default_label_premium'     => array('label' => __('Boosts (libellé global)', 'discord-bot-jlg'), 'placeholder' => __('Boosts serveur', 'discord-bot-jlg')),
+            'default_label_premium_singular' => array('label' => __('Boost (singulier)', 'discord-bot-jlg'), 'placeholder' => __('Boost serveur', 'discord-bot-jlg')),
+            'default_label_premium_plural'   => array('label' => __('Boosts (pluriel)', 'discord-bot-jlg'), 'placeholder' => __('Boosts serveur', 'discord-bot-jlg')),
+        );
+
+        $presence_labels = array(
+            'default_label_presence_online'    => array('label' => __('Présence : en ligne', 'discord-bot-jlg'), 'placeholder' => __('En ligne', 'discord-bot-jlg')),
+            'default_label_presence_idle'      => array('label' => __('Présence : inactif', 'discord-bot-jlg'), 'placeholder' => __('Inactif', 'discord-bot-jlg')),
+            'default_label_presence_dnd'       => array('label' => __('Présence : ne pas déranger', 'discord-bot-jlg'), 'placeholder' => __('Ne pas déranger', 'discord-bot-jlg')),
+            'default_label_presence_offline'   => array('label' => __('Présence : hors ligne', 'discord-bot-jlg'), 'placeholder' => __('Hors ligne', 'discord-bot-jlg')),
+            'default_label_presence_streaming' => array('label' => __('Présence : en direct', 'discord-bot-jlg'), 'placeholder' => __('En direct', 'discord-bot-jlg')),
+            'default_label_presence_other'     => array('label' => __('Présence : autres', 'discord-bot-jlg'), 'placeholder' => __('Autres', 'discord-bot-jlg')),
+        );
+
+        ?>
+        <fieldset>
+            <legend class="screen-reader-text"><?php esc_html_e('Libellés par défaut', 'discord-bot-jlg'); ?></legend>
+            <p class="description"><?php esc_html_e('Ces textes sont injectés automatiquement dans le bloc, le shortcode et le widget. Laissez vide pour conserver les libellés natifs.', 'discord-bot-jlg'); ?></p>
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; max-width: 900px;">
+                <?php foreach ($main_labels as $option_key => $metadata) :
+                    $current_value = isset($options[$option_key]) ? $options[$option_key] : '';
+                    ?>
+                    <label style="display: flex; flex-direction: column; gap: 4px;">
+                        <span><?php echo esc_html($metadata['label']); ?></span>
+                        <input type="text"
+                               name="<?php echo esc_attr($this->option_name); ?>[<?php echo esc_attr($option_key); ?>]"
+                               value="<?php echo esc_attr($current_value); ?>"
+                               class="regular-text"
+                               placeholder="<?php echo esc_attr($metadata['placeholder']); ?>" />
+                    </label>
+                <?php endforeach; ?>
+            </div>
+
+            <h4 style="margin-top: 18px;"><?php esc_html_e('Détails de présence', 'discord-bot-jlg'); ?></h4>
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; max-width: 900px;">
+                <?php foreach ($presence_labels as $option_key => $metadata) :
+                    $current_value = isset($options[$option_key]) ? $options[$option_key] : '';
+                    ?>
+                    <label style="display: flex; flex-direction: column; gap: 4px;">
+                        <span><?php echo esc_html($metadata['label']); ?></span>
+                        <input type="text"
+                               name="<?php echo esc_attr($this->option_name); ?>[<?php echo esc_attr($option_key); ?>]"
+                               value="<?php echo esc_attr($current_value); ?>"
+                               class="regular-text"
+                               placeholder="<?php echo esc_attr($metadata['placeholder']); ?>" />
+                    </label>
+                <?php endforeach; ?>
+            </div>
+        </fieldset>
+        <?php
+    }
+
     /**
      * Rend le sélecteur de thème par défaut.
      */
@@ -1582,6 +1788,7 @@ class Discord_Bot_JLG_Admin {
                 <li><?php echo wp_kses_post(__('« Afficher le nom du serveur » pré-renseigne <code>show_server_name="true"</code>.', 'discord-bot-jlg')); ?></li>
                 <li><?php echo wp_kses_post(__('« Afficher l\'avatar » active <code>show_server_avatar="true"</code> et ajuste la taille depuis la barre latérale du bloc.', 'discord-bot-jlg')); ?></li>
                 <li><?php echo wp_kses_post(__('Le thème choisi devient la valeur par défaut de l\'attribut <code>theme</code>.', 'discord-bot-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('Les icônes et libellés saisis dans « Icônes/Libellés par défaut » sont proposés automatiquement partout (bloc, widget, shortcode).', 'discord-bot-jlg')); ?></li>
                 <li><?php echo wp_kses_post(__('En cochant « Rafraîchissement auto », le shortcode/ bloc utilise <code>refresh="true"</code> et l\'intervalle numérique saisi pour <code>refresh_interval</code>.', 'discord-bot-jlg')); ?></li>
             </ul>
 

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -55,6 +55,40 @@ class Discord_Bot_JLG_Shortcode {
             'accent_text_color'  => isset($options['accent_text_color']) ? discord_bot_jlg_sanitize_color($options['accent_text_color']) : '',
         );
 
+        $default_text_sources = array(
+            'icon_online'          => array('option' => 'default_icon_online', 'fallback' => '🟢'),
+            'icon_total'           => array('option' => 'default_icon_total', 'fallback' => '👥'),
+            'icon_presence'        => array('option' => 'default_icon_presence', 'fallback' => '📊'),
+            'icon_approximate'     => array('option' => 'default_icon_approximate', 'fallback' => '📈'),
+            'icon_premium'         => array('option' => 'default_icon_premium', 'fallback' => '💎'),
+            'label_online'         => array('option' => 'default_label_online', 'fallback' => __('En ligne', 'discord-bot-jlg')),
+            'label_total'          => array('option' => 'default_label_total', 'fallback' => __('Membres', 'discord-bot-jlg')),
+            'label_presence'       => array('option' => 'default_label_presence', 'fallback' => __('Présence par statut', 'discord-bot-jlg')),
+            'label_presence_online'=> array('option' => 'default_label_presence_online', 'fallback' => __('En ligne', 'discord-bot-jlg')),
+            'label_presence_idle'  => array('option' => 'default_label_presence_idle', 'fallback' => __('Inactif', 'discord-bot-jlg')),
+            'label_presence_dnd'   => array('option' => 'default_label_presence_dnd', 'fallback' => __('Ne pas déranger', 'discord-bot-jlg')),
+            'label_presence_offline'=> array('option' => 'default_label_presence_offline', 'fallback' => __('Hors ligne', 'discord-bot-jlg')),
+            'label_presence_streaming'=> array('option' => 'default_label_presence_streaming', 'fallback' => __('En direct', 'discord-bot-jlg')),
+            'label_presence_other' => array('option' => 'default_label_presence_other', 'fallback' => __('Autres', 'discord-bot-jlg')),
+            'label_approximate'    => array('option' => 'default_label_approximate', 'fallback' => __('Membres (approx.)', 'discord-bot-jlg')),
+            'label_premium'        => array('option' => 'default_label_premium', 'fallback' => __('Boosts serveur', 'discord-bot-jlg')),
+            'label_premium_singular' => array('option' => 'default_label_premium_singular', 'fallback' => __('Boost serveur', 'discord-bot-jlg')),
+            'label_premium_plural' => array('option' => 'default_label_premium_plural', 'fallback' => __('Boosts serveur', 'discord-bot-jlg')),
+        );
+
+        $default_texts = array();
+
+        foreach ($default_text_sources as $attribute_key => $config) {
+            $option_key = $config['option'];
+            $raw_value  = isset($options[$option_key]) ? sanitize_text_field($options[$option_key]) : '';
+
+            if ('' === $raw_value) {
+                $raw_value = $config['fallback'];
+            }
+
+            $default_texts[$attribute_key] = $raw_value;
+        }
+
         $default_invite_url = isset($options['invite_url']) ? esc_url_raw($options['invite_url']) : '';
         $default_invite_label = isset($options['invite_label'])
             ? sanitize_text_field($options['invite_label'])
@@ -106,24 +140,24 @@ class Discord_Bot_JLG_Shortcode {
                 'width'                => '',
                 'class'                => '',
                 'className'            => '',
-                'icon_online'          => '🟢',
-                'icon_total'           => '👥',
-                'icon_presence'        => '📊',
-                'icon_approximate'     => '📈',
-                'icon_premium'         => '💎',
-                'label_online'         => __('En ligne', 'discord-bot-jlg'),
-                'label_total'          => __('Membres', 'discord-bot-jlg'),
-                'label_presence'       => __('Présence par statut', 'discord-bot-jlg'),
-                'label_presence_online'=> __('En ligne', 'discord-bot-jlg'),
-                'label_presence_idle'  => __('Inactif', 'discord-bot-jlg'),
-                'label_presence_dnd'   => __('Ne pas déranger', 'discord-bot-jlg'),
-                'label_presence_offline'=> __('Hors ligne', 'discord-bot-jlg'),
-                'label_presence_streaming'=> __('En direct', 'discord-bot-jlg'),
-                'label_presence_other' => __('Autres', 'discord-bot-jlg'),
-                'label_approximate'    => __('Membres (approx.)', 'discord-bot-jlg'),
-                'label_premium'        => __('Boosts serveur', 'discord-bot-jlg'),
-                'label_premium_singular' => __('Boost serveur', 'discord-bot-jlg'),
-                'label_premium_plural' => __('Boosts serveur', 'discord-bot-jlg'),
+                'icon_online'          => $default_texts['icon_online'],
+                'icon_total'           => $default_texts['icon_total'],
+                'icon_presence'        => $default_texts['icon_presence'],
+                'icon_approximate'     => $default_texts['icon_approximate'],
+                'icon_premium'         => $default_texts['icon_premium'],
+                'label_online'         => $default_texts['label_online'],
+                'label_total'          => $default_texts['label_total'],
+                'label_presence'       => $default_texts['label_presence'],
+                'label_presence_online'=> $default_texts['label_presence_online'],
+                'label_presence_idle'  => $default_texts['label_presence_idle'],
+                'label_presence_dnd'   => $default_texts['label_presence_dnd'],
+                'label_presence_offline'=> $default_texts['label_presence_offline'],
+                'label_presence_streaming'=> $default_texts['label_presence_streaming'],
+                'label_presence_other' => $default_texts['label_presence_other'],
+                'label_approximate'    => $default_texts['label_approximate'],
+                'label_premium'        => $default_texts['label_premium'],
+                'label_premium_singular' => $default_texts['label_premium_singular'],
+                'label_premium_plural' => $default_texts['label_premium_plural'],
                 'hide_labels'          => false,
                 'hide_icons'           => false,
                 'border_radius'        => '8',

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -107,6 +107,41 @@ class Discord_Stats_Widget extends WP_Widget {
             $shortcode_atts['bot_token'] = $bot_token_override;
         }
 
+        $textual_attributes = array(
+            'icon_online',
+            'icon_total',
+            'icon_presence',
+            'icon_approximate',
+            'icon_premium',
+            'label_online',
+            'label_total',
+            'label_presence',
+            'label_presence_online',
+            'label_presence_idle',
+            'label_presence_dnd',
+            'label_presence_offline',
+            'label_presence_streaming',
+            'label_presence_other',
+            'label_approximate',
+            'label_premium',
+            'label_premium_singular',
+            'label_premium_plural',
+        );
+
+        foreach ($textual_attributes as $attribute_key) {
+            if (!array_key_exists($attribute_key, $instance)) {
+                continue;
+            }
+
+            $raw_value = $instance[$attribute_key];
+
+            if ('' === $raw_value || null === $raw_value) {
+                continue;
+            }
+
+            $shortcode_atts[$attribute_key] = sanitize_text_field($raw_value);
+        }
+
         $attr_parts = array();
         foreach ($shortcode_atts as $key => $value) {
             if ('' === $value) {
@@ -391,6 +426,27 @@ class Discord_Stats_Widget extends WP_Widget {
             $cache_duration = $min_refresh;
         }
 
+        $display_defaults = array(
+            'icon_online'          => isset($options['default_icon_online']) ? sanitize_text_field($options['default_icon_online']) : '',
+            'icon_total'           => isset($options['default_icon_total']) ? sanitize_text_field($options['default_icon_total']) : '',
+            'icon_presence'        => isset($options['default_icon_presence']) ? sanitize_text_field($options['default_icon_presence']) : '',
+            'icon_approximate'     => isset($options['default_icon_approximate']) ? sanitize_text_field($options['default_icon_approximate']) : '',
+            'icon_premium'         => isset($options['default_icon_premium']) ? sanitize_text_field($options['default_icon_premium']) : '',
+            'label_online'         => isset($options['default_label_online']) ? sanitize_text_field($options['default_label_online']) : '',
+            'label_total'          => isset($options['default_label_total']) ? sanitize_text_field($options['default_label_total']) : '',
+            'label_presence'       => isset($options['default_label_presence']) ? sanitize_text_field($options['default_label_presence']) : '',
+            'label_presence_online'=> isset($options['default_label_presence_online']) ? sanitize_text_field($options['default_label_presence_online']) : '',
+            'label_presence_idle'  => isset($options['default_label_presence_idle']) ? sanitize_text_field($options['default_label_presence_idle']) : '',
+            'label_presence_dnd'   => isset($options['default_label_presence_dnd']) ? sanitize_text_field($options['default_label_presence_dnd']) : '',
+            'label_presence_offline'=> isset($options['default_label_presence_offline']) ? sanitize_text_field($options['default_label_presence_offline']) : '',
+            'label_presence_streaming'=> isset($options['default_label_presence_streaming']) ? sanitize_text_field($options['default_label_presence_streaming']) : '',
+            'label_presence_other' => isset($options['default_label_presence_other']) ? sanitize_text_field($options['default_label_presence_other']) : '',
+            'label_approximate'    => isset($options['default_label_approximate']) ? sanitize_text_field($options['default_label_approximate']) : '',
+            'label_premium'        => isset($options['default_label_premium']) ? sanitize_text_field($options['default_label_premium']) : '',
+            'label_premium_singular' => isset($options['default_label_premium_singular']) ? sanitize_text_field($options['default_label_premium_singular']) : '',
+            'label_premium_plural' => isset($options['default_label_premium_plural']) ? sanitize_text_field($options['default_label_premium_plural']) : '',
+        );
+
         return array(
             'title'                => $default_title,
             'layout'               => 'horizontal',
@@ -412,6 +468,24 @@ class Discord_Stats_Widget extends WP_Widget {
             'profile_key'          => '',
             'server_id_override'   => '',
             'bot_token_override'   => '',
+            'icon_online'          => $display_defaults['icon_online'],
+            'icon_total'           => $display_defaults['icon_total'],
+            'icon_presence'        => $display_defaults['icon_presence'],
+            'icon_approximate'     => $display_defaults['icon_approximate'],
+            'icon_premium'         => $display_defaults['icon_premium'],
+            'label_online'         => $display_defaults['label_online'],
+            'label_total'          => $display_defaults['label_total'],
+            'label_presence'       => $display_defaults['label_presence'],
+            'label_presence_online'=> $display_defaults['label_presence_online'],
+            'label_presence_idle'  => $display_defaults['label_presence_idle'],
+            'label_presence_dnd'   => $display_defaults['label_presence_dnd'],
+            'label_presence_offline'=> $display_defaults['label_presence_offline'],
+            'label_presence_streaming'=> $display_defaults['label_presence_streaming'],
+            'label_presence_other' => $display_defaults['label_presence_other'],
+            'label_approximate'    => $display_defaults['label_approximate'],
+            'label_premium'        => $display_defaults['label_premium'],
+            'label_premium_singular' => $display_defaults['label_premium_singular'],
+            'label_premium_plural' => $display_defaults['label_premium_plural'],
         );
     }
 }

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -48,6 +48,24 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
             'accent_color' => '#654321',
             'accent_color_alt' => '#765432',
             'accent_text_color' => '#111111',
+            'default_icon_online' => '🔥',
+            'default_icon_total' => '🧑‍🤝‍🧑',
+            'default_icon_presence' => '🛰️',
+            'default_icon_approximate' => '📐',
+            'default_icon_premium' => '💠',
+            'default_label_online' => 'Actifs',
+            'default_label_total' => 'Membres inscrits',
+            'default_label_presence' => 'Répartition des membres',
+            'default_label_presence_online' => 'Connectés',
+            'default_label_presence_idle' => 'En pause',
+            'default_label_presence_dnd' => 'Occupés',
+            'default_label_presence_offline' => 'Déconnectés',
+            'default_label_presence_streaming' => 'En stream',
+            'default_label_presence_other' => 'Autres statuts',
+            'default_label_approximate' => 'Total approx.',
+            'default_label_premium' => 'Boosts actifs',
+            'default_label_premium_singular' => 'Boost actif',
+            'default_label_premium_plural' => 'Boosts actifs',
         );
 
         $stats = array(
@@ -175,6 +193,12 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertStringContainsString('--discord-accent: #654321', $html);
         $this->assertStringContainsString('--discord-accent-secondary: #765432', $html);
         $this->assertStringContainsString('--discord-accent-contrast: #111111', $html);
+        $this->assertStringContainsString('data-label-online="Actifs"', $html);
+        $this->assertStringContainsString('discord-icon">🔥<', $html);
+        $this->assertStringContainsString('data-label-total="Membres inscrits"', $html);
+        $this->assertStringContainsString('data-label-presence="Répartition des membres"', $html);
+        $this->assertStringContainsString('data-label-other="Autres statuts"', $html);
+        $this->assertStringContainsString('data-label-premium="Boosts actifs"', $html);
     }
 
     public function test_render_shortcode_includes_custom_colors() {


### PR DESCRIPTION
## Summary
- add admin settings to persist default icons and labels for Discord statistics, including sanitization
- propagate these defaults through the shortcode, widget and Gutenberg block so authors receive pre-filled attributes
- document the new configuration options and cover the behaviour in unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df96626fd8832eac746874cf9d27c8