### PR TITLE
Add analytics persistence and dashboards

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-admin.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-admin.css
@@ -25,6 +25,65 @@
     max-width: 100%;
 }
 
+.discord-analytics-panel {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+    margin: 30px 0;
+    padding: 24px;
+}
+
+.discord-analytics-panel__header {
+    margin-bottom: 16px;
+}
+
+.discord-analytics-panel__body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    align-items: stretch;
+}
+
+.discord-analytics-panel__canvas {
+    flex: 1 1 420px;
+    min-width: 260px;
+}
+
+.discord-analytics-panel__summary {
+    flex: 0 0 240px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.discord-analytics-summary__item {
+    background: #f8fafc;
+    border-radius: 8px;
+    padding: 12px 14px;
+}
+
+.discord-analytics-summary__label {
+    display: block;
+    font-size: 13px;
+    color: #475569;
+    margin-bottom: 4px;
+}
+
+.discord-analytics-summary__value {
+    font-size: 18px;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.discord-analytics-panel__notice {
+    margin-top: 16px;
+    color: #64748b;
+}
+
+.discord-analytics-panel__notice.error {
+    color: #b91c1c;
+}
+
 @media (max-width: 782px) {
     .discord-bot-settings-layout {
         flex-direction: column;
@@ -33,5 +92,9 @@
     .discord-bot-settings-main,
     .discord-bot-settings-sidebar {
         flex: 1 1 100%;
+    }
+
+    .discord-analytics-panel__body {
+        flex-direction: column;
     }
 }

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -693,6 +693,47 @@
     animation: discord-bot-jlg-loading-shimmer 1.5s ease-in-out infinite;
 }
 
+.discord-analytics-embed {
+    margin-top: 16px;
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: 10px;
+    padding: 12px 14px;
+}
+
+.discord-analytics-embed__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 13px;
+    color: rgba(15, 23, 42, 0.7);
+}
+
+.discord-analytics-embed__title {
+    font-weight: 600;
+    color: rgba(15, 23, 42, 0.85);
+}
+
+.discord-analytics-embed__range {
+    font-size: 12px;
+}
+
+.discord-analytics-embed__sparkline {
+    margin-top: 6px;
+    height: 56px;
+}
+
+.discord-analytics-embed__sparkline svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.discord-analytics-embed__note {
+    margin-top: 6px;
+    font-size: 12px;
+    color: rgba(15, 23, 42, 0.7);
+}
+
 @keyframes discord-bot-jlg-loading-shimmer {
     0% {
         transform: translateX(-120%);

--- a/discord-bot-jlg/assets/js/discord-bot-jlg-admin-analytics.js
+++ b/discord-bot-jlg/assets/js/discord-bot-jlg-admin-analytics.js
@@ -1,0 +1,298 @@
+(function (window, document) {
+    'use strict';
+
+    if (!window || !document) {
+        return;
+    }
+
+    var config = window.discordBotJlgAdminAnalytics || {};
+    var chartInstance = null;
+
+    function ready(fn) {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', fn);
+        } else {
+            fn();
+        }
+    }
+
+    function buildRequestUrl() {
+        if (!config.restUrl) {
+            return '';
+        }
+
+        try {
+            var origin = window.location && window.location.origin ? window.location.origin : undefined;
+            var url = new URL(config.restUrl, origin);
+
+            if (config.profileKey) {
+                url.searchParams.set('profile_key', config.profileKey);
+            }
+
+            if (config.days) {
+                url.searchParams.set('days', String(config.days));
+            }
+
+            return url.toString();
+        } catch (error) {
+            return config.restUrl;
+        }
+    }
+
+    function fetchAnalyticsData() {
+        var endpoint = buildRequestUrl();
+        if (!endpoint) {
+            return Promise.reject(new Error('Missing analytics endpoint'));
+        }
+
+        var options = {
+            method: 'GET',
+            credentials: 'same-origin'
+        };
+
+        if (config.nonce) {
+            options.headers = {
+                'X-WP-Nonce': config.nonce
+            };
+        }
+
+        return fetch(endpoint, options).then(function (response) {
+            if (!response.ok) {
+                var error = new Error('HTTP ' + response.status);
+                error.status = response.status;
+                throw error;
+            }
+
+            return response.json();
+        }).then(function (payload) {
+            if (!payload || payload.success === false) {
+                throw new Error('Analytics payload missing');
+            }
+
+            return payload.data || {};
+        });
+    }
+
+    function formatNumber(value) {
+        if (typeof value !== 'number' || !isFinite(value)) {
+            return '—';
+        }
+
+        try {
+            return new Intl.NumberFormat(window.navigator.language || 'fr-FR', {
+                maximumFractionDigits: 0
+            }).format(value);
+        } catch (error) {
+            return Math.round(value).toString();
+        }
+    }
+
+    function formatDelta(delta) {
+        if (typeof delta !== 'number' || !isFinite(delta) || delta === 0) {
+            return delta === 0 ? '±0' : '—';
+        }
+
+        var prefix = delta > 0 ? '▲' : '▼';
+        return prefix + Math.abs(delta);
+    }
+
+    function formatTimestamp(timestamp) {
+        if (typeof timestamp !== 'number' || timestamp <= 0) {
+            return '';
+        }
+
+        try {
+            return new Date(timestamp * 1000).toLocaleString(window.navigator.language || 'fr-FR');
+        } catch (error) {
+            return '';
+        }
+    }
+
+    function setNotice(message, isError) {
+        var panel = document.getElementById(config.containerId || 'discord-analytics-panel');
+        if (!panel) {
+            return;
+        }
+
+        var notice = panel.querySelector('[data-role="analytics-notice"]');
+        if (!notice) {
+            notice = document.createElement('p');
+            notice.setAttribute('data-role', 'analytics-notice');
+            panel.appendChild(notice);
+        }
+
+        notice.textContent = message || '';
+        if (message) {
+            notice.classList.toggle('error', !!isError);
+        } else {
+            notice.classList.remove('error');
+        }
+    }
+
+    function updateSummary(data) {
+        var averages = data.averages || {};
+        var peak = data.peak_presence || {};
+        var trend = data.boost_trend || {};
+
+        var averageOnlineEl = document.querySelector('[data-role="analytics-average-online"]');
+        var averagePresenceEl = document.querySelector('[data-role="analytics-average-presence"]');
+        var averageTotalEl = document.querySelector('[data-role="analytics-average-total"]');
+        var peakPresenceEl = document.querySelector('[data-role="analytics-peak-presence"]');
+        var boostTrendEl = document.querySelector('[data-role="analytics-boost-trend"]');
+
+        if (averageOnlineEl) {
+            averageOnlineEl.textContent = formatNumber(averages.online);
+        }
+
+        if (averagePresenceEl) {
+            averagePresenceEl.textContent = formatNumber(averages.presence);
+        }
+
+        if (averageTotalEl) {
+            averageTotalEl.textContent = formatNumber(averages.total);
+        }
+
+        if (peakPresenceEl) {
+            var peakLabel = formatNumber(peak.count);
+            var peakTime = formatTimestamp(peak.timestamp);
+            peakPresenceEl.textContent = peakTime ? peakLabel + ' (' + peakTime + ')' : peakLabel;
+        }
+
+        if (boostTrendEl) {
+            var latest = formatNumber(trend.latest);
+            var deltaLabel = formatDelta(trend.delta);
+            boostTrendEl.textContent = latest === '—' ? '—' : latest + ' ' + deltaLabel;
+        }
+    }
+
+    function renderChart(data) {
+        var canvas = document.getElementById(config.canvasId || 'discord-analytics-chart');
+        if (!canvas || typeof window.Chart === 'undefined') {
+            return;
+        }
+
+        var timeseries = Array.isArray(data.timeseries) ? data.timeseries : [];
+        if (!timeseries.length) {
+            if (chartInstance) {
+                chartInstance.destroy();
+                chartInstance = null;
+            }
+            return;
+        }
+
+        var labels = timeseries.map(function (point) {
+            return formatTimestamp(point.timestamp);
+        });
+
+        var onlineDataset = timeseries.map(function (point) {
+            return typeof point.online === 'number' ? point.online : null;
+        });
+        var presenceDataset = timeseries.map(function (point) {
+            return typeof point.presence === 'number' ? point.presence : null;
+        });
+        var premiumDataset = timeseries.map(function (point) {
+            return typeof point.premium === 'number' ? point.premium : null;
+        });
+
+        var context = canvas.getContext('2d');
+        if (!context) {
+            return;
+        }
+
+        if (chartInstance) {
+            chartInstance.destroy();
+            chartInstance = null;
+        }
+
+        chartInstance = new window.Chart(context, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: config.labels && config.labels.averageOnline ? config.labels.averageOnline : 'En ligne',
+                        data: onlineDataset,
+                        borderColor: '#22c55e',
+                        backgroundColor: 'rgba(34, 197, 94, 0.16)',
+                        fill: false,
+                        tension: 0.3,
+                    },
+                    {
+                        label: config.labels && config.labels.averagePresence ? config.labels.averagePresence : 'Présence',
+                        data: presenceDataset,
+                        borderColor: '#3b82f6',
+                        backgroundColor: 'rgba(59, 130, 246, 0.16)',
+                        fill: false,
+                        tension: 0.3,
+                    },
+                    {
+                        label: config.labels && config.labels.boostTrend ? config.labels.boostTrend : 'Boosts',
+                        data: premiumDataset,
+                        borderColor: '#a855f7',
+                        backgroundColor: 'rgba(168, 85, 247, 0.16)',
+                        fill: false,
+                        tension: 0.3,
+                        yAxisID: 'yBoosts'
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: {
+                    intersect: false,
+                    mode: 'index'
+                },
+                plugins: {
+                    legend: {
+                        position: 'bottom'
+                    }
+                },
+                scales: {
+                    x: {
+                        ticks: {
+                            maxRotation: 45,
+                            minRotation: 0
+                        }
+                    },
+                    y: {
+                        beginAtZero: true
+                    },
+                    yBoosts: {
+                        beginAtZero: true,
+                        position: 'right',
+                        grid: {
+                            drawOnChartArea: false
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    function initializePanel() {
+        var panel = document.getElementById(config.containerId || 'discord-analytics-panel');
+        if (!panel) {
+            return;
+        }
+
+        setNotice('', false);
+
+        fetchAnalyticsData().then(function (data) {
+            var hasData = data && Array.isArray(data.timeseries) && data.timeseries.length;
+            if (!hasData) {
+                setNotice(config.labels && config.labels.noData ? config.labels.noData : 'Aucune donnée disponible.', false);
+            } else {
+                setNotice('', false);
+            }
+
+            updateSummary(data || {});
+            renderChart(data || {});
+        }).catch(function (error) {
+            console.error('Discord Bot JLG analytics error:', error);
+            setNotice((config.labels && config.labels.noData) ? config.labels.noData : 'Aucune donnée disponible.', true);
+        });
+    }
+
+    ready(initializePanel);
+})(window, document);

--- a/discord-bot-jlg/inc/class-discord-analytics.php
+++ b/discord-bot-jlg/inc/class-discord-analytics.php
@@ -1,0 +1,395 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Discord_Bot_JLG_Analytics {
+    const TABLE_SUFFIX = 'discord_bot_jlg_snapshots';
+    const DEFAULT_RETENTION_DAYS = 90;
+    const MAX_POINTS = 500;
+
+    /**
+     * @var wpdb|null
+     */
+    private $wpdb;
+
+    /**
+     * @var string
+     */
+    private $table_name;
+
+    /**
+     * @var bool
+     */
+    private $use_memory_storage;
+
+    /**
+     * @var array
+     */
+    private $memory_storage;
+
+    public function __construct($wpdb = null, $table_name = '') {
+        if (null === $wpdb && isset($GLOBALS['wpdb']) && is_object($GLOBALS['wpdb'])) {
+            $wpdb = $GLOBALS['wpdb'];
+        }
+
+        $this->wpdb = (is_object($wpdb) && method_exists($wpdb, 'get_results')) ? $wpdb : null;
+        $this->use_memory_storage = (null === $this->wpdb);
+        $this->memory_storage = array();
+
+        if ('' === $table_name) {
+            $prefix = $this->wpdb && isset($this->wpdb->prefix) ? $this->wpdb->prefix : 'wp_';
+            $this->table_name = $prefix . self::TABLE_SUFFIX;
+        } else {
+            $this->table_name = $table_name;
+        }
+    }
+
+    public function get_table_name() {
+        return $this->table_name;
+    }
+
+    public function install() {
+        if ($this->use_memory_storage) {
+            return true;
+        }
+
+        $charset_collate = '';
+        if (isset($this->wpdb->charset) && $this->wpdb->charset) {
+            $charset_collate = 'CHARACTER SET ' . $this->wpdb->charset;
+        }
+        if (isset($this->wpdb->collate) && $this->wpdb->collate) {
+            $charset_collate .= ' COLLATE ' . $this->wpdb->collate;
+        }
+
+        $sql = sprintf(
+            'CREATE TABLE %1$s (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                profile_key VARCHAR(191) NOT NULL,
+                server_id VARCHAR(64) NOT NULL,
+                snapshot_time DATETIME NOT NULL,
+                online_count INT DEFAULT NULL,
+                total_count INT DEFAULT NULL,
+                approximate_presence_count INT DEFAULT NULL,
+                approximate_member_count INT DEFAULT NULL,
+                premium_subscription_count INT DEFAULT NULL,
+                presence_breakdown LONGTEXT DEFAULT NULL,
+                PRIMARY KEY  (id),
+                KEY profile_key_time (profile_key, snapshot_time),
+                KEY snapshot_time (snapshot_time)
+            ) %2$s',
+            $this->table_name,
+            $charset_collate
+        );
+
+        if (!function_exists('dbDelta')) {
+            $upgrade_file = rtrim(ABSPATH, '/\\') . '/wp-admin/includes/upgrade.php';
+            if (file_exists($upgrade_file)) {
+                require_once $upgrade_file;
+            }
+        }
+
+        if (function_exists('dbDelta')) {
+            dbDelta($sql);
+            return true;
+        }
+
+        $this->wpdb->query($sql);
+        return true;
+    }
+
+    public function log_snapshot($profile_key, $server_id, array $stats) {
+        $profile_key = sanitize_key($profile_key);
+        if ('' === $profile_key) {
+            $profile_key = 'default';
+        }
+
+        $server_id = preg_replace('/[^0-9]/', '', (string) $server_id);
+        $snapshot_time = current_time('mysql', true);
+
+        $online  = isset($stats['online']) ? (int) $stats['online'] : null;
+        $total   = isset($stats['total']) && null !== $stats['total'] ? (int) $stats['total'] : null;
+        $approx_presence = isset($stats['approximate_presence_count'])
+            ? (int) $stats['approximate_presence_count']
+            : null;
+        $approx_members = isset($stats['approximate_member_count'])
+            ? (int) $stats['approximate_member_count']
+            : null;
+        $premium = isset($stats['premium_subscription_count'])
+            ? (int) $stats['premium_subscription_count']
+            : null;
+
+        $presence_breakdown = null;
+        if (!empty($stats['presence_count_by_status']) && is_array($stats['presence_count_by_status'])) {
+            $presence_breakdown = wp_json_encode($this->sanitize_presence_counts($stats['presence_count_by_status']));
+        }
+
+        if ($this->use_memory_storage) {
+            $this->memory_storage[] = array(
+                'profile_key' => $profile_key,
+                'server_id'   => $server_id,
+                'snapshot_time' => $snapshot_time,
+                'online_count'   => $online,
+                'total_count'    => $total,
+                'approximate_presence_count' => $approx_presence,
+                'approximate_member_count'   => $approx_members,
+                'premium_subscription_count' => $premium,
+                'presence_breakdown'         => $presence_breakdown,
+            );
+            return true;
+        }
+
+        $data = array(
+            'profile_key' => $profile_key,
+            'server_id'   => $server_id,
+            'snapshot_time' => $snapshot_time,
+            'online_count'   => $online,
+            'total_count'    => $total,
+            'approximate_presence_count' => $approx_presence,
+            'approximate_member_count'   => $approx_members,
+            'premium_subscription_count' => $premium,
+            'presence_breakdown'         => $presence_breakdown,
+        );
+
+        $formats = array('%s', '%s', '%s', '%d', '%d', '%d', '%d', '%d', '%s');
+
+        if (method_exists($this->wpdb, 'insert')) {
+            $this->wpdb->insert($this->table_name, $data, $formats);
+        }
+
+        return true;
+    }
+
+    public function purge_old_entries($retention_days) {
+        $retention_days = (int) $retention_days;
+        if ($retention_days <= 0) {
+            return 0;
+        }
+
+        $cutoff = current_time('timestamp', true) - ($retention_days * DAY_IN_SECONDS);
+        if ($cutoff <= 0) {
+            return 0;
+        }
+
+        $cutoff_mysql = gmdate('Y-m-d H:i:s', $cutoff);
+
+        if ($this->use_memory_storage) {
+            $before = count($this->memory_storage);
+            $this->memory_storage = array_values(array_filter(
+                $this->memory_storage,
+                function ($entry) use ($cutoff_mysql) {
+                    return isset($entry['snapshot_time']) && $entry['snapshot_time'] >= $cutoff_mysql;
+                }
+            ));
+            return $before - count($this->memory_storage);
+        }
+
+        $sql = $this->wpdb->prepare(
+            "DELETE FROM {$this->table_name} WHERE snapshot_time < %s",
+            $cutoff_mysql
+        );
+
+        if (method_exists($this->wpdb, 'query')) {
+            return (int) $this->wpdb->query($sql);
+        }
+
+        return 0;
+    }
+
+    public function get_aggregates($args = array()) {
+        $defaults = array(
+            'profile_key' => '',
+            'server_id'   => '',
+            'days'        => 7,
+            'limit'       => self::MAX_POINTS,
+        );
+
+        $args = wp_parse_args($args, $defaults);
+        $profile_key = sanitize_key($args['profile_key']);
+        $server_id   = preg_replace('/[^0-9]/', '', (string) $args['server_id']);
+        $days        = max(1, (int) $args['days']);
+        $limit       = max(1, (int) $args['limit']);
+
+        $end_timestamp = current_time('timestamp', true);
+        $start_timestamp = $end_timestamp - ($days * DAY_IN_SECONDS);
+        $start_mysql = gmdate('Y-m-d H:i:s', $start_timestamp);
+
+        $entries = $this->use_memory_storage
+            ? $this->filter_memory_entries($profile_key, $server_id, $start_mysql, $limit)
+            : $this->query_entries($profile_key, $server_id, $start_mysql, $limit);
+
+        return $this->build_aggregate_payload($entries, $start_timestamp, $end_timestamp, $days);
+    }
+
+    private function sanitize_presence_counts($counts) {
+        if (!is_array($counts)) {
+            return array();
+        }
+
+        $sanitized = array();
+        foreach ($counts as $status => $value) {
+            $key = sanitize_key($status);
+            if ('' === $key) {
+                continue;
+            }
+
+            $sanitized[$key] = (int) $value;
+        }
+
+        return $sanitized;
+    }
+
+    private function filter_memory_entries($profile_key, $server_id, $start_mysql, $limit) {
+        $filtered = array();
+        foreach ($this->memory_storage as $entry) {
+            if ($profile_key && (!isset($entry['profile_key']) || $entry['profile_key'] !== $profile_key)) {
+                continue;
+            }
+            if ($server_id && (!isset($entry['server_id']) || $entry['server_id'] !== $server_id)) {
+                continue;
+            }
+            if (!isset($entry['snapshot_time']) || $entry['snapshot_time'] < $start_mysql) {
+                continue;
+            }
+            $filtered[] = $entry;
+        }
+
+        usort($filtered, function ($a, $b) {
+            $time_a = isset($a['snapshot_time']) ? strtotime($a['snapshot_time']) : 0;
+            $time_b = isset($b['snapshot_time']) ? strtotime($b['snapshot_time']) : 0;
+            if ($time_a === $time_b) {
+                return 0;
+            }
+            return ($time_a < $time_b) ? -1 : 1;
+        });
+
+        if (count($filtered) > $limit) {
+            $filtered = array_slice($filtered, count($filtered) - $limit);
+        }
+
+        return $filtered;
+    }
+
+    private function query_entries($profile_key, $server_id, $start_mysql, $limit) {
+        $conditions = array('snapshot_time >= %s');
+        $params = array($start_mysql);
+
+        if ('' !== $profile_key) {
+            $conditions[] = 'profile_key = %s';
+            $params[] = $profile_key;
+        }
+
+        if ('' !== $server_id) {
+            $conditions[] = 'server_id = %s';
+            $params[] = $server_id;
+        }
+
+        $where_clause = implode(' AND ', $conditions);
+        $sql = "SELECT snapshot_time, profile_key, server_id, online_count, total_count, approximate_presence_count, approximate_member_count, premium_subscription_count, presence_breakdown FROM {$this->table_name} WHERE {$where_clause} ORDER BY snapshot_time ASC";
+        if ($limit > 0) {
+            $sql .= ' LIMIT ' . (int) $limit;
+        }
+
+        if (!empty($params)) {
+            $sql = $this->wpdb->prepare($sql, $params);
+        }
+
+        $results = $this->wpdb->get_results($sql, ARRAY_A);
+        if (!is_array($results)) {
+            return array();
+        }
+
+        return $results;
+    }
+
+    private function build_aggregate_payload($entries, $start_timestamp, $end_timestamp, $days) {
+        $timeseries = array();
+        $online_sum = 0;
+        $online_count = 0;
+        $presence_sum = 0;
+        $presence_count = 0;
+        $total_sum = 0;
+        $total_count = 0;
+        $peak_presence = array('count' => null, 'timestamp' => null);
+        $first_premium = null;
+        $last_premium = null;
+
+        foreach ($entries as $entry) {
+            $timestamp = isset($entry['snapshot_time']) ? strtotime($entry['snapshot_time'] . ' UTC') : 0;
+            if ($timestamp <= 0) {
+                continue;
+            }
+
+            $online = isset($entry['online_count']) ? (int) $entry['online_count'] : null;
+            $total  = isset($entry['total_count']) ? (int) $entry['total_count'] : null;
+            $presence = isset($entry['approximate_presence_count'])
+                ? (int) $entry['approximate_presence_count']
+                : null;
+            if (null === $presence && isset($entry['online_count'])) {
+                $presence = (int) $entry['online_count'];
+            }
+            $premium = isset($entry['premium_subscription_count'])
+                ? (int) $entry['premium_subscription_count']
+                : null;
+
+            $timeseries[] = array(
+                'timestamp' => $timestamp,
+                'online'    => $online,
+                'presence'  => $presence,
+                'total'     => $total,
+                'premium'   => $premium,
+            );
+
+            if (null !== $online) {
+                $online_sum += $online;
+                $online_count++;
+            }
+
+            if (null !== $total) {
+                $total_sum += $total;
+                $total_count++;
+            }
+
+            if (null !== $presence) {
+                $presence_sum += $presence;
+                $presence_count++;
+                if (null === $peak_presence['count'] || $presence > $peak_presence['count']) {
+                    $peak_presence['count'] = $presence;
+                    $peak_presence['timestamp'] = $timestamp;
+                }
+            }
+
+            if (null !== $premium) {
+                if (null === $first_premium) {
+                    $first_premium = $premium;
+                }
+                $last_premium = $premium;
+            }
+        }
+
+        $averages = array(
+            'online'   => $online_count > 0 ? $online_sum / $online_count : null,
+            'presence' => $presence_count > 0 ? $presence_sum / $presence_count : null,
+            'total'    => $total_count > 0 ? $total_sum / $total_count : null,
+        );
+
+        $boost_trend = array(
+            'latest'   => $last_premium,
+            'initial'  => $first_premium,
+            'delta'    => (null !== $last_premium && null !== $first_premium) ? ($last_premium - $first_premium) : null,
+        );
+
+        return array(
+            'range' => array(
+                'start' => $start_timestamp,
+                'end'   => $end_timestamp,
+                'days'  => $days,
+            ),
+            'averages' => $averages,
+            'peak_presence' => $peak_presence,
+            'boost_trend' => $boost_trend,
+            'timeseries' => $timeseries,
+        );
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -81,7 +81,7 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION
         );
 
-        $this->admin = new Discord_Bot_JLG_Admin(DISCORD_BOT_JLG_OPTION_NAME, $this->api);
+        $this->admin = new Discord_Bot_JLG_Admin(DISCORD_BOT_JLG_OPTION_NAME, $this->api, null);
     }
 
     protected function tearDown(): void {
@@ -431,7 +431,7 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION,
             $http_client
         );
-        $this->admin = new Discord_Bot_JLG_Admin(DISCORD_BOT_JLG_OPTION_NAME, $this->api);
+        $this->admin = new Discord_Bot_JLG_Admin(DISCORD_BOT_JLG_OPTION_NAME, $this->api, null);
 
         $fallback_reason = 'Connexion à Discord interrompue';
         update_option(

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Analytics.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Analytics.php
@@ -1,0 +1,50 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class Test_Discord_Bot_JLG_Analytics extends TestCase {
+    protected function tearDown(): void {
+        unset($GLOBALS['wp_test_current_timestamp']);
+        parent::tearDown();
+    }
+
+    public function test_log_snapshot_and_get_aggregates() {
+        $analytics = new Discord_Bot_JLG_Analytics(null, 'test_snapshots');
+        $GLOBALS['wp_test_current_timestamp'] = 1_700_000_000;
+
+        $analytics->log_snapshot('default', '123', array(
+            'online' => 15,
+            'approximate_presence_count' => 18,
+            'premium_subscription_count' => 3,
+        ));
+
+        $aggregates = $analytics->get_aggregates(array('profile_key' => 'default', 'days' => 7));
+
+        $this->assertArrayHasKey('timeseries', $aggregates);
+        $this->assertCount(1, $aggregates['timeseries']);
+        $point = $aggregates['timeseries'][0];
+        $this->assertSame(15, $point['online']);
+        $this->assertSame(18, $point['presence']);
+        $this->assertSame(3, $point['premium']);
+        $this->assertArrayHasKey('averages', $aggregates);
+        $this->assertSame(15.0, $aggregates['averages']['online']);
+    }
+
+    public function test_purge_old_entries_removes_outdated_records() {
+        $analytics = new Discord_Bot_JLG_Analytics(null, 'test_snapshots');
+
+        $GLOBALS['wp_test_current_timestamp'] = 1_700_000_000;
+        $analytics->log_snapshot('default', '123', array('online' => 10));
+
+        $GLOBALS['wp_test_current_timestamp'] = 1_700_086_400; // +1 day
+        $analytics->log_snapshot('default', '123', array('online' => 20));
+
+        $deleted = $analytics->purge_old_entries(1);
+        $this->assertSame(1, $deleted);
+
+        $aggregates = $analytics->get_aggregates(array('profile_key' => 'default', 'days' => 7));
+        $this->assertCount(1, $aggregates['timeseries']);
+        $this->assertSame(20, $aggregates['timeseries'][0]['online']);
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_REST_Controller.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_REST_Controller.php
@@ -34,6 +34,20 @@ class Stubbed_Discord_Bot_JLG_API_For_REST extends Discord_Bot_JLG_API {
     }
 }
 
+class Stubbed_Discord_Bot_JLG_Analytics {
+    public $last_args = array();
+    private $payload;
+
+    public function __construct($payload = array()) {
+        $this->payload = $payload;
+    }
+
+    public function get_aggregates($args = array()) {
+        $this->last_args = $args;
+        return $this->payload;
+    }
+}
+
 class Test_Discord_Bot_JLG_REST_Controller extends TestCase {
     protected function tearDown(): void {
         $GLOBALS['wp_test_nonce_validations'] = array();
@@ -52,7 +66,7 @@ class Test_Discord_Bot_JLG_REST_Controller extends TestCase {
             )
         );
 
-        $controller = new Discord_Bot_JLG_REST_Controller($api);
+        $controller = new Discord_Bot_JLG_REST_Controller($api, null);
         $request    = new WP_REST_Request();
         $request->set_param('profile_key', 'custom_profile');
         $request->set_param('server_id', ' 123456 ');
@@ -77,7 +91,7 @@ class Test_Discord_Bot_JLG_REST_Controller extends TestCase {
         $GLOBALS['wp_test_nonce_validations']['wp_rest'] = false;
 
         $api = new Stubbed_Discord_Bot_JLG_API_For_REST();
-        $controller = new Discord_Bot_JLG_REST_Controller($api);
+        $controller = new Discord_Bot_JLG_REST_Controller($api, null);
         $request    = new WP_REST_Request();
         $request->set_header('X-WP-Nonce', 'invalid');
 
@@ -106,7 +120,7 @@ class Test_Discord_Bot_JLG_REST_Controller extends TestCase {
             )
         );
 
-        $controller = new Discord_Bot_JLG_REST_Controller($api);
+        $controller = new Discord_Bot_JLG_REST_Controller($api, null);
         $request    = new WP_REST_Request();
 
         $response = $controller->handle_get_stats($request);
@@ -118,5 +132,41 @@ class Test_Discord_Bot_JLG_REST_Controller extends TestCase {
         $this->assertTrue($payload['data']['rate_limited']);
         $this->assertArrayHasKey('is_public_request', $api->last_args);
         $this->assertTrue($api->last_args['is_public_request']);
+    }
+
+    public function test_analytics_route_returns_aggregates() {
+        $api = new Stubbed_Discord_Bot_JLG_API_For_REST();
+        $analytics_payload = array('timeseries' => array(array('timestamp' => 1000, 'online' => 12)));
+        $analytics = new Stubbed_Discord_Bot_JLG_Analytics($analytics_payload);
+
+        $controller = new Discord_Bot_JLG_REST_Controller($api, $analytics);
+        $request    = new WP_REST_Request();
+        $request->set_param('profile_key', 'guild');
+        $request->set_param('days', 5);
+
+        $response = $controller->handle_get_analytics($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(200, $response->get_status());
+
+        $payload = $response->get_data();
+        $this->assertTrue($payload['success']);
+        $this->assertSame($analytics_payload, $payload['data']);
+        $this->assertArrayHasKey('profile_key', $analytics->last_args);
+        $this->assertSame('guild', $analytics->last_args['profile_key']);
+        $this->assertSame(5, $analytics->last_args['days']);
+    }
+
+    public function test_analytics_route_handles_missing_service() {
+        $api = new Stubbed_Discord_Bot_JLG_API_For_REST();
+        $controller = new Discord_Bot_JLG_REST_Controller($api, null);
+        $request    = new WP_REST_Request();
+
+        $response = $controller->handle_get_analytics($request);
+
+        $this->assertSame(501, $response->get_status());
+        $payload = $response->get_data();
+        $this->assertFalse($payload['success']);
+        $this->assertArrayHasKey('message', $payload['data']);
     }
 }

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -16,6 +16,7 @@ if (!defined('DAY_IN_SECONDS')) {
 }
 
 require_once __DIR__ . '/../../inc/helpers.php';
+require_once __DIR__ . '/../../inc/class-discord-analytics.php';
 require_once __DIR__ . '/../../inc/class-discord-http.php';
 require_once __DIR__ . '/../../inc/class-discord-api.php';
 require_once __DIR__ . '/../../inc/class-discord-widget.php';


### PR DESCRIPTION
## Summary
- add an analytics persistence service to capture cron snapshots with retention controls
- expose aggregated metrics via REST and surface them in the admin dashboard and optional sparkline embeds
- extend block/editor settings, frontend assets, and PHPUnit coverage to support analytics displays

## Testing
- npm -s run test
- ~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit -c discord-bot-jlg/phpunit.xml.dist *(fails: WordPress test suite missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26d682c68832e8fe62da39eb055ee