### PR TITLE
Polish Discord stats region labelling metadata

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -282,6 +282,10 @@
             label = baseLabel || serverName || 'Discord';
         }
 
+        if (typeof label === 'string') {
+            label = label.trim();
+        }
+
         var labelElements = [];
         var seenElements = [];
 

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -553,6 +553,14 @@ class Discord_Bot_JLG_Shortcode {
             $render_synthetic_label   = true;
         }
 
+        if (!empty($region_label_ids)) {
+            $region_label_ids = array_values(array_unique(array_filter($region_label_ids, 'strlen')));
+        }
+
+        if ('' !== $region_label_text) {
+            $region_label_text = trim($region_label_text);
+        }
+
         $attributes = array(
             sprintf('id="%s"', esc_attr($unique_id)),
             sprintf('class="%s"', esc_attr(implode(' ', $container_classes))),


### PR DESCRIPTION
## Summary
- de-duplicate and trim region label identifiers before wiring the container attributes server-side
- trim the computed aria-label text on refresh to avoid stray whitespace in region metadata

## Testing
- php -l discord-bot-jlg/inc/class-discord-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68e03bade338832e8a4bae7444fd242b