### PR TITLE
Secure bot token overrides with transient references

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Pendant une requête d'actualisation, le conteneur affiche désormais un indicat
 
 Les rafraîchissements publics (visiteurs non connectés) n'exigent plus de nonce WordPress ; seuls les administrateurs connectés utilisent un jeton de sécurité pour l'action AJAX `refresh_discord_stats`.
 
+### Sécurisation des tokens temporaires
+
+Les surcharges de tokens transmises via le shortcode, le bloc ou le widget ne sont plus renvoyées telles quelles dans le HTML. Lors du rendu, le plugin stocke le secret côté serveur (transient de 15 minutes par défaut) et associe uniquement une référence opaque (`data-token-key`) au conteneur public. Le script `discord-bot-jlg.js` envoie ensuite ce `token_key` lors des rafraîchissements AJAX ; la méthode PHP `resolve_connection_context()` résout le token réel et le réinjecte dans l'appel HTTP sans jamais l'exposer au navigateur.
+
+Le délai d'expiration des références peut être ajusté via le filtre `discord_bot_jlg_token_reference_ttl`. Si la référence n'est plus valide (purge de cache, expiration…), un simple rechargement de la page régénère automatiquement un identifiant et réactive l'auto-actualisation.
+
 ### Accessibilité
 
 Le plugin embarque sa propre définition `.screen-reader-text`, incluse à la fois dans les feuilles de style principales et inline chargées par le shortcode. Ce fallback reprend le pattern WordPress (position absolue, dimensions réduites à 1px, `clip-path: inset(50%)`, etc.) afin que les libellés masqués restent interprétables par les lecteurs d'écran même si le thème actif ne fournit pas cette classe utilitaire.

--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -42,6 +42,7 @@
         var overrides = {
             profileKey: '',
             serverId: '',
+            tokenKey: '',
             botToken: ''
         };
 
@@ -52,6 +53,10 @@
 
             if (typeof config.serverId === 'string' && config.serverId) {
                 overrides.serverId = config.serverId;
+            }
+
+            if (typeof config.tokenKey === 'string' && config.tokenKey) {
+                overrides.tokenKey = config.tokenKey;
             }
 
             if (typeof config.botToken === 'string' && config.botToken) {
@@ -70,6 +75,10 @@
                 overrides.serverId = dataset.serverIdOverride;
             }
 
+            if (typeof dataset.tokenKey === 'string' && dataset.tokenKey) {
+                overrides.tokenKey = dataset.tokenKey;
+            }
+
             if (typeof dataset.botTokenOverride === 'string' && dataset.botTokenOverride) {
                 overrides.botToken = dataset.botTokenOverride;
             }
@@ -77,6 +86,7 @@
 
         overrides.profileKey = overrides.profileKey ? String(overrides.profileKey).trim() : '';
         overrides.serverId = overrides.serverId ? String(overrides.serverId).trim() : '';
+        overrides.tokenKey = overrides.tokenKey ? String(overrides.tokenKey).trim() : '';
         overrides.botToken = overrides.botToken ? String(overrides.botToken).trim() : '';
 
         return overrides;
@@ -1718,6 +1728,10 @@
 
         if (overrides.serverId) {
             formData.append('server_id', overrides.serverId);
+        }
+
+        if (overrides.tokenKey) {
+            formData.append('token_key', overrides.tokenKey);
         }
 
         if (overrides.botToken) {

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -976,6 +976,7 @@ class Discord_Bot_JLG_Admin {
             <li><?php esc_html_e('Ouvrez cette URL dans votre navigateur', 'discord-bot-jlg'); ?></li>
             <li><?php echo wp_kses_post(__('Sélectionnez votre serveur et cliquez sur <strong>"Autoriser"</strong>', 'discord-bot-jlg')); ?></li>
         </ol>
+        <p><?php echo wp_kses_post(__('🔒 Le token que vous collez dans WordPress reste côté serveur : le front reçoit uniquement une référence éphémère utilisée par les rafraîchissements AJAX. En cas d’expiration, un simple rechargement de la page régénère la référence.', 'discord-bot-jlg')); ?></p>
 
         <h4><?php esc_html_e('Étape 3 : Obtenir l\'ID de votre serveur', 'discord-bot-jlg'); ?></h4>
         <ol>

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -184,7 +184,6 @@ class Discord_Bot_JLG_Shortcode {
                 'cta_tooltip'          => '',
                 'profile'              => '',
                 'server_id'            => '',
-                'bot_token'            => '',
             ),
             $atts,
             'discord_stats'
@@ -239,7 +238,16 @@ class Discord_Bot_JLG_Shortcode {
 
         $profile_key        = $this->sanitize_profile_key($atts['profile']);
         $override_server_id = $this->sanitize_server_id_attribute($atts['server_id']);
-        $override_bot_token = $this->sanitize_bot_token_attribute($atts['bot_token']);
+
+        $override_bot_token = '';
+        if (isset($received_atts['bot_token'])) {
+            $override_bot_token = $this->sanitize_bot_token_attribute($received_atts['bot_token']);
+        }
+
+        $token_reference_key = '';
+        if ('' !== $override_bot_token) {
+            $token_reference_key = $this->api->register_temporary_token_override($override_bot_token);
+        }
 
         if ($force_demo) {
             $stats = $this->api->get_demo_stats();
@@ -631,8 +639,8 @@ class Discord_Bot_JLG_Shortcode {
             $attributes[] = sprintf('data-server-id-override="%s"', esc_attr($override_server_id));
         }
 
-        if ('' !== $override_bot_token) {
-            $attributes[] = sprintf('data-bot-token-override="%s"', esc_attr($override_bot_token));
+        if ('' !== $token_reference_key) {
+            $attributes[] = sprintf('data-token-key="%s"', esc_attr($token_reference_key));
         }
 
         $refresh_interval = 0;

--- a/tests/js/discord-bot-jlg.test.js
+++ b/tests/js/discord-bot-jlg.test.js
@@ -184,6 +184,7 @@ describe('discord-bot-jlg integration', () => {
 
     test('successful refresh updates DOM elements and clears errors', async () => {
         const container = createContainer();
+        container.dataset.tokenKey = 'abc123';
 
         window.discordBotJlg = {
             ajaxUrl: 'https://example.com/wp-admin/admin-ajax.php',
@@ -243,6 +244,17 @@ describe('discord-bot-jlg integration', () => {
         expect(demoBadge).toBeNull();
         expect(container.dataset.refreshing).toBe('false');
         expect(container.querySelector('.discord-refresh-status')).toBeNull();
+
+        const requestOptions = global.fetch.mock.calls[0][1];
+        expect(requestOptions.body).toBeInstanceOf(MockFormData);
+        expect(requestOptions.body.entries).toEqual(
+            expect.arrayContaining([
+                ['action', 'refresh_discord_stats'],
+                ['token_key', 'abc123']
+            ])
+        );
+        const tokenEntries = requestOptions.body.entries.filter((entry) => entry[0] === 'bot_token');
+        expect(tokenEntries.length).toBe(0);
 
         const setTimeoutCalls = setTimeoutSpy.mock.calls;
         expect(setTimeoutCalls[setTimeoutCalls.length - 1][1]).toBe(15000);


### PR DESCRIPTION
## Summary
- replace the front-end bot token attribute with transient-backed references resolved during AJAX refreshes
- update the shortcode, API layer, and admin help to document and support the new secure flow
- extend the PHP and Jest test suites to cover token reference storage, resolution, and request payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e12d759bd8832e93f3693aac5bab97