### PR TITLE
Improve ARIA for error alert

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -258,7 +258,7 @@ class Discord_Bot_JLG_Shortcode {
 
         if (!is_array($stats)) {
             return sprintf(
-                '<div class="discord-stats-error">%s</div>',
+                '<div class="discord-stats-error" role="alert" aria-live="assertive">%s</div>',
                 esc_html__('Impossible de récupérer les stats Discord', 'discord-bot-jlg')
             );
         }


### PR DESCRIPTION
## Summary
- ensure the shortcode error container announces failures with role="alert" and aria-live="assertive"
- confirm the existing discord-stats-error styling remains compatible with the new accessibility attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc1c49f7c832eb3b5e0314cceeabc