### PR TITLE
Use random IVs for Discord token encryption

### DIFF
--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Helpers.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Helpers.php
@@ -38,6 +38,31 @@ class Test_Discord_Bot_JLG_Helpers extends TestCase {
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
+    public function test_encrypt_secret_generates_unique_ciphertext_each_time() {
+        $this->define_auth_constants();
+
+        $plaintext = 'discord-secret-token';
+
+        $first = discord_bot_jlg_encrypt_secret($plaintext);
+        $second = discord_bot_jlg_encrypt_secret($plaintext);
+
+        $this->assertFalse(is_wp_error($first));
+        $this->assertFalse(is_wp_error($second));
+        $this->assertNotSame($first, $second);
+
+        $decrypted_first = discord_bot_jlg_decrypt_secret($first);
+        $decrypted_second = discord_bot_jlg_decrypt_secret($second);
+
+        $this->assertFalse(is_wp_error($decrypted_first));
+        $this->assertFalse(is_wp_error($decrypted_second));
+        $this->assertSame($plaintext, $decrypted_first);
+        $this->assertSame($plaintext, $decrypted_second);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_encrypt_secret_returns_error_when_constants_missing() {
         $result = discord_bot_jlg_encrypt_secret('token');
 
@@ -160,6 +185,41 @@ class Test_Discord_Bot_JLG_Helpers extends TestCase {
             'Le token chiffré n’a pas pu être vérifié.',
             $result->get_error_message()
         );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_decrypt_secret_migrates_legacy_secret() {
+        $this->define_auth_constants();
+
+        $plaintext = 'legacy-token-value';
+
+        $key_material = hash('sha256', self::AUTH_KEY, true);
+        $iv_material  = hash('sha256', self::AUTH_SALT . self::AUTH_KEY, true);
+        $iv           = substr($iv_material, 0, 16);
+        $ciphertext   = openssl_encrypt($plaintext, 'aes-256-cbc', $key_material, OPENSSL_RAW_DATA, $iv);
+        $mac          = hash_hmac('sha256', $ciphertext, self::AUTH_SALT, true);
+        $legacy       = DISCORD_BOT_JLG_SECRET_PREFIX_LEGACY . base64_encode($ciphertext . $mac);
+
+        $this->assertTrue(discord_bot_jlg_is_encrypted_secret($legacy));
+
+        $captured = null;
+        add_action('discord_bot_jlg_secret_migrated', function ($migrated, $original) use (&$captured) {
+            $captured = array($migrated, $original);
+        }, 10, 2);
+
+        $decrypted = discord_bot_jlg_decrypt_secret($legacy);
+
+        $this->assertFalse(is_wp_error($decrypted));
+        $this->assertSame($plaintext, $decrypted);
+        $this->assertIsArray($captured);
+        $this->assertSame($legacy, $captured[1]);
+        $this->assertTrue(discord_bot_jlg_is_encrypted_secret($captured[0]));
+        $this->assertStringStartsWith(DISCORD_BOT_JLG_SECRET_PREFIX, $captured[0]);
+
+        remove_all_filters('discord_bot_jlg_secret_migrated');
     }
 
     private function define_auth_constants(): void {

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -431,6 +431,26 @@ function remove_all_filters($hook) {
     }
 }
 
+function do_action($hook, ...$args) {
+    if (!isset($GLOBALS['wp_test_filters'][$hook])) {
+        return;
+    }
+
+    ksort($GLOBALS['wp_test_filters'][$hook]);
+
+    foreach ($GLOBALS['wp_test_filters'][$hook] as $priority => $callbacks) {
+        foreach ($callbacks as $callback) {
+            $params = array();
+
+            if ($callback['accepted_args'] > 0) {
+                $params = array_slice($args, 0, $callback['accepted_args']);
+            }
+
+            call_user_func_array($callback['callback'], $params);
+        }
+    }
+}
+
 function apply_filters($hook, $value, ...$args) {
     if (!isset($GLOBALS['wp_test_filters'][$hook])) {
         return $value;


### PR DESCRIPTION
## Summary
- generate a random IV for each encrypted token, update the payload prefix, and authenticate both IV and ciphertext
- extend decryption to recognise legacy payloads, migrate them to the new format, and surface a migration hook
- expand the helper PHPUnit suite with coverage for IV randomness, legacy migration, and add a test `do_action` helper

## Testing
- php -l discord-bot-jlg/inc/helpers.php
- php -l discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Helpers.php
- php -l discord-bot-jlg/tests/phpunit/bootstrap.php


------
https://chatgpt.com/codex/tasks/task_e_68e0ea00cc40832eb2771cd6275f601a