### PR TITLE
Remove frontend bot token overrides

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -41,8 +41,7 @@
     function collectConnectionOverrides(container, config) {
         var overrides = {
             profileKey: '',
-            serverId: '',
-            botToken: ''
+            serverId: ''
         };
 
         if (config && typeof config === 'object') {
@@ -52,10 +51,6 @@
 
             if (typeof config.serverId === 'string' && config.serverId) {
                 overrides.serverId = config.serverId;
-            }
-
-            if (typeof config.botToken === 'string' && config.botToken) {
-                overrides.botToken = config.botToken;
             }
         }
 
@@ -69,15 +64,10 @@
             if (typeof dataset.serverIdOverride === 'string' && dataset.serverIdOverride) {
                 overrides.serverId = dataset.serverIdOverride;
             }
-
-            if (typeof dataset.botTokenOverride === 'string' && dataset.botTokenOverride) {
-                overrides.botToken = dataset.botTokenOverride;
-            }
         }
 
         overrides.profileKey = overrides.profileKey ? String(overrides.profileKey).trim() : '';
         overrides.serverId = overrides.serverId ? String(overrides.serverId).trim() : '';
-        overrides.botToken = overrides.botToken ? String(overrides.botToken).trim() : '';
 
         return overrides;
     }
@@ -1720,9 +1710,6 @@
             formData.append('server_id', overrides.serverId);
         }
 
-        if (overrides.botToken) {
-            formData.append('bot_token', overrides.botToken);
-        }
 
         var requestPromise = fetch(config.ajaxUrl, {
             method: 'POST',

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -169,7 +169,6 @@ class Discord_Bot_JLG_API {
                 'bypass_cache' => false,
                 'profile_key'  => '',
                 'server_id'    => '',
-                'bot_token'    => '',
             )
         );
 
@@ -177,7 +176,6 @@ class Discord_Bot_JLG_API {
         $args['bypass_cache'] = discord_bot_jlg_validate_bool($args['bypass_cache']);
         $args['profile_key']  = isset($args['profile_key']) ? sanitize_key($args['profile_key']) : '';
         $args['server_id']    = isset($args['server_id']) ? $this->sanitize_server_id($args['server_id']) : '';
-        $args['bot_token']    = isset($args['bot_token']) ? $this->sanitize_token_override($args['bot_token']) : '';
 
         if (true === $args['force_demo']) {
             $demo_stats = $this->get_demo_stats(false);
@@ -467,15 +465,9 @@ class Discord_Bot_JLG_API {
             $server_id_override = $this->sanitize_server_id(wp_unslash($_POST['server_id']));
         }
 
-        $bot_token_override = '';
-        if (isset($_POST['bot_token'])) {
-            $bot_token_override = $this->sanitize_token_override(wp_unslash($_POST['bot_token']));
-        }
-
         $connection_args = array(
             'profile_key' => $profile_key_override,
             'server_id'   => $server_id_override,
-            'bot_token'   => $bot_token_override,
         );
 
         $options = $this->get_plugin_options();
@@ -634,7 +626,6 @@ class Discord_Bot_JLG_API {
                     'bypass_cache' => $bypass_cache,
                     'profile_key'  => $profile_key_override,
                     'server_id'    => $server_id_override,
-                    'bot_token'    => $bot_token_override,
                 )
             );
 
@@ -2143,7 +2134,6 @@ class Discord_Bot_JLG_API {
 
         $profile_key = isset($args['profile_key']) ? sanitize_key($args['profile_key']) : '';
         $server_id_override = isset($args['server_id']) ? $this->sanitize_server_id($args['server_id']) : '';
-        $bot_token_override = isset($args['bot_token']) ? $this->sanitize_token_override($args['bot_token']) : '';
 
         if ('' !== $profile_key) {
             $profile = $this->find_server_profile($profile_key, $options);
@@ -2183,12 +2173,6 @@ class Discord_Bot_JLG_API {
             $signature_parts[] = 'server:' . $server_id_override;
         }
 
-        if ('' !== $bot_token_override) {
-            $effective_options['bot_token'] = $bot_token_override;
-            $effective_options['__bot_token_override'] = true;
-            $signature_parts[] = 'token:' . sha1($bot_token_override);
-        }
-
         if (!isset($effective_options['server_id'])) {
             $effective_options['server_id'] = '';
         } else {
@@ -2224,20 +2208,6 @@ class Discord_Bot_JLG_API {
         $value = preg_replace('/[^0-9]/', '', (string) $value);
 
         return (string) $value;
-    }
-
-    private function sanitize_token_override($token) {
-        if (!is_string($token) && !is_numeric($token)) {
-            return '';
-        }
-
-        $token = trim((string) $token);
-
-        if ('' === $token) {
-            return '';
-        }
-
-        return sanitize_text_field($token);
     }
 
     private function find_server_profile($profile_key, $options) {

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -184,7 +184,6 @@ class Discord_Bot_JLG_Shortcode {
                 'cta_tooltip'          => '',
                 'profile'              => '',
                 'server_id'            => '',
-                'bot_token'            => '',
             ),
             $atts,
             'discord_stats'
@@ -239,7 +238,6 @@ class Discord_Bot_JLG_Shortcode {
 
         $profile_key        = $this->sanitize_profile_key($atts['profile']);
         $override_server_id = $this->sanitize_server_id_attribute($atts['server_id']);
-        $override_bot_token = $this->sanitize_bot_token_attribute($atts['bot_token']);
 
         if ($force_demo) {
             $stats = $this->api->get_demo_stats();
@@ -249,7 +247,6 @@ class Discord_Bot_JLG_Shortcode {
                     array(
                         'profile_key' => $profile_key,
                         'server_id'   => $override_server_id,
-                        'bot_token'   => $override_bot_token,
                     ),
                     'strlen'
                 )
@@ -631,9 +628,6 @@ class Discord_Bot_JLG_Shortcode {
             $attributes[] = sprintf('data-server-id-override="%s"', esc_attr($override_server_id));
         }
 
-        if ('' !== $override_bot_token) {
-            $attributes[] = sprintf('data-bot-token-override="%s"', esc_attr($override_bot_token));
-        }
 
         $refresh_interval = 0;
         $min_refresh_interval = $min_refresh_option;
@@ -1062,20 +1056,6 @@ class Discord_Bot_JLG_Shortcode {
         $value = preg_replace('/[^0-9]/', '', (string) $value);
 
         return (string) $value;
-    }
-
-    private function sanitize_bot_token_attribute($value) {
-        if (!is_string($value) && !is_numeric($value)) {
-            return '';
-        }
-
-        $value = trim((string) $value);
-
-        if ('' === $value) {
-            return '';
-        }
-
-        return sanitize_text_field($value);
     }
 
     private function validate_width_value($raw_width) {

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -100,13 +100,6 @@ class Discord_Stats_Widget extends WP_Widget {
             $shortcode_atts['server_id'] = $server_id_override;
         }
 
-        $bot_token_override = isset($instance['bot_token_override'])
-            ? sanitize_text_field($instance['bot_token_override'])
-            : '';
-        if ('' !== $bot_token_override) {
-            $shortcode_atts['bot_token'] = $bot_token_override;
-        }
-
         $textual_attributes = array(
             'icon_online',
             'icon_total',

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Stats_Widget.php
@@ -52,14 +52,12 @@ class Test_Discord_Stats_Widget extends TestCase {
         $new_instance = array(
             'profile_key'        => 'Profil Personnel',
             'server_id_override' => 'abc123456',
-            'bot_token_override' => " token\n",
         );
 
         $updated = $widget->update($new_instance, array());
 
         $this->assertSame('profil-personnel', $updated['profile_key']);
         $this->assertSame('123456', $updated['server_id_override']);
-        $this->assertSame('token', $updated['bot_token_override']);
     }
 
     public function test_update_handles_metric_toggles() {
@@ -91,7 +89,6 @@ class Test_Discord_Stats_Widget extends TestCase {
         $instance = array(
             'profile_key'        => 'profil-special',
             'server_id_override' => '987654321',
-            'bot_token_override' => 'widget-token',
         );
 
         ob_start();
@@ -101,7 +98,7 @@ class Test_Discord_Stats_Widget extends TestCase {
         $this->assertNotNull($GLOBALS['discord_bot_jlg_last_shortcode']);
         $this->assertStringContainsString('profile="profil-special"', $GLOBALS['discord_bot_jlg_last_shortcode']);
         $this->assertStringContainsString('server_id="987654321"', $GLOBALS['discord_bot_jlg_last_shortcode']);
-        $this->assertStringContainsString('bot_token="widget-token"', $GLOBALS['discord_bot_jlg_last_shortcode']);
+        $this->assertStringNotContainsString('bot_token=', $GLOBALS['discord_bot_jlg_last_shortcode']);
     }
 
     public function test_widget_shortcode_includes_metric_toggles() {


### PR DESCRIPTION
## Summary
- drop the `bot_token` shortcode attribute and related widget markup so client renders no longer expose token overrides
- update the API to ignore override tokens supplied via requests, relying only on stored profiles or the configured constant
- simplify the public script and tests to stop reading/sending token overrides and assert the behaviour

## Testing
- npm test -- --runTestsByPath tests/js/discord-bot-jlg.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e12d78389c832ebc8e5f5eba16a6e5