### PR TITLE
Align cache minimum duration with cron schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Plugin WordPress permettant d'afficher les statistiques d'un serveur Discord.
 Accédez à la page **Discord Bot** dans l’administration pour :
 - Saisir le token de votre bot Discord ;
 - Indiquer l’ID du serveur à surveiller ;
-- Définir la durée du cache des statistiques ;
+- Définir la durée du cache des statistiques (minimum 60 secondes, alignées sur le cron de rafraîchissement) ;
 - Choisir les éléments affichés par défaut (nom/avatar du serveur, rafraîchissement automatique, thème) ;
 - Personnaliser les icônes et libellés proposés par défaut (cartes principales, répartition des présences, boosts) ;
 - Ajouter du CSS personnalisé.

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -299,6 +299,13 @@ class Discord_Bot_JLG_Admin {
             : 10;
         $max_refresh_interval = 3600;
 
+        $min_cache_duration = max(
+            60,
+            defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
+                ? (int) Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
+                : 60
+        );
+
         $current_refresh_interval = isset($current_options['default_refresh_interval'])
             ? absint($current_options['default_refresh_interval'])
             : 60;
@@ -341,7 +348,10 @@ class Discord_Bot_JLG_Admin {
                 ? sanitize_text_field($current_options['invite_label'])
                 : '',
             'cache_duration' => isset($current_options['cache_duration'])
-                ? (int) $current_options['cache_duration']
+                ? max(
+                    $min_cache_duration,
+                    min(3600, (int) $current_options['cache_duration'])
+                )
                 : 300,
             'custom_css'     => '',
             'default_refresh_interval' => $current_refresh_interval,
@@ -533,13 +543,13 @@ class Discord_Bot_JLG_Admin {
                     ? (int) $current_options['cache_duration']
                     : 300;
                 $sanitized['cache_duration'] = max(
-                    Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                    $min_cache_duration,
                     min(3600, $fallback_duration)
                 );
             } else {
                 $cache_duration              = absint($raw_cache_duration);
                 $sanitized['cache_duration'] = max(
-                    Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                    $min_cache_duration,
                     min(3600, $cache_duration)
                 );
             }
@@ -1495,16 +1505,22 @@ class Discord_Bot_JLG_Admin {
      */
     public function cache_duration_render() {
         $options = get_option($this->option_name);
+        $min_cache_duration = max(
+            60,
+            defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
+                ? (int) Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL
+                : 60
+        );
         ?>
         <input type="number" name="<?php echo esc_attr($this->option_name); ?>[cache_duration]"
                value="<?php echo esc_attr(isset($options['cache_duration']) ? $options['cache_duration'] : ''); ?>"
-               min="<?php echo esc_attr(Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL); ?>" max="3600" class="small-text" />
+               min="<?php echo esc_attr($min_cache_duration); ?>" max="3600" class="small-text" />
         <p class="description">
             <?php
             printf(
                 /* translators: 1: minimum cache duration in seconds, 2: maximum cache duration in seconds. */
                 esc_html__('Minimum %1$s secondes, maximum %2$s secondes (1 heure)', 'discord-bot-jlg'),
-                esc_html(Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL),
+                esc_html(number_format_i18n($min_cache_duration)),
                 esc_html(number_format_i18n(3600))
             );
             ?>

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -115,7 +115,7 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                     'show_online'  => 1,
                     'show_total'   => 0,
                     'widget_title' => sanitize_text_field(' <strong>Stats</strong> '),
-                    'cache_duration' => 45,
+                    'cache_duration' => self::get_min_cache_duration(),
                     'custom_css'   => $sanitized_css,
                 ),
             ),
@@ -129,7 +129,7 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                 ),
                 array(
                     'server_id'      => '123456789012345678',
-                    'cache_duration' => Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                    'cache_duration' => self::get_min_cache_duration(),
                     'demo_mode'      => 0,
                     'show_online'    => 1,
                     'show_total'     => 1,
@@ -522,6 +522,10 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
         delete_option(Discord_Bot_JLG_API::LAST_FALLBACK_OPTION);
     }
 
+    private static function get_min_cache_duration(): int {
+        return max(60, (int) Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL);
+    }
+
     private function get_expected_defaults(): array {
         return array(
             'server_id'      => '',
@@ -538,7 +542,7 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             'default_theme'   => 'dark',
             'widget_title'   => '',
             'cache_duration' => max(
-                Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
+                self::get_min_cache_duration(),
                 min(3600, (int) $this->saved_options['cache_duration'])
             ),
             'custom_css'     => '',


### PR DESCRIPTION
## Summary
- enforce a 60-second floor for the cache duration during option sanitization and admin UI rendering
- adjust the Discord_Bot_JLG_Admin PHPUnit fixtures to expect the new minimum cache value
- document the cron-aligned minimum cache duration in the README for administrators

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: phpunit binary not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e14906c370832e9697fc0e3185beb9