### PR TITLE
Remove mandatory polyfill dependencies from shortcode script

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -1178,13 +1178,35 @@ class Discord_Bot_JLG_Shortcode {
             DISCORD_BOT_JLG_VERSION
         );
 
+        $script_dependencies = array();
+
         wp_register_script(
             'discord-bot-jlg-frontend',
             DISCORD_BOT_JLG_PLUGIN_URL . 'assets/js/discord-bot-jlg.js',
-            array('wp-polyfill', 'wp-api-fetch'),
+            $script_dependencies,
             DISCORD_BOT_JLG_VERSION,
             true
         );
+
+        if (function_exists('wp_get_script_polyfill')) {
+            if (function_exists('wp_scripts')) {
+                wp_scripts();
+            }
+
+            if (isset($GLOBALS['wp_scripts'])) {
+                $polyfill_loader = wp_get_script_polyfill(
+                    $GLOBALS['wp_scripts'],
+                    array(
+                        'fetch'   => array('wp-polyfill-fetch'),
+                        'Promise' => array('wp-polyfill-promise'),
+                    )
+                );
+
+                if (!empty($polyfill_loader) && function_exists('wp_add_inline_script')) {
+                    wp_add_inline_script('discord-bot-jlg-frontend', $polyfill_loader, 'before');
+                }
+            }
+        }
 
         $locale = str_replace('_', '-', get_locale());
 

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -14,6 +14,7 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $GLOBALS['wp_test_registered_scripts'] = array();
         $GLOBALS['wp_test_enqueued_scripts']   = array();
         $GLOBALS['wp_test_localized_scripts']  = array();
+        $GLOBALS['wp_test_inline_scripts']     = array();
 
         $this->reset_shortcode_static_state();
     }
@@ -216,5 +217,18 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertStringContainsString('--discord-accent: #ff00aa', $html);
         $this->assertStringContainsString('--discord-accent-secondary: #ff00aa', $html);
         $this->assertStringContainsString('--discord-accent-contrast: #0f0f0f', $html);
+    }
+
+    public function test_frontend_script_has_no_forced_polyfill_dependencies() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $shortcode->render_shortcode(array());
+
+        $this->assertArrayHasKey('discord-bot-jlg-frontend', $GLOBALS['wp_test_registered_scripts']);
+
+        $registered_script = $GLOBALS['wp_test_registered_scripts']['discord-bot-jlg-frontend'];
+
+        $this->assertIsArray($registered_script['deps']);
+        $this->assertSame(array(), $registered_script['deps']);
     }
 }

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -288,6 +288,7 @@ $GLOBALS['wp_test_inline_styles']     = array();
 $GLOBALS['wp_test_registered_scripts'] = array();
 $GLOBALS['wp_test_enqueued_scripts']   = array();
 $GLOBALS['wp_test_localized_scripts']  = array();
+$GLOBALS['wp_test_inline_scripts']     = array();
 
 function wp_register_style($handle, $src = '', $deps = array(), $ver = false) {
     $GLOBALS['wp_test_registered_styles'][$handle] = array(
@@ -326,6 +327,19 @@ function wp_register_script($handle, $src = '', $deps = array(), $ver = false, $
 
 function wp_enqueue_script($handle) {
     $GLOBALS['wp_test_enqueued_scripts'][$handle] = true;
+    return true;
+}
+
+function wp_add_inline_script($handle, $data, $position = 'after') {
+    if (!isset($GLOBALS['wp_test_inline_scripts'][$handle])) {
+        $GLOBALS['wp_test_inline_scripts'][$handle] = array();
+    }
+
+    $GLOBALS['wp_test_inline_scripts'][$handle][] = array(
+        'data'     => (string) $data,
+        'position' => $position,
+    );
+
     return true;
 }
 


### PR DESCRIPTION
## Summary
- remove the wp-polyfill and wp-api-fetch dependencies from the Discord shortcode frontend script
- add a conditional polyfill loader using wp_get_script_polyfill and stub inline script handling for tests
- extend the shortcode PHPUnit suite to assert the frontend script registers without forced polyfill dependencies

## Testing
- Not run (phpunit unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e12d794740832eb29041cf1b48f1cc