### PR TITLE
Limit demo intro notice width

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -1772,7 +1772,7 @@ class Discord_Bot_JLG_Admin {
      */
     private function render_demo_intro_notice() {
         ?>
-        <div style="background: #fff3cd; padding: 10px 20px; border-radius: 8px; margin: 20px 0;">
+        <div style="background: #fff3cd; padding: 10px 20px; border-radius: 8px; margin: 20px auto; width: 100%; max-width: 500px;">
             <p><?php echo wp_kses_post(__('<strong>💡 Astuce :</strong> Tous les exemples ci-dessous utilisent le mode démo. Vous pouvez les copier-coller directement !', 'discord-bot-jlg')); ?></p>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- restrict the yellow demo intro notice so it centers and caps its width on large screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2dc6f1dbc832eb199b4cdad58298c