### PR TITLE
Restrict analytics REST endpoint access to admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Accédez à la page **Discord Bot** dans l’administration pour :
 - Personnaliser les icônes et libellés proposés par défaut (cartes principales, répartition des présences, boosts) ;
 - Ajouter du CSS personnalisé.
 
+> ℹ️ Les tableaux de bord d’analytics et l’API REST `discord-bot-jlg/v1/analytics` ne sont accessibles qu’aux utilisateurs connectés disposant de la capacité `manage_options` (ou via une clé API déclarée à l’aide du filtre `discord_bot_jlg_rest_access_key`).
+
 ### Définir le token via une constante
 
 Il est possible de forcer l'utilisation d'un token spécifique en définissant la constante `DISCORD_BOT_JLG_TOKEN` dans votre fichier `wp-config.php` ou dans un plugin mu. Lorsque cette constante est présente (et non vide), elle est utilisée à la place de la valeur enregistrée dans l'administration et le champ correspondant devient en lecture seule.

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -524,6 +524,28 @@ function wp_safe_remote_get($url, $args = array()) {
 }
 
 function current_user_can($capability) {
+    if (isset($GLOBALS['wp_test_current_user_can'])) {
+        $current_user_can = $GLOBALS['wp_test_current_user_can'];
+
+        if (is_callable($current_user_can)) {
+            return (bool) call_user_func($current_user_can, $capability);
+        }
+
+        if (is_array($current_user_can)) {
+            if (array_key_exists($capability, $current_user_can)) {
+                return (bool) $current_user_can[$capability];
+            }
+
+            if (array_key_exists('*', $current_user_can)) {
+                return (bool) $current_user_can['*'];
+            }
+        }
+
+        if (is_bool($current_user_can)) {
+            return $current_user_can;
+        }
+    }
+
     return true;
 }
 
@@ -682,14 +704,26 @@ function wp_validate_boolean($value) {
 }
 
 class WP_Error {
+    private $code;
     private $message;
+    private $data;
 
-    public function __construct($code = '', $message = '') {
+    public function __construct($code = '', $message = '', $data = null) {
+        $this->code    = (string) $code;
         $this->message = $message;
+        $this->data    = $data;
+    }
+
+    public function get_error_code() {
+        return $this->code;
     }
 
     public function get_error_message() {
         return $this->message;
+    }
+
+    public function get_error_data() {
+        return $this->data;
     }
 }
 


### PR DESCRIPTION
## Summary
- enforce capability checks on the stats and analytics REST routes with an optional access key filter
- return a WP_Error with status 403 when permission checks fail and extend the REST controller tests
- document the requirement to be logged in before viewing analytics data

## Testing
- Not run (phpunit not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e27f3924bc832e98d22a913213223f