### PR TITLE
Ensure Discord stats retain accessible labels

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -680,7 +680,8 @@ class Discord_Bot_JLG_Shortcode {
                     <div class="discord-stat discord-online"
                         data-value="<?php echo esc_attr((int) $stats['online']); ?>"
                         data-label-online="<?php echo esc_attr($atts['label_online']); ?>"
-                        data-hide-labels="<?php echo esc_attr($hide_labels ? 'true' : 'false'); ?>">
+                        data-hide-labels="<?php echo esc_attr($hide_labels ? 'true' : 'false'); ?>"
+                        data-label-id="<?php echo esc_attr($online_label_id); ?>">
                         <?php if (!$hide_icons): ?>
                         <span class="discord-icon"><?php echo esc_html($atts['icon_online']); ?></span>
                         <?php endif; ?>


### PR DESCRIPTION
## Summary
- preserve the HTML structure inside Discord stat counters so screen reader labels remain intact
- ensure dynamically created online labels expose a stable id and wire aria-labelledby automatically
- expose the server-rendered label id on the online counter for script reuse

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfccd41550832e86a6e4b6c341ce2e