### PR TITLE
Fix polyfill loader registration for frontend script

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -1240,8 +1240,8 @@ class Discord_Bot_JLG_Shortcode {
                 $polyfill_loader = wp_get_script_polyfill(
                     $GLOBALS['wp_scripts'],
                     array(
-                        'fetch'   => array('wp-polyfill-fetch'),
-                        'Promise' => array('wp-polyfill-promise'),
+                        'fetch'   => 'wp-polyfill-fetch',
+                        'Promise' => 'wp-polyfill-promise',
                     )
                 );
 


### PR DESCRIPTION
## Summary
- ensure the polyfill loader receives handle names instead of nested arrays when registering frontend assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d2fbd544832eae3fa8f252b1d133