### PR TITLE
Fix demo badge positioning on ultra-wide displays

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -474,8 +474,8 @@
 
 .discord-stats-container .discord-demo-badge {
     position: absolute;
-    top: -10px;
-    right: -10px;
+    top: clamp(8px, var(--discord-padding), 16px);
+    right: clamp(8px, var(--discord-padding), 16px);
     background: linear-gradient(45deg, var(--discord-badge-start, #ff6b6b), var(--discord-badge-end, #f06292));
     color: var(--discord-badge-text, #ffffff);
     padding: 2px 8px;
@@ -486,6 +486,9 @@
     z-index: 10;
     animation: pulse 2s infinite;
     transform: scale(var(--discord-badge-scale));
+    transform-origin: top right;
+    max-width: calc(100% - (2 * clamp(8px, var(--discord-padding), 16px)));
+    box-sizing: border-box;
 }
 
 .discord-stats-container[data-refreshing="true"] .discord-stats-wrapper {

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -580,6 +580,7 @@
         transform: translateX(-50%) scale(var(--discord-badge-scale));
         text-align: center;
         white-space: nowrap;
+        max-width: calc(100% - 24px);
     }
 }
 
@@ -617,7 +618,27 @@
         bottom: calc(12px + 38px);
         padding: 3px 8px;
         letter-spacing: 0.08em;
+        max-width: calc(100% - 20px);
     }
+}
+
+.discord-demo-badge {
+    position: absolute;
+    top: clamp(8px, var(--discord-padding), 16px);
+    right: clamp(8px, var(--discord-padding), 16px);
+    background: linear-gradient(45deg, var(--discord-badge-start, #ff6b6b), var(--discord-badge-end, #f06292));
+    color: var(--discord-badge-text, #ffffff);
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: clamp(8px, 1.8vw, 10px);
+    font-weight: bold;
+    text-transform: uppercase;
+    z-index: 10;
+    animation: pulse 2s infinite;
+    transform: scale(var(--discord-badge-scale));
+    transform-origin: top right;
+    max-width: calc(100% - (2 * clamp(8px, var(--discord-padding), 16px)));
+    box-sizing: border-box;
 }
 
 .discord-bot-jlg-preview-loading {


### PR DESCRIPTION
## Summary
- anchor the demo badge inside the stats container so it stays within the card on wide layouts
- constrain the badge width and transform origin to keep the label visible across breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e9b200f8832e9d76a38d979adb54