### PR TITLE
Restrict Discord analytics REST endpoints to administrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Pendant une requête d'actualisation, le conteneur affiche désormais un indicat
 
 Les rafraîchissements publics (visiteurs non connectés) n'exigent plus de nonce WordPress ; seuls les administrateurs connectés utilisent un jeton de sécurité pour l'action AJAX `refresh_discord_stats`.
 
+### Analytics (REST)
+
+Les graphiques d'analytics et la page d'administration exploitent l'endpoint REST `discord-bot-jlg/v1/analytics`. Pour des raisons de confidentialité, sa consultation nécessite d'être connecté avec la capacité `manage_options`. Si vous devez ouvrir l'accès à un outil externe, vous pouvez fournir une clé API partagée en filtrant `discord_bot_jlg_rest_api_keys` et en l'envoyant via l'en-tête `X-Discord-Bot-JLG-Key` (ou le paramètre `api_key`).
+
 ### Accessibilité
 
 Le plugin embarque sa propre définition `.screen-reader-text`, incluse à la fois dans les feuilles de style principales et inline chargées par le shortcode. Ce fallback reprend le pattern WordPress (position absolue, dimensions réduites à 1px, `clip-path: inset(50%)`, etc.) afin que les libellés masqués restent interprétables par les lecteurs d'écran même si le thème actif ne fournit pas cette classe utilitaire.

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -524,7 +524,29 @@ function wp_safe_remote_get($url, $args = array()) {
 }
 
 function current_user_can($capability) {
-    return true;
+    if (!isset($GLOBALS['wp_test_current_user_caps'])) {
+        return true;
+    }
+
+    $caps = $GLOBALS['wp_test_current_user_caps'];
+
+    if (true === $caps) {
+        return true;
+    }
+
+    if (!is_array($caps)) {
+        return false;
+    }
+
+    if (array_key_exists($capability, $caps)) {
+        return (bool) $caps[$capability];
+    }
+
+    if (array_key_exists('*', $caps)) {
+        return (bool) $caps['*'];
+    }
+
+    return false;
 }
 
 if (!function_exists('__return_true')) {
@@ -683,13 +705,19 @@ function wp_validate_boolean($value) {
 
 class WP_Error {
     private $message;
+    private $data;
 
-    public function __construct($code = '', $message = '') {
+    public function __construct($code = '', $message = '', $data = null) {
         $this->message = $message;
+        $this->data    = $data;
     }
 
     public function get_error_message() {
         return $this->message;
+    }
+
+    public function get_error_data($code = '') {
+        return $this->data;
     }
 }
 


### PR DESCRIPTION
## Summary
- guard the Discord REST routes behind a manage_options capability check with optional shared API keys
- extend the PHPUnit bootstrap and tests to exercise the new permission callback behaviour
- document the analytics REST endpoint access requirements in the README

## Testing
- phpunit --testsuite discord-bot-jlg *(fails: phpunit not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27fe8d7bc832ea32ca6d6b91c29a0