### PR TITLE
Add Radix UI themed option for Discord stats display

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -642,6 +642,76 @@
     --discord-logo-color: currentColor;
 }
 
+.discord-stats-container.discord-theme-radix {
+    --discord-gap: clamp(18px, 4vw, 28px);
+    --discord-padding: clamp(16px, 3.2vw, 24px);
+    --discord-radius: clamp(12px, 2.4vw, 18px);
+    --discord-icon-size: clamp(18px, 3.8vw, 26px);
+    --discord-number-size: clamp(24px, 4.4vw, 36px);
+    --discord-label-size: clamp(13px, 2.6vw, 17px);
+    --discord-surface-background: rgba(248, 250, 252, 0.9);
+    --discord-surface-text: #0f172a;
+    --discord-surface-border: rgba(148, 163, 184, 0.45);
+    --discord-surface-shadow: 0 12px 30px -22px rgba(15, 23, 42, 0.35), 0 0 0 1px rgba(148, 163, 184, 0.22);
+    --discord-surface-hover-shadow: 0 22px 48px -24px rgba(15, 23, 42, 0.45), 0 0 0 1px rgba(37, 99, 235, 0.28);
+    --discord-accent: #2563eb;
+    --discord-accent-secondary: #1d4ed8;
+    --discord-accent-contrast: #f8fafc;
+    --discord-focus-outline: rgba(37, 99, 235, 0.4);
+    --discord-outline-contrast: rgba(37, 99, 235, 0.5);
+    --discord-avatar-background: rgba(37, 99, 235, 0.08);
+    --discord-avatar-shadow: 0 10px 28px -20px rgba(15, 23, 42, 0.4);
+    --discord-button-shadow: rgba(37, 99, 235, 0.25);
+    --discord-button-shadow-hover: rgba(37, 99, 235, 0.35);
+    --discord-refresh-background: rgba(15, 23, 42, 0.88);
+    --discord-refresh-text: #e2e8f0;
+    --discord-refresh-border: rgba(148, 163, 184, 0.35);
+    --discord-logo-color: #1e293b;
+    --discord-badge-start: #2563eb;
+    --discord-badge-end: #7c3aed;
+    --discord-badge-text: #f8fafc;
+    background: linear-gradient(180deg, rgba(241, 245, 249, 0.72) 0%, rgba(248, 250, 252, 0.08) 100%);
+    border-radius: max(var(--discord-radius), 16px);
+    padding: var(--wp--style--spacing--padding, clamp(20px, 4.2vw, 32px));
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    box-shadow: 0 30px 60px -44px rgba(15, 23, 42, 0.55);
+}
+
+.discord-stats-container.discord-theme-radix .discord-stats-main {
+    background: rgba(255, 255, 255, 0.82);
+    padding: clamp(18px, 3.8vw, 28px);
+    border-radius: calc(var(--discord-radius) * 1.35);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    box-shadow: 0 24px 45px -36px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(14px);
+}
+
+.discord-stats-container.discord-theme-radix .discord-stat {
+    backdrop-filter: saturate(1.25);
+}
+
+.discord-stats-container.discord-theme-radix .discord-cta-button--solid {
+    background: linear-gradient(180deg, #2563eb 0%, #1d4ed8 100%);
+    color: var(--discord-accent-contrast, #f8fafc);
+    box-shadow: 0 12px 32px -18px rgba(37, 99, 235, 0.55);
+}
+
+.discord-stats-container.discord-theme-radix .discord-cta-button--solid:hover,
+.discord-stats-container.discord-theme-radix .discord-cta-button--solid:focus-visible {
+    filter: brightness(1.02);
+}
+
+.discord-stats-container.discord-theme-radix .discord-cta-button--outline {
+    color: #1d4ed8;
+    border-color: rgba(37, 99, 235, 0.4);
+}
+
+.discord-stats-container.discord-theme-radix .discord-cta-button--outline:hover,
+.discord-stats-container.discord-theme-radix .discord-cta-button--outline:focus-visible {
+    color: #1e40af;
+    border-color: rgba(37, 99, 235, 0.6);
+}
+
 .discord-stats-container.discord-align-center .discord-stats-main {
     justify-content: center;
 }

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -504,6 +504,76 @@
     --discord-logo-color: currentColor;
 }
 
+.discord-stats-container.discord-theme-radix {
+    --discord-gap: clamp(18px, 4vw, 28px);
+    --discord-padding: clamp(16px, 3.2vw, 24px);
+    --discord-radius: clamp(12px, 2.4vw, 18px);
+    --discord-icon-size: clamp(18px, 3.8vw, 26px);
+    --discord-number-size: clamp(24px, 4.4vw, 36px);
+    --discord-label-size: clamp(13px, 2.6vw, 17px);
+    --discord-surface-background: rgba(248, 250, 252, 0.9);
+    --discord-surface-text: #0f172a;
+    --discord-surface-border: rgba(148, 163, 184, 0.45);
+    --discord-surface-shadow: 0 12px 30px -22px rgba(15, 23, 42, 0.35), 0 0 0 1px rgba(148, 163, 184, 0.22);
+    --discord-surface-hover-shadow: 0 22px 48px -24px rgba(15, 23, 42, 0.45), 0 0 0 1px rgba(37, 99, 235, 0.28);
+    --discord-accent: #2563eb;
+    --discord-accent-secondary: #1d4ed8;
+    --discord-accent-contrast: #f8fafc;
+    --discord-focus-outline: rgba(37, 99, 235, 0.4);
+    --discord-outline-contrast: rgba(37, 99, 235, 0.5);
+    --discord-avatar-background: rgba(37, 99, 235, 0.08);
+    --discord-avatar-shadow: 0 10px 28px -20px rgba(15, 23, 42, 0.4);
+    --discord-button-shadow: rgba(37, 99, 235, 0.25);
+    --discord-button-shadow-hover: rgba(37, 99, 235, 0.35);
+    --discord-refresh-background: rgba(15, 23, 42, 0.88);
+    --discord-refresh-text: #e2e8f0;
+    --discord-refresh-border: rgba(148, 163, 184, 0.35);
+    --discord-logo-color: #1e293b;
+    --discord-badge-start: #2563eb;
+    --discord-badge-end: #7c3aed;
+    --discord-badge-text: #f8fafc;
+    background: linear-gradient(180deg, rgba(241, 245, 249, 0.72) 0%, rgba(248, 250, 252, 0.08) 100%);
+    border-radius: max(var(--discord-radius), 16px);
+    padding: var(--wp--style--spacing--padding, clamp(20px, 4.2vw, 32px));
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    box-shadow: 0 30px 60px -44px rgba(15, 23, 42, 0.55);
+}
+
+.discord-stats-container.discord-theme-radix .discord-stats-main {
+    background: rgba(255, 255, 255, 0.82);
+    padding: clamp(18px, 3.8vw, 28px);
+    border-radius: calc(var(--discord-radius) * 1.35);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    box-shadow: 0 24px 45px -36px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(14px);
+}
+
+.discord-stats-container.discord-theme-radix .discord-stat {
+    backdrop-filter: saturate(1.25);
+}
+
+.discord-stats-container.discord-theme-radix .discord-cta-button--solid {
+    background: linear-gradient(180deg, #2563eb 0%, #1d4ed8 100%);
+    color: var(--discord-accent-contrast, #f8fafc);
+    box-shadow: 0 12px 32px -18px rgba(37, 99, 235, 0.55);
+}
+
+.discord-stats-container.discord-theme-radix .discord-cta-button--solid:hover,
+.discord-stats-container.discord-theme-radix .discord-cta-button--solid:focus-visible {
+    filter: brightness(1.02);
+}
+
+.discord-stats-container.discord-theme-radix .discord-cta-button--outline {
+    color: #1d4ed8;
+    border-color: rgba(37, 99, 235, 0.4);
+}
+
+.discord-stats-container.discord-theme-radix .discord-cta-button--outline:hover,
+.discord-stats-container.discord-theme-radix .discord-cta-button--outline:focus-visible {
+    color: #1e40af;
+    border-color: rgba(37, 99, 235, 0.6);
+}
+
 /* Widget styles */
 .widget .discord-stats-wrapper {
     flex-direction: column;

--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -97,7 +97,8 @@
         { label: __('Discord', 'discord-bot-jlg'), value: 'discord' },
         { label: __('Sombre', 'discord-bot-jlg'), value: 'dark' },
         { label: __('Clair', 'discord-bot-jlg'), value: 'light' },
-        { label: __('Minimal', 'discord-bot-jlg'), value: 'minimal' }
+        { label: __('Minimal', 'discord-bot-jlg'), value: 'minimal' },
+        { label: __('Radix UI', 'discord-bot-jlg'), value: 'radix' }
     ];
 
     var alignOptions = [

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -1464,6 +1464,7 @@ class Discord_Bot_JLG_Admin {
             'dark'    => __('Sombre', 'discord-bot-jlg'),
             'light'   => __('Clair', 'discord-bot-jlg'),
             'minimal' => __('Minimal', 'discord-bot-jlg'),
+            'radix'   => __('Radix UI', 'discord-bot-jlg'),
         );
 
         $choices = array();
@@ -1931,7 +1932,7 @@ class Discord_Bot_JLG_Admin {
                 <h5><?php esc_html_e('🎨 Apparence & Layout :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
                     <li><?php echo wp_kses_post(__('<strong>layout</strong> : horizontal, vertical, compact', 'discord-bot-jlg')); ?></li>
-                    <li><?php echo wp_kses_post(__('<strong>theme</strong> : discord, dark, light, minimal', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>theme</strong> : discord, dark, light, minimal, radix', 'discord-bot-jlg')); ?></li>
                     <li><?php echo wp_kses_post(__('<strong>align</strong> : left, center, right', 'discord-bot-jlg')); ?></li>
                     <li><?php echo wp_kses_post(__('<strong>width</strong> : largeur CSS (ex: "300px", "100%")', 'discord-bot-jlg')); ?></li>
                     <li><?php echo wp_kses_post(__('<strong>compact</strong> : true/false (version réduite)', 'discord-bot-jlg')); ?></li>

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -35,7 +35,7 @@ class Discord_Stats_Widget extends WP_Widget {
 
         $allowed_layouts   = array('horizontal', 'vertical');
         $allowed_positions = array('left', 'right', 'top');
-        $allowed_themes    = array('discord', 'dark', 'light', 'minimal');
+        $allowed_themes    = array('discord', 'dark', 'light', 'minimal', 'radix');
 
         $layout = sanitize_key($instance['layout']);
         if (!in_array($layout, $allowed_layouts, true)) {
@@ -177,7 +177,7 @@ class Discord_Stats_Widget extends WP_Widget {
         $instance['discord_icon_position'] = in_array($icon_position, array('left', 'right', 'top'), true) ? $icon_position : 'left';
 
         $theme = isset($new_instance['theme']) ? sanitize_key($new_instance['theme']) : 'discord';
-        $instance['theme'] = in_array($theme, array('discord', 'dark', 'light', 'minimal'), true) ? $theme : 'discord';
+        $instance['theme'] = in_array($theme, array('discord', 'dark', 'light', 'minimal', 'radix'), true) ? $theme : 'discord';
 
         $instance['refresh'] = !empty($new_instance['refresh']) ? 1 : 0;
         $min_refresh = defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
@@ -304,6 +304,7 @@ class Discord_Stats_Widget extends WP_Widget {
                 <option value="dark" <?php selected($instance['theme'], 'dark'); ?>><?php esc_html_e('Sombre', 'discord-bot-jlg'); ?></option>
                 <option value="light" <?php selected($instance['theme'], 'light'); ?>><?php esc_html_e('Clair', 'discord-bot-jlg'); ?></option>
                 <option value="minimal" <?php selected($instance['theme'], 'minimal'); ?>><?php esc_html_e('Minimal', 'discord-bot-jlg'); ?></option>
+                <option value="radix" <?php selected($instance['theme'], 'radix'); ?>><?php esc_html_e('Radix UI', 'discord-bot-jlg'); ?></option>
             </select>
         </p>
 

--- a/discord-bot-jlg/inc/helpers.php
+++ b/discord-bot-jlg/inc/helpers.php
@@ -18,7 +18,7 @@ if (!function_exists('discord_bot_jlg_get_available_themes')) {
      * @return string[]
      */
     function discord_bot_jlg_get_available_themes() {
-        $themes = array('discord', 'dark', 'light', 'minimal');
+        $themes = array('discord', 'dark', 'light', 'minimal', 'radix');
 
         if (function_exists('apply_filters')) {
             $filtered = apply_filters('discord_bot_jlg_available_themes', $themes);

--- a/discord-bot-jlg/languages/discord-bot-jlg.pot
+++ b/discord-bot-jlg/languages/discord-bot-jlg.pot
@@ -436,7 +436,11 @@ msgid "<strong>layout</strong> : horizontal, vertical, compact"
 msgstr ""
 
 #: inc/class-discord-admin.php:718
-msgid "<strong>theme</strong> : discord, dark, light, minimal"
+msgid "<strong>theme</strong> : discord, dark, light, minimal, radix"
+msgstr ""
+
+#: assets/js/discord-bot-block.js:101 inc/class-discord-admin.php:1467 inc/class-discord-widget.php:307
+msgid "Radix UI"
 msgstr ""
 
 #: inc/class-discord-admin.php:719


### PR DESCRIPTION
## Summary
- add a Radix UI-inspired visual theme for the Discord stats widget including updated surfaces, spacing, and CTA styles
- expose the new theme choice in the block editor, widget configuration, and helper utilities
- refresh the French translation template to document the additional theme option

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e54eece1a4832ea44f02f46e4c6dcb