### PR TITLE
Add REST API endpoint for stats refresh

### DIFF
--- a/discord-bot-jlg/assets/js/discord-bot-jlg.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg.js
@@ -72,6 +72,103 @@
         return overrides;
     }
 
+    function buildRestRequestUrl(baseUrl, overrides) {
+        if (typeof baseUrl !== 'string' || !baseUrl) {
+            return '';
+        }
+
+        var profileKey = overrides && overrides.profileKey ? overrides.profileKey : '';
+        var serverId = overrides && overrides.serverId ? overrides.serverId : '';
+
+        var urlObject = null;
+        if (typeof URL === 'function') {
+            try {
+                var origin = (typeof window !== 'undefined' && window.location && window.location.origin)
+                    ? window.location.origin
+                    : undefined;
+                urlObject = new URL(baseUrl, origin);
+            } catch (error) {
+                urlObject = null;
+            }
+        }
+
+        if (urlObject && urlObject.searchParams) {
+            if (profileKey) {
+                urlObject.searchParams.set('profile_key', profileKey);
+            }
+
+            if (serverId) {
+                urlObject.searchParams.set('server_id', serverId);
+            }
+
+            return urlObject.toString();
+        }
+
+        var queryParts = [];
+        if (profileKey) {
+            queryParts.push('profile_key=' + encodeURIComponent(profileKey));
+        }
+
+        if (serverId) {
+            queryParts.push('server_id=' + encodeURIComponent(serverId));
+        }
+
+        if (!queryParts.length) {
+            return baseUrl;
+        }
+
+        var separator = baseUrl.indexOf('?') === -1 ? '?' : '&';
+
+        return baseUrl + separator + queryParts.join('&');
+    }
+
+    function requestStatsViaAjax(config, overrides) {
+        if (!config || typeof config.ajaxUrl !== 'string' || !config.ajaxUrl) {
+            return Promise.reject(new Error('Missing AJAX endpoint URL'));
+        }
+
+        var formData = new FormData();
+        formData.append('action', config.action || 'refresh_discord_stats');
+
+        if (config.requiresNonce && config.nonce) {
+            formData.append('_ajax_nonce', config.nonce);
+        }
+
+        if (overrides && overrides.profileKey) {
+            formData.append('profile_key', overrides.profileKey);
+        }
+
+        if (overrides && overrides.serverId) {
+            formData.append('server_id', overrides.serverId);
+        }
+
+        return fetch(config.ajaxUrl, {
+            method: 'POST',
+            body: formData,
+            credentials: 'same-origin'
+        });
+    }
+
+    function requestStatsViaRest(config, overrides) {
+        if (!config || typeof config.restUrl !== 'string' || !config.restUrl) {
+            return Promise.reject(new Error('Missing REST endpoint URL'));
+        }
+
+        var endpointUrl = buildRestRequestUrl(config.restUrl, overrides);
+        var options = {
+            method: 'GET',
+            credentials: 'same-origin'
+        };
+
+        if (config.restNonce) {
+            options.headers = {
+                'X-WP-Nonce': config.restNonce
+            };
+        }
+
+        return fetch(endpointUrl, options);
+    }
+
     function getOrCreateErrorMessageElement(container) {
         if (!container) {
             return null;
@@ -1693,29 +1790,32 @@
             retryAfter: null
         };
 
-        var formData = new FormData();
-        formData.append('action', config.action || 'refresh_discord_stats');
-
-        if (config.requiresNonce && config.nonce) {
-            formData.append('_ajax_nonce', config.nonce);
-        }
-
         var overrides = collectConnectionOverrides(container, config);
 
-        if (overrides.profileKey) {
-            formData.append('profile_key', overrides.profileKey);
+        var useRestEndpoint = !!(config && typeof config.restUrl === 'string' && config.restUrl);
+        var fetchPromise;
+
+        if (useRestEndpoint) {
+            fetchPromise = requestStatsViaRest(config, overrides)
+                .then(function (response) {
+                    if (response && response.status === 404 && config && config.ajaxUrl) {
+                        return requestStatsViaAjax(config, overrides);
+                    }
+
+                    return response;
+                })
+                .catch(function (error) {
+                    if (config && config.ajaxUrl) {
+                        return requestStatsViaAjax(config, overrides);
+                    }
+
+                    throw error;
+                });
+        } else {
+            fetchPromise = requestStatsViaAjax(config, overrides);
         }
 
-        if (overrides.serverId) {
-            formData.append('server_id', overrides.serverId);
-        }
-
-
-        var requestPromise = fetch(config.ajaxUrl, {
-            method: 'POST',
-            body: formData,
-            credentials: 'same-origin'
-        })
+        var requestPromise = fetchPromise
             .then(function (response) {
                 if (!response || typeof response !== 'object') {
                     var invalidResponseError = new Error('Invalid network response');

--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -153,6 +153,7 @@ require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-admin.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-shortcode.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-widget.php';
 require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-site-health.php';
+require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-rest.php';
 
 if (defined('WP_CLI') && WP_CLI) {
     require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/class-discord-cli.php';
@@ -184,6 +185,7 @@ class DiscordServerStats {
     private $shortcode;
     private $widget;
     private $site_health;
+    private $rest_controller;
 
     public function __construct() {
         $this->default_options = discord_bot_jlg_get_default_options();
@@ -193,6 +195,7 @@ class DiscordServerStats {
         $this->shortcode = new Discord_Bot_JLG_Shortcode(DISCORD_BOT_JLG_OPTION_NAME, $this->api);
         $this->widget    = new Discord_Bot_JLG_Widget();
         $this->site_health = new Discord_Bot_JLG_Site_Health($this->api);
+        $this->rest_controller = new Discord_Bot_JLG_REST_Controller($this->api);
 
         add_filter('default_option_' . DISCORD_BOT_JLG_OPTION_NAME, array($this, 'provide_default_options'));
         add_filter('option_' . DISCORD_BOT_JLG_OPTION_NAME, array($this, 'merge_options_with_defaults'));

--- a/discord-bot-jlg/inc/class-discord-rest.php
+++ b/discord-bot-jlg/inc/class-discord-rest.php
@@ -1,0 +1,106 @@
+<?php
+if (false === defined('ABSPATH')) {
+    exit;
+}
+
+class Discord_Bot_JLG_REST_Controller {
+    const ROUTE_NAMESPACE = 'discord-bot-jlg/v1';
+    const ROUTE_STATS = '/stats';
+
+    /**
+     * @var Discord_Bot_JLG_API
+     */
+    private $api;
+
+    public function __construct(Discord_Bot_JLG_API $api) {
+        $this->api = $api;
+
+        add_action('rest_api_init', array($this, 'register_routes'));
+    }
+
+    public function register_routes() {
+        register_rest_route(
+            self::ROUTE_NAMESPACE,
+            self::ROUTE_STATS,
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array($this, 'handle_get_stats'),
+                    'permission_callback' => '__return_true',
+                    'args'                => array(
+                        'profile_key' => array(
+                            'description'       => __('Profil de serveur à utiliser.', 'discord-bot-jlg'),
+                            'type'              => 'string',
+                            'sanitize_callback' => 'sanitize_key',
+                        ),
+                        'server_id' => array(
+                            'description'       => __('Identifiant du serveur Discord.', 'discord-bot-jlg'),
+                            'type'              => 'string',
+                            'sanitize_callback' => 'sanitize_text_field',
+                        ),
+                        'force_refresh' => array(
+                            'description'       => __('Force le rafraîchissement du cache (administrateurs uniquement).', 'discord-bot-jlg'),
+                            'type'              => 'boolean',
+                        ),
+                    ),
+                ),
+            ),
+            true
+        );
+    }
+
+    public function handle_get_stats(WP_REST_Request $request) {
+        $is_user_logged_in      = is_user_logged_in();
+        $force_refresh_requested = discord_bot_jlg_validate_bool($request->get_param('force_refresh'));
+
+        if ($is_user_logged_in) {
+            $nonce = $request->get_header('X-WP-Nonce');
+            if (empty($nonce) || !wp_verify_nonce($nonce, 'wp_rest')) {
+                $error_payload = array(
+                    'nonce_expired' => true,
+                    'message'       => __('Nonce invalide', 'discord-bot-jlg'),
+                );
+
+                return rest_ensure_response(
+                    new WP_REST_Response(
+                        array(
+                            'success' => false,
+                            'data'    => $error_payload,
+                        ),
+                        403
+                    )
+                );
+            }
+        }
+
+        $profile_key = $request->get_param('profile_key');
+        if (!is_string($profile_key)) {
+            $profile_key = '';
+        }
+        $profile_key = sanitize_key($profile_key);
+
+        $server_id = $request->get_param('server_id');
+        if (!is_string($server_id)) {
+            $server_id = '';
+        }
+        $server_id = sanitize_text_field($server_id);
+
+        $result = $this->api->process_refresh_request(
+            array(
+                'is_public_request' => !$is_user_logged_in,
+                'profile_key'       => $profile_key,
+                'server_id'         => $server_id,
+                'force_refresh'     => $force_refresh_requested,
+            )
+        );
+
+        $status = isset($result['status']) ? (int) $result['status'] : 200;
+
+        $response = array(
+            'success' => !empty($result['success']),
+            'data'    => (isset($result['data']) && is_array($result['data'])) ? $result['data'] : array(),
+        );
+
+        return rest_ensure_response(new WP_REST_Response($response, $status));
+    }
+}

--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -1200,6 +1200,8 @@ class Discord_Bot_JLG_Shortcode {
                 'action'  => 'refresh_discord_stats',
                 'nonce'   => $requires_nonce ? wp_create_nonce('refresh_discord_stats') : '',
                 'requiresNonce' => $requires_nonce,
+                'restUrl' => rest_url('discord-bot-jlg/v1/stats'),
+                'restNonce' => $requires_nonce ? wp_create_nonce('wp_rest') : '',
                 'locale'  => $locale,
                 'minRefreshInterval' => defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
                     ? Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_REST_Controller.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_REST_Controller.php
@@ -1,0 +1,122 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class Stubbed_Discord_Bot_JLG_API_For_REST extends Discord_Bot_JLG_API {
+    public $last_args = array();
+    private $next_result = array();
+
+    public function __construct() {
+        parent::__construct(
+            DISCORD_BOT_JLG_OPTION_NAME,
+            DISCORD_BOT_JLG_CACHE_KEY,
+            DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION
+        );
+    }
+
+    public function set_next_result(array $result) {
+        $this->next_result = $result;
+    }
+
+    public function process_refresh_request($args = array()) {
+        $this->last_args = $args;
+
+        if (empty($this->next_result)) {
+            return array(
+                'success' => false,
+                'data'    => array(),
+                'status'  => 500,
+            );
+        }
+
+        return $this->next_result;
+    }
+}
+
+class Test_Discord_Bot_JLG_REST_Controller extends TestCase {
+    protected function tearDown(): void {
+        $GLOBALS['wp_test_nonce_validations'] = array();
+        $GLOBALS['wp_test_is_user_logged_in'] = false;
+
+        parent::tearDown();
+    }
+
+    public function test_public_request_returns_successful_payload() {
+        $api = new Stubbed_Discord_Bot_JLG_API_For_REST();
+        $api->set_next_result(
+            array(
+                'success' => true,
+                'data'    => array('foo' => 'bar'),
+                'status'  => 200,
+            )
+        );
+
+        $controller = new Discord_Bot_JLG_REST_Controller($api);
+        $request    = new WP_REST_Request();
+        $request->set_param('profile_key', 'custom_profile');
+        $request->set_param('server_id', ' 123456 ');
+
+        $response = $controller->handle_get_stats($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(200, $response->get_status());
+
+        $payload = $response->get_data();
+        $this->assertTrue($payload['success']);
+        $this->assertSame(array('foo' => 'bar'), $payload['data']);
+        $this->assertArrayHasKey('profile_key', $api->last_args);
+        $this->assertSame('custom_profile', $api->last_args['profile_key']);
+        $this->assertSame('123456', $api->last_args['server_id']);
+        $this->assertArrayHasKey('is_public_request', $api->last_args);
+        $this->assertTrue($api->last_args['is_public_request']);
+    }
+
+    public function test_request_with_invalid_nonce_is_rejected() {
+        $GLOBALS['wp_test_is_user_logged_in']           = true;
+        $GLOBALS['wp_test_nonce_validations']['wp_rest'] = false;
+
+        $api = new Stubbed_Discord_Bot_JLG_API_For_REST();
+        $controller = new Discord_Bot_JLG_REST_Controller($api);
+        $request    = new WP_REST_Request();
+        $request->set_header('X-WP-Nonce', 'invalid');
+
+        $response = $controller->handle_get_stats($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(403, $response->get_status());
+
+        $payload = $response->get_data();
+        $this->assertFalse($payload['success']);
+        $this->assertArrayHasKey('nonce_expired', $payload['data']);
+        $this->assertTrue($payload['data']['nonce_expired']);
+        $this->assertSame(array(), $api->last_args);
+    }
+
+    public function test_rate_limited_response_is_forwarded() {
+        $api = new Stubbed_Discord_Bot_JLG_API_For_REST();
+        $api->set_next_result(
+            array(
+                'success' => false,
+                'data'    => array(
+                    'rate_limited' => true,
+                    'retry_after'  => 12,
+                ),
+                'status'  => 429,
+            )
+        );
+
+        $controller = new Discord_Bot_JLG_REST_Controller($api);
+        $request    = new WP_REST_Request();
+
+        $response = $controller->handle_get_stats($request);
+
+        $this->assertSame(429, $response->get_status());
+        $payload = $response->get_data();
+        $this->assertFalse($payload['success']);
+        $this->assertArrayHasKey('rate_limited', $payload['data']);
+        $this->assertTrue($payload['data']['rate_limited']);
+        $this->assertArrayHasKey('is_public_request', $api->last_args);
+        $this->assertTrue($api->last_args['is_public_request']);
+    }
+}


### PR DESCRIPTION
## Summary
- share the stats refresh workflow in `Discord_Bot_JLG_API` so both legacy AJAX and the new REST controller can reuse it
- introduce `Discord_Bot_JLG_REST_Controller` and localize REST config for the frontend, updating the script to target the REST route with an AJAX fallback
- expand the test bootstrap and add PHPUnit coverage for the REST controller behaviour

## Testing
- Not run (phpunit command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e14909e308832e86e989ae1316ff50