### PR TITLE
Implement coded UI presets for Discord stats

### DIFF
--- a/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg-inline.css
@@ -1095,6 +1095,308 @@
     border-color: rgba(37, 99, 235, 0.6);
 }
 
+.discord-stats-container.discord-theme-headless {
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --discord-gap: clamp(16px, 3.6vw, 26px);
+    --discord-padding: clamp(16px, 3.4vw, 26px);
+    --discord-radius: clamp(10px, 2.4vw, 18px);
+    --discord-surface-background: rgba(15, 23, 42, 0.03);
+    --discord-surface-text: #0f172a;
+    --discord-surface-border: rgba(15, 23, 42, 0.08);
+    --discord-surface-shadow: 0 1px 0 rgba(15, 23, 42, 0.08), 0 18px 32px -26px rgba(15, 23, 42, 0.5);
+    --discord-surface-hover-shadow: 0 2px 0 rgba(15, 23, 42, 0.12), 0 28px 42px -26px rgba(15, 23, 42, 0.55);
+    --discord-accent: #3b82f6;
+    --discord-accent-secondary: #1d4ed8;
+    --discord-accent-contrast: #f8fafc;
+    --discord-focus-outline: rgba(249, 115, 22, 0.5);
+    --discord-outline-contrast: rgba(249, 115, 22, 0.45);
+    --discord-avatar-background: rgba(59, 130, 246, 0.08);
+    --discord-avatar-shadow: 0 14px 38px -28px rgba(15, 23, 42, 0.65);
+    --discord-button-shadow: rgba(59, 130, 246, 0.24);
+    --discord-button-shadow-hover: rgba(59, 130, 246, 0.34);
+    --discord-refresh-background: rgba(15, 23, 42, 0.96);
+    --discord-refresh-text: #f8fafc;
+    --discord-refresh-border: rgba(148, 163, 184, 0.3);
+    --discord-logo-color: #1f2937;
+    --discord-badge-start: #3b82f6;
+    --discord-badge-end: #f97316;
+    --discord-badge-text: #0f172a;
+}
+
+.discord-stats-container.discord-theme-headless .discord-stats-main {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(241, 245, 249, 0.75) 100%);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: calc(var(--discord-radius) * 1.2);
+    box-shadow: 0 24px 38px -32px rgba(15, 23, 42, 0.45);
+}
+
+.discord-stats-container.discord-theme-headless .discord-stat {
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    background: rgba(255, 255, 255, 0.88);
+    box-shadow: none;
+}
+
+.discord-stats-container.discord-theme-headless .discord-presence-breakdown {
+    border: 1px dashed rgba(148, 163, 184, 0.4);
+    border-radius: calc(var(--discord-radius) * 1.1);
+}
+
+.discord-stats-container.discord-theme-shadcn {
+    font-family: "Geist", "Satoshi", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --discord-gap: clamp(18px, 4vw, 28px);
+    --discord-padding: clamp(18px, 4vw, 28px);
+    --discord-radius: clamp(14px, 2.6vw, 22px);
+    --discord-surface-background: rgba(248, 250, 252, 0.88);
+    --discord-surface-text: #0f172a;
+    --discord-surface-border: rgba(148, 163, 184, 0.32);
+    --discord-surface-shadow: 0 18px 38px -22px rgba(15, 23, 42, 0.45);
+    --discord-surface-hover-shadow: 0 26px 56px -24px rgba(15, 23, 42, 0.5);
+    --discord-accent: #34d399;
+    --discord-accent-secondary: #22c55e;
+    --discord-accent-contrast: #0f172a;
+    --discord-focus-outline: rgba(52, 211, 153, 0.45);
+    --discord-outline-contrast: rgba(30, 64, 175, 0.35);
+    --discord-avatar-background: rgba(52, 211, 153, 0.12);
+    --discord-avatar-shadow: 0 12px 34px -24px rgba(15, 23, 42, 0.5);
+    --discord-button-shadow: rgba(52, 211, 153, 0.26);
+    --discord-button-shadow-hover: rgba(52, 211, 153, 0.36);
+    --discord-refresh-background: rgba(15, 23, 42, 0.9);
+    --discord-refresh-text: #f8fafc;
+    --discord-refresh-border: rgba(148, 163, 184, 0.26);
+    --discord-logo-color: #1f2937;
+    --discord-badge-start: #34d399;
+    --discord-badge-end: #22d3ee;
+    --discord-badge-text: #0f172a;
+}
+
+.discord-stats-container.discord-theme-shadcn .discord-stats-main {
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    border-radius: calc(var(--discord-radius) * 1.25);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.discord-stats-container.discord-theme-shadcn .discord-stat {
+    border-radius: calc(var(--discord-radius) * 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.26);
+    background: rgba(248, 250, 252, 0.95);
+}
+
+.discord-stats-container.discord-theme-shadcn .discord-cta-button--solid {
+    font-weight: 600;
+}
+
+@media (prefers-color-scheme: dark) {
+    .discord-stats-container.discord-theme-shadcn {
+        --discord-surface-background: rgba(15, 23, 42, 0.84);
+        --discord-surface-text: #e2e8f0;
+        --discord-surface-border: rgba(94, 234, 212, 0.18);
+        --discord-avatar-background: rgba(94, 234, 212, 0.18);
+        --discord-logo-color: #e2e8f0;
+        --discord-surface-shadow: 0 22px 60px -24px rgba(15, 23, 42, 0.9);
+        --discord-surface-hover-shadow: 0 32px 68px -18px rgba(45, 212, 191, 0.35);
+        --discord-accent-contrast: #022c22;
+    }
+
+    .discord-stats-container.discord-theme-shadcn .discord-stats-main {
+        background: rgba(15, 23, 42, 0.82);
+        border-color: rgba(94, 234, 212, 0.24);
+    }
+}
+
+.discord-stats-container.discord-theme-bootstrap {
+    --discord-gap: clamp(16px, 3.4vw, 24px);
+    --discord-padding: clamp(18px, 4vw, 28px);
+    --discord-radius: clamp(12px, 2.8vw, 20px);
+    --discord-surface-background: #f8f9fa;
+    --discord-surface-text: #212529;
+    --discord-surface-border: rgba(0, 0, 0, 0.1);
+    --discord-surface-shadow: 0 0.75rem 2rem rgba(33, 37, 41, 0.08);
+    --discord-surface-hover-shadow: 0 1.5rem 3rem rgba(33, 37, 41, 0.12);
+    --discord-accent: #0d6efd;
+    --discord-accent-secondary: #0b5ed7;
+    --discord-accent-contrast: #ffffff;
+    --discord-focus-outline: rgba(13, 110, 253, 0.35);
+    --discord-outline-contrast: rgba(13, 110, 253, 0.28);
+    --discord-avatar-background: rgba(13, 110, 253, 0.12);
+    --discord-avatar-shadow: 0 16px 40px -26px rgba(13, 110, 253, 0.4);
+    --discord-button-shadow: rgba(13, 110, 253, 0.3);
+    --discord-button-shadow-hover: rgba(13, 110, 253, 0.38);
+    --discord-refresh-background: rgba(33, 37, 41, 0.95);
+    --discord-refresh-text: #f8f9fa;
+    --discord-refresh-border: rgba(248, 249, 250, 0.18);
+    --discord-logo-color: #0d6efd;
+    --discord-badge-start: #0d6efd;
+    --discord-badge-end: #6610f2;
+    --discord-badge-text: #ffffff;
+}
+
+.discord-stats-container.discord-theme-bootstrap .discord-stats-main {
+    background: #ffffff;
+    border-radius: calc(var(--discord-radius) * 1.4);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1rem 2.5rem rgba(33, 37, 41, 0.08);
+}
+
+.discord-stats-container.discord-theme-bootstrap .discord-stat {
+    background: #ffffff;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: calc(var(--discord-radius) * 0.9);
+}
+
+.discord-stats-container.discord-theme-bootstrap .discord-cta-button--solid {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.discord-stats-container.discord-theme-semantic {
+    --discord-gap: clamp(18px, 4.2vw, 28px);
+    --discord-padding: clamp(18px, 4vw, 28px);
+    --discord-radius: clamp(14px, 2.8vw, 22px);
+    --discord-surface-background: #f9fafb;
+    --discord-surface-text: #1f2937;
+    --discord-surface-border: rgba(17, 24, 39, 0.08);
+    --discord-surface-shadow: 0 22px 46px -28px rgba(24, 24, 27, 0.4);
+    --discord-surface-hover-shadow: 0 28px 60px -24px rgba(24, 24, 27, 0.45);
+    --discord-accent: #2185d0;
+    --discord-accent-secondary: #a333c8;
+    --discord-accent-contrast: #fdf2f8;
+    --discord-focus-outline: rgba(161, 51, 200, 0.4);
+    --discord-outline-contrast: rgba(33, 133, 208, 0.32);
+    --discord-avatar-background: rgba(161, 51, 200, 0.1);
+    --discord-avatar-shadow: 0 12px 38px -26px rgba(33, 133, 208, 0.45);
+    --discord-button-shadow: rgba(33, 133, 208, 0.24);
+    --discord-button-shadow-hover: rgba(161, 51, 200, 0.32);
+    --discord-refresh-background: rgba(30, 64, 175, 0.95);
+    --discord-refresh-text: #f8fafc;
+    --discord-refresh-border: rgba(33, 133, 208, 0.28);
+    --discord-logo-color: #1f2937;
+    --discord-badge-start: #2185d0;
+    --discord-badge-end: #a333c8;
+    --discord-badge-text: #f9fafb;
+}
+
+.discord-stats-container.discord-theme-semantic .discord-stats-main {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(249, 250, 251, 0.85) 100%);
+    border-radius: calc(var(--discord-radius) * 1.3);
+    border: 1px solid rgba(33, 133, 208, 0.18);
+}
+
+.discord-stats-container.discord-theme-semantic .discord-stat {
+    border-radius: calc(var(--discord-radius) * 0.95);
+    border: 1px solid rgba(161, 51, 200, 0.14);
+    background: rgba(255, 255, 255, 0.92);
+}
+
+.discord-stats-container.discord-theme-anime {
+    --discord-gap: clamp(18px, 4.6vw, 32px);
+    --discord-padding: clamp(22px, 4.8vw, 34px);
+    --discord-radius: clamp(16px, 3vw, 24px);
+    --discord-icon-size: clamp(20px, 4vw, 28px);
+    --discord-number-size: clamp(26px, 4.8vw, 38px);
+    --discord-label-size: clamp(13px, 3vw, 18px);
+    --discord-surface-background: rgba(17, 24, 39, 0.72);
+    --discord-surface-text: #f1f5f9;
+    --discord-surface-border: rgba(56, 189, 248, 0.22);
+    --discord-surface-shadow: 0 38px 70px -28px rgba(56, 189, 248, 0.45);
+    --discord-surface-hover-shadow: 0 48px 80px -24px rgba(244, 114, 182, 0.55);
+    --discord-accent: #38bdf8;
+    --discord-accent-secondary: #f472b6;
+    --discord-accent-contrast: #0f172a;
+    --discord-focus-outline: rgba(244, 114, 182, 0.6);
+    --discord-outline-contrast: rgba(56, 189, 248, 0.6);
+    --discord-avatar-background: rgba(56, 189, 248, 0.14);
+    --discord-avatar-shadow: 0 26px 66px -34px rgba(244, 114, 182, 0.55);
+    --discord-button-shadow: rgba(56, 189, 248, 0.32);
+    --discord-button-shadow-hover: rgba(244, 114, 182, 0.42);
+    --discord-refresh-background: rgba(15, 23, 42, 0.92);
+    --discord-refresh-text: #cffafe;
+    --discord-refresh-border: rgba(244, 114, 182, 0.36);
+    --discord-logo-color: #f8fafc;
+    --discord-badge-start: #38bdf8;
+    --discord-badge-end: #f472b6;
+    --discord-badge-text: #0f172a;
+    background: linear-gradient(135deg, #0f172a 0%, #1f2937 50%, #111827 100%);
+    position: relative;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.discord-stats-container.discord-theme-anime::before {
+    content: "";
+    position: absolute;
+    inset: -35%;
+    background: radial-gradient(ellipse at top, rgba(244, 114, 182, 0.32) 0%, transparent 55%),
+        radial-gradient(ellipse at bottom, rgba(56, 189, 248, 0.35) 0%, transparent 60%);
+    filter: blur(20px);
+    opacity: 0.75;
+    transform: scale(1) rotate(0deg);
+    animation: discord-anime-pulse 12s ease-in-out infinite;
+    z-index: -1;
+}
+
+.discord-stats-container.discord-theme-anime .discord-stats-main {
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(56, 189, 248, 0.28);
+    border-radius: calc(var(--discord-radius) * 1.35);
+    box-shadow: 0 34px 90px -36px rgba(56, 189, 248, 0.55);
+    backdrop-filter: blur(18px) saturate(1.35);
+}
+
+.discord-stats-container.discord-theme-anime .discord-stat {
+    background: rgba(15, 23, 42, 0.78);
+    border: 1px solid rgba(244, 114, 182, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.12);
+}
+
+.discord-stats-container.discord-theme-anime .discord-cta-button--solid {
+    box-shadow: 0 18px 42px -22px rgba(244, 114, 182, 0.6);
+    position: relative;
+    overflow: hidden;
+}
+
+.discord-stats-container.discord-theme-anime .discord-cta-button--solid::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(56, 189, 248, 0.35), rgba(244, 114, 182, 0.45));
+    mix-blend-mode: screen;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.discord-stats-container.discord-theme-anime .discord-cta-button--solid:hover::after,
+.discord-stats-container.discord-theme-anime .discord-cta-button--solid:focus-visible::after {
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .discord-stats-container.discord-theme-anime::before {
+        animation: none;
+    }
+
+    .discord-stats-container.discord-theme-anime .discord-cta-button--solid::after {
+        transition-duration: 0s;
+    }
+}
+
+@keyframes discord-anime-pulse {
+    0% {
+        transform: scale(1) rotate(0deg);
+        opacity: 0.7;
+    }
+
+    50% {
+        transform: scale(1.1) rotate(8deg);
+        opacity: 0.95;
+    }
+
+    100% {
+        transform: scale(1) rotate(0deg);
+        opacity: 0.7;
+    }
+}
+
 .discord-stats-container.discord-align-center .discord-stats-main {
     justify-content: center;
 }

--- a/discord-bot-jlg/assets/css/discord-bot-jlg.css
+++ b/discord-bot-jlg/assets/css/discord-bot-jlg.css
@@ -958,6 +958,308 @@
     border-color: rgba(37, 99, 235, 0.6);
 }
 
+.discord-stats-container.discord-theme-headless {
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --discord-gap: clamp(16px, 3.6vw, 26px);
+    --discord-padding: clamp(16px, 3.4vw, 26px);
+    --discord-radius: clamp(10px, 2.4vw, 18px);
+    --discord-surface-background: rgba(15, 23, 42, 0.03);
+    --discord-surface-text: #0f172a;
+    --discord-surface-border: rgba(15, 23, 42, 0.08);
+    --discord-surface-shadow: 0 1px 0 rgba(15, 23, 42, 0.08), 0 18px 32px -26px rgba(15, 23, 42, 0.5);
+    --discord-surface-hover-shadow: 0 2px 0 rgba(15, 23, 42, 0.12), 0 28px 42px -26px rgba(15, 23, 42, 0.55);
+    --discord-accent: #3b82f6;
+    --discord-accent-secondary: #1d4ed8;
+    --discord-accent-contrast: #f8fafc;
+    --discord-focus-outline: rgba(249, 115, 22, 0.5);
+    --discord-outline-contrast: rgba(249, 115, 22, 0.45);
+    --discord-avatar-background: rgba(59, 130, 246, 0.08);
+    --discord-avatar-shadow: 0 14px 38px -28px rgba(15, 23, 42, 0.65);
+    --discord-button-shadow: rgba(59, 130, 246, 0.24);
+    --discord-button-shadow-hover: rgba(59, 130, 246, 0.34);
+    --discord-refresh-background: rgba(15, 23, 42, 0.96);
+    --discord-refresh-text: #f8fafc;
+    --discord-refresh-border: rgba(148, 163, 184, 0.3);
+    --discord-logo-color: #1f2937;
+    --discord-badge-start: #3b82f6;
+    --discord-badge-end: #f97316;
+    --discord-badge-text: #0f172a;
+}
+
+.discord-stats-container.discord-theme-headless .discord-stats-main {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(241, 245, 249, 0.75) 100%);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: calc(var(--discord-radius) * 1.2);
+    box-shadow: 0 24px 38px -32px rgba(15, 23, 42, 0.45);
+}
+
+.discord-stats-container.discord-theme-headless .discord-stat {
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    background: rgba(255, 255, 255, 0.88);
+    box-shadow: none;
+}
+
+.discord-stats-container.discord-theme-headless .discord-presence-breakdown {
+    border: 1px dashed rgba(148, 163, 184, 0.4);
+    border-radius: calc(var(--discord-radius) * 1.1);
+}
+
+.discord-stats-container.discord-theme-shadcn {
+    font-family: "Geist", "Satoshi", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --discord-gap: clamp(18px, 4vw, 28px);
+    --discord-padding: clamp(18px, 4vw, 28px);
+    --discord-radius: clamp(14px, 2.6vw, 22px);
+    --discord-surface-background: rgba(248, 250, 252, 0.88);
+    --discord-surface-text: #0f172a;
+    --discord-surface-border: rgba(148, 163, 184, 0.32);
+    --discord-surface-shadow: 0 18px 38px -22px rgba(15, 23, 42, 0.45);
+    --discord-surface-hover-shadow: 0 26px 56px -24px rgba(15, 23, 42, 0.5);
+    --discord-accent: #34d399;
+    --discord-accent-secondary: #22c55e;
+    --discord-accent-contrast: #0f172a;
+    --discord-focus-outline: rgba(52, 211, 153, 0.45);
+    --discord-outline-contrast: rgba(30, 64, 175, 0.35);
+    --discord-avatar-background: rgba(52, 211, 153, 0.12);
+    --discord-avatar-shadow: 0 12px 34px -24px rgba(15, 23, 42, 0.5);
+    --discord-button-shadow: rgba(52, 211, 153, 0.26);
+    --discord-button-shadow-hover: rgba(52, 211, 153, 0.36);
+    --discord-refresh-background: rgba(15, 23, 42, 0.9);
+    --discord-refresh-text: #f8fafc;
+    --discord-refresh-border: rgba(148, 163, 184, 0.26);
+    --discord-logo-color: #1f2937;
+    --discord-badge-start: #34d399;
+    --discord-badge-end: #22d3ee;
+    --discord-badge-text: #0f172a;
+}
+
+.discord-stats-container.discord-theme-shadcn .discord-stats-main {
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    border-radius: calc(var(--discord-radius) * 1.25);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.discord-stats-container.discord-theme-shadcn .discord-stat {
+    border-radius: calc(var(--discord-radius) * 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.26);
+    background: rgba(248, 250, 252, 0.95);
+}
+
+.discord-stats-container.discord-theme-shadcn .discord-cta-button--solid {
+    font-weight: 600;
+}
+
+@media (prefers-color-scheme: dark) {
+    .discord-stats-container.discord-theme-shadcn {
+        --discord-surface-background: rgba(15, 23, 42, 0.84);
+        --discord-surface-text: #e2e8f0;
+        --discord-surface-border: rgba(94, 234, 212, 0.18);
+        --discord-avatar-background: rgba(94, 234, 212, 0.18);
+        --discord-logo-color: #e2e8f0;
+        --discord-surface-shadow: 0 22px 60px -24px rgba(15, 23, 42, 0.9);
+        --discord-surface-hover-shadow: 0 32px 68px -18px rgba(45, 212, 191, 0.35);
+        --discord-accent-contrast: #022c22;
+    }
+
+    .discord-stats-container.discord-theme-shadcn .discord-stats-main {
+        background: rgba(15, 23, 42, 0.82);
+        border-color: rgba(94, 234, 212, 0.24);
+    }
+}
+
+.discord-stats-container.discord-theme-bootstrap {
+    --discord-gap: clamp(16px, 3.4vw, 24px);
+    --discord-padding: clamp(18px, 4vw, 28px);
+    --discord-radius: clamp(12px, 2.8vw, 20px);
+    --discord-surface-background: #f8f9fa;
+    --discord-surface-text: #212529;
+    --discord-surface-border: rgba(0, 0, 0, 0.1);
+    --discord-surface-shadow: 0 0.75rem 2rem rgba(33, 37, 41, 0.08);
+    --discord-surface-hover-shadow: 0 1.5rem 3rem rgba(33, 37, 41, 0.12);
+    --discord-accent: #0d6efd;
+    --discord-accent-secondary: #0b5ed7;
+    --discord-accent-contrast: #ffffff;
+    --discord-focus-outline: rgba(13, 110, 253, 0.35);
+    --discord-outline-contrast: rgba(13, 110, 253, 0.28);
+    --discord-avatar-background: rgba(13, 110, 253, 0.12);
+    --discord-avatar-shadow: 0 16px 40px -26px rgba(13, 110, 253, 0.4);
+    --discord-button-shadow: rgba(13, 110, 253, 0.3);
+    --discord-button-shadow-hover: rgba(13, 110, 253, 0.38);
+    --discord-refresh-background: rgba(33, 37, 41, 0.95);
+    --discord-refresh-text: #f8f9fa;
+    --discord-refresh-border: rgba(248, 249, 250, 0.18);
+    --discord-logo-color: #0d6efd;
+    --discord-badge-start: #0d6efd;
+    --discord-badge-end: #6610f2;
+    --discord-badge-text: #ffffff;
+}
+
+.discord-stats-container.discord-theme-bootstrap .discord-stats-main {
+    background: #ffffff;
+    border-radius: calc(var(--discord-radius) * 1.4);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1rem 2.5rem rgba(33, 37, 41, 0.08);
+}
+
+.discord-stats-container.discord-theme-bootstrap .discord-stat {
+    background: #ffffff;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: calc(var(--discord-radius) * 0.9);
+}
+
+.discord-stats-container.discord-theme-bootstrap .discord-cta-button--solid {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.discord-stats-container.discord-theme-semantic {
+    --discord-gap: clamp(18px, 4.2vw, 28px);
+    --discord-padding: clamp(18px, 4vw, 28px);
+    --discord-radius: clamp(14px, 2.8vw, 22px);
+    --discord-surface-background: #f9fafb;
+    --discord-surface-text: #1f2937;
+    --discord-surface-border: rgba(17, 24, 39, 0.08);
+    --discord-surface-shadow: 0 22px 46px -28px rgba(24, 24, 27, 0.4);
+    --discord-surface-hover-shadow: 0 28px 60px -24px rgba(24, 24, 27, 0.45);
+    --discord-accent: #2185d0;
+    --discord-accent-secondary: #a333c8;
+    --discord-accent-contrast: #fdf2f8;
+    --discord-focus-outline: rgba(161, 51, 200, 0.4);
+    --discord-outline-contrast: rgba(33, 133, 208, 0.32);
+    --discord-avatar-background: rgba(161, 51, 200, 0.1);
+    --discord-avatar-shadow: 0 12px 38px -26px rgba(33, 133, 208, 0.45);
+    --discord-button-shadow: rgba(33, 133, 208, 0.24);
+    --discord-button-shadow-hover: rgba(161, 51, 200, 0.32);
+    --discord-refresh-background: rgba(30, 64, 175, 0.95);
+    --discord-refresh-text: #f8fafc;
+    --discord-refresh-border: rgba(33, 133, 208, 0.28);
+    --discord-logo-color: #1f2937;
+    --discord-badge-start: #2185d0;
+    --discord-badge-end: #a333c8;
+    --discord-badge-text: #f9fafb;
+}
+
+.discord-stats-container.discord-theme-semantic .discord-stats-main {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(249, 250, 251, 0.85) 100%);
+    border-radius: calc(var(--discord-radius) * 1.3);
+    border: 1px solid rgba(33, 133, 208, 0.18);
+}
+
+.discord-stats-container.discord-theme-semantic .discord-stat {
+    border-radius: calc(var(--discord-radius) * 0.95);
+    border: 1px solid rgba(161, 51, 200, 0.14);
+    background: rgba(255, 255, 255, 0.92);
+}
+
+.discord-stats-container.discord-theme-anime {
+    --discord-gap: clamp(18px, 4.6vw, 32px);
+    --discord-padding: clamp(22px, 4.8vw, 34px);
+    --discord-radius: clamp(16px, 3vw, 24px);
+    --discord-icon-size: clamp(20px, 4vw, 28px);
+    --discord-number-size: clamp(26px, 4.8vw, 38px);
+    --discord-label-size: clamp(13px, 3vw, 18px);
+    --discord-surface-background: rgba(17, 24, 39, 0.72);
+    --discord-surface-text: #f1f5f9;
+    --discord-surface-border: rgba(56, 189, 248, 0.22);
+    --discord-surface-shadow: 0 38px 70px -28px rgba(56, 189, 248, 0.45);
+    --discord-surface-hover-shadow: 0 48px 80px -24px rgba(244, 114, 182, 0.55);
+    --discord-accent: #38bdf8;
+    --discord-accent-secondary: #f472b6;
+    --discord-accent-contrast: #0f172a;
+    --discord-focus-outline: rgba(244, 114, 182, 0.6);
+    --discord-outline-contrast: rgba(56, 189, 248, 0.6);
+    --discord-avatar-background: rgba(56, 189, 248, 0.14);
+    --discord-avatar-shadow: 0 26px 66px -34px rgba(244, 114, 182, 0.55);
+    --discord-button-shadow: rgba(56, 189, 248, 0.32);
+    --discord-button-shadow-hover: rgba(244, 114, 182, 0.42);
+    --discord-refresh-background: rgba(15, 23, 42, 0.92);
+    --discord-refresh-text: #cffafe;
+    --discord-refresh-border: rgba(244, 114, 182, 0.36);
+    --discord-logo-color: #f8fafc;
+    --discord-badge-start: #38bdf8;
+    --discord-badge-end: #f472b6;
+    --discord-badge-text: #0f172a;
+    background: linear-gradient(135deg, #0f172a 0%, #1f2937 50%, #111827 100%);
+    position: relative;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.discord-stats-container.discord-theme-anime::before {
+    content: "";
+    position: absolute;
+    inset: -35%;
+    background: radial-gradient(ellipse at top, rgba(244, 114, 182, 0.32) 0%, transparent 55%),
+        radial-gradient(ellipse at bottom, rgba(56, 189, 248, 0.35) 0%, transparent 60%);
+    filter: blur(20px);
+    opacity: 0.75;
+    transform: scale(1) rotate(0deg);
+    animation: discord-anime-pulse 12s ease-in-out infinite;
+    z-index: -1;
+}
+
+.discord-stats-container.discord-theme-anime .discord-stats-main {
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(56, 189, 248, 0.28);
+    border-radius: calc(var(--discord-radius) * 1.35);
+    box-shadow: 0 34px 90px -36px rgba(56, 189, 248, 0.55);
+    backdrop-filter: blur(18px) saturate(1.35);
+}
+
+.discord-stats-container.discord-theme-anime .discord-stat {
+    background: rgba(15, 23, 42, 0.78);
+    border: 1px solid rgba(244, 114, 182, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.12);
+}
+
+.discord-stats-container.discord-theme-anime .discord-cta-button--solid {
+    box-shadow: 0 18px 42px -22px rgba(244, 114, 182, 0.6);
+    position: relative;
+    overflow: hidden;
+}
+
+.discord-stats-container.discord-theme-anime .discord-cta-button--solid::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(56, 189, 248, 0.35), rgba(244, 114, 182, 0.45));
+    mix-blend-mode: screen;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.discord-stats-container.discord-theme-anime .discord-cta-button--solid:hover::after,
+.discord-stats-container.discord-theme-anime .discord-cta-button--solid:focus-visible::after {
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .discord-stats-container.discord-theme-anime::before {
+        animation: none;
+    }
+
+    .discord-stats-container.discord-theme-anime .discord-cta-button--solid::after {
+        transition-duration: 0s;
+    }
+}
+
+@keyframes discord-anime-pulse {
+    0% {
+        transform: scale(1) rotate(0deg);
+        opacity: 0.7;
+    }
+
+    50% {
+        transform: scale(1.1) rotate(8deg);
+        opacity: 0.95;
+    }
+
+    100% {
+        transform: scale(1) rotate(0deg);
+        opacity: 0.7;
+    }
+}
+
 /* Widget styles */
 .widget .discord-stats-wrapper {
     flex-direction: column;

--- a/discord-bot-jlg/assets/js/discord-bot-block.js
+++ b/discord-bot-jlg/assets/js/discord-bot-block.js
@@ -98,7 +98,12 @@
         { label: __('Sombre', 'discord-bot-jlg'), value: 'dark' },
         { label: __('Clair', 'discord-bot-jlg'), value: 'light' },
         { label: __('Minimal', 'discord-bot-jlg'), value: 'minimal' },
-        { label: __('Radix UI', 'discord-bot-jlg'), value: 'radix' }
+        { label: __('Radix Structure', 'discord-bot-jlg'), value: 'radix' },
+        { label: __('Headless Essence', 'discord-bot-jlg'), value: 'headless' },
+        { label: __('Shadcn Minimal', 'discord-bot-jlg'), value: 'shadcn' },
+        { label: __('Bootstrap Fluent', 'discord-bot-jlg'), value: 'bootstrap' },
+        { label: __('Semantic Harmony', 'discord-bot-jlg'), value: 'semantic' },
+        { label: __('Anime Pulse', 'discord-bot-jlg'), value: 'anime' }
     ];
 
     var alignOptions = [

--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -1460,11 +1460,16 @@ class Discord_Bot_JLG_Admin {
      */
     private function get_theme_choices() {
         $labels = array(
-            'discord' => __('Discord', 'discord-bot-jlg'),
-            'dark'    => __('Sombre', 'discord-bot-jlg'),
-            'light'   => __('Clair', 'discord-bot-jlg'),
-            'minimal' => __('Minimal', 'discord-bot-jlg'),
-            'radix'   => __('Radix UI', 'discord-bot-jlg'),
+            'discord'   => __('Discord', 'discord-bot-jlg'),
+            'dark'      => __('Sombre', 'discord-bot-jlg'),
+            'light'     => __('Clair', 'discord-bot-jlg'),
+            'minimal'   => __('Minimal', 'discord-bot-jlg'),
+            'radix'     => __('Radix Structure', 'discord-bot-jlg'),
+            'headless'  => __('Headless Essence', 'discord-bot-jlg'),
+            'shadcn'    => __('Shadcn Minimal', 'discord-bot-jlg'),
+            'bootstrap' => __('Bootstrap Fluent', 'discord-bot-jlg'),
+            'semantic'  => __('Semantic Harmony', 'discord-bot-jlg'),
+            'anime'     => __('Anime Pulse', 'discord-bot-jlg'),
         );
 
         $choices = array();
@@ -1932,7 +1937,7 @@ class Discord_Bot_JLG_Admin {
                 <h5><?php esc_html_e('🎨 Apparence & Layout :', 'discord-bot-jlg'); ?></h5>
                 <ul style="columns: 2; column-gap: 30px;">
                     <li><?php echo wp_kses_post(__('<strong>layout</strong> : horizontal, vertical, compact', 'discord-bot-jlg')); ?></li>
-                    <li><?php echo wp_kses_post(__('<strong>theme</strong> : discord, dark, light, minimal, radix', 'discord-bot-jlg')); ?></li>
+                    <li><?php echo wp_kses_post(__('<strong>theme</strong> : discord, dark, light, minimal, radix, headless, shadcn, bootstrap, semantic, anime', 'discord-bot-jlg')); ?></li>
                     <li><?php echo wp_kses_post(__('<strong>align</strong> : left, center, right', 'discord-bot-jlg')); ?></li>
                     <li><?php echo wp_kses_post(__('<strong>width</strong> : largeur CSS (ex: "300px", "100%")', 'discord-bot-jlg')); ?></li>
                     <li><?php echo wp_kses_post(__('<strong>compact</strong> : true/false (version réduite)', 'discord-bot-jlg')); ?></li>

--- a/discord-bot-jlg/inc/class-discord-widget.php
+++ b/discord-bot-jlg/inc/class-discord-widget.php
@@ -35,7 +35,7 @@ class Discord_Stats_Widget extends WP_Widget {
 
         $allowed_layouts   = array('horizontal', 'vertical');
         $allowed_positions = array('left', 'right', 'top');
-        $allowed_themes    = array('discord', 'dark', 'light', 'minimal', 'radix');
+        $allowed_themes    = discord_bot_jlg_get_available_themes();
 
         $layout = sanitize_key($instance['layout']);
         if (!in_array($layout, $allowed_layouts, true)) {
@@ -177,7 +177,7 @@ class Discord_Stats_Widget extends WP_Widget {
         $instance['discord_icon_position'] = in_array($icon_position, array('left', 'right', 'top'), true) ? $icon_position : 'left';
 
         $theme = isset($new_instance['theme']) ? sanitize_key($new_instance['theme']) : 'discord';
-        $instance['theme'] = in_array($theme, array('discord', 'dark', 'light', 'minimal', 'radix'), true) ? $theme : 'discord';
+        $instance['theme'] = in_array($theme, discord_bot_jlg_get_available_themes(), true) ? $theme : 'discord';
 
         $instance['refresh'] = !empty($new_instance['refresh']) ? 1 : 0;
         $min_refresh = defined('Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL')
@@ -296,15 +296,33 @@ class Discord_Stats_Widget extends WP_Widget {
             </select>
         </p>
 
+        <?php
+        $theme_labels = array(
+            'discord'   => __('Discord', 'discord-bot-jlg'),
+            'dark'      => __('Sombre', 'discord-bot-jlg'),
+            'light'     => __('Clair', 'discord-bot-jlg'),
+            'minimal'   => __('Minimal', 'discord-bot-jlg'),
+            'radix'     => __('Radix Structure', 'discord-bot-jlg'),
+            'headless'  => __('Headless Essence', 'discord-bot-jlg'),
+            'shadcn'    => __('Shadcn Minimal', 'discord-bot-jlg'),
+            'bootstrap' => __('Bootstrap Fluent', 'discord-bot-jlg'),
+            'semantic'  => __('Semantic Harmony', 'discord-bot-jlg'),
+            'anime'     => __('Anime Pulse', 'discord-bot-jlg'),
+        );
+
+        $available_themes = discord_bot_jlg_get_available_themes();
+        ?>
         <p>
             <label for="<?php echo esc_attr($this->get_field_id('theme')); ?>"><?php esc_html_e('Thème visuel', 'discord-bot-jlg'); ?></label>
             <select class="widefat" id="<?php echo esc_attr($this->get_field_id('theme')); ?>"
                     name="<?php echo esc_attr($this->get_field_name('theme')); ?>">
-                <option value="discord" <?php selected($instance['theme'], 'discord'); ?>><?php esc_html_e('Discord', 'discord-bot-jlg'); ?></option>
-                <option value="dark" <?php selected($instance['theme'], 'dark'); ?>><?php esc_html_e('Sombre', 'discord-bot-jlg'); ?></option>
-                <option value="light" <?php selected($instance['theme'], 'light'); ?>><?php esc_html_e('Clair', 'discord-bot-jlg'); ?></option>
-                <option value="minimal" <?php selected($instance['theme'], 'minimal'); ?>><?php esc_html_e('Minimal', 'discord-bot-jlg'); ?></option>
-                <option value="radix" <?php selected($instance['theme'], 'radix'); ?>><?php esc_html_e('Radix UI', 'discord-bot-jlg'); ?></option>
+                <?php foreach ($available_themes as $theme_value) :
+                    $label = isset($theme_labels[$theme_value]) ? $theme_labels[$theme_value] : ucfirst($theme_value);
+                    ?>
+                    <option value="<?php echo esc_attr($theme_value); ?>" <?php selected($instance['theme'], $theme_value); ?>>
+                        <?php echo esc_html($label); ?>
+                    </option>
+                <?php endforeach; ?>
             </select>
         </p>
 

--- a/discord-bot-jlg/inc/helpers.php
+++ b/discord-bot-jlg/inc/helpers.php
@@ -18,7 +18,18 @@ if (!function_exists('discord_bot_jlg_get_available_themes')) {
      * @return string[]
      */
     function discord_bot_jlg_get_available_themes() {
-        $themes = array('discord', 'dark', 'light', 'minimal', 'radix');
+        $themes = array(
+            'discord',
+            'dark',
+            'light',
+            'minimal',
+            'radix',
+            'headless',
+            'shadcn',
+            'bootstrap',
+            'semantic',
+            'anime',
+        );
 
         if (function_exists('apply_filters')) {
             $filtered = apply_filters('discord_bot_jlg_available_themes', $themes);

--- a/discord-bot-jlg/languages/discord-bot-jlg.pot
+++ b/discord-bot-jlg/languages/discord-bot-jlg.pot
@@ -436,11 +436,31 @@ msgid "<strong>layout</strong> : horizontal, vertical, compact"
 msgstr ""
 
 #: inc/class-discord-admin.php:718
-msgid "<strong>theme</strong> : discord, dark, light, minimal, radix"
+msgid "<strong>theme</strong> : discord, dark, light, minimal, radix, headless, shadcn, bootstrap, semantic, anime"
 msgstr ""
 
-#: assets/js/discord-bot-block.js:101 inc/class-discord-admin.php:1467 inc/class-discord-widget.php:307
-msgid "Radix UI"
+#: assets/js/discord-bot-block.js:101 inc/class-discord-admin.php:1467 inc/class-discord-widget.php:305
+msgid "Radix Structure"
+msgstr ""
+
+#: assets/js/discord-bot-block.js:102 inc/class-discord-admin.php:1468 inc/class-discord-widget.php:306
+msgid "Headless Essence"
+msgstr ""
+
+#: assets/js/discord-bot-block.js:103 inc/class-discord-admin.php:1469 inc/class-discord-widget.php:307
+msgid "Shadcn Minimal"
+msgstr ""
+
+#: assets/js/discord-bot-block.js:104 inc/class-discord-admin.php:1470 inc/class-discord-widget.php:308
+msgid "Bootstrap Fluent"
+msgstr ""
+
+#: assets/js/discord-bot-block.js:105 inc/class-discord-admin.php:1471 inc/class-discord-widget.php:309
+msgid "Semantic Harmony"
+msgstr ""
+
+#: assets/js/discord-bot-block.js:106 inc/class-discord-admin.php:1472 inc/class-discord-widget.php:310
+msgid "Anime Pulse"
 msgstr ""
 
 #: inc/class-discord-admin.php:719

--- a/docs/presets-ui.md
+++ b/docs/presets-ui.md
@@ -1,0 +1,86 @@
+# Presets graphiques inspirés de Headless UI, Shadcn UI, Radix UI, Bootstrap, Semantic UI et Anime.js
+
+Ce document rassemble plusieurs pistes de presets graphiques pouvant être intégrés à l'interface du plugin (page d'administration, widgets front-end, documentation). Chaque preset reprend les principes d'une bibliothèque populaire tout en restant compatible avec l'écosystème WordPress (variables CSS, composants modulaires, support du mode réduit en mouvement).
+
+## 1. Preset « Headless Essence » (inspiré de Headless UI)
+- **Philosophie** : composants sans styles imposés, accent sur la structure et l'accessibilité. Chaque module expose des classes utilitaires prêtes pour Tailwind ou du CSS personnalisé.
+- **Identifiant plugin** : `headless` (`.discord-stats-container.discord-theme-headless`).
+- **Palette** : gris froid (#0f172a, #1e293b, #334155) avec accent bleu ardoise (#3b82f6) et focus visibles (#f97316).
+- **Typographie** : `Inter`, `system-ui` ou équivalent, tailles fluides (`clamp(0.95rem, 1vw + 0.5rem, 1.1rem)`).
+- **Composants clés** :
+  - Navigation verticale avec transitions discrètes (`transition-colors`, `focus:ring`).
+  - Panneaux accordéon (Disclosure) en CSS pur : `details/summary` stylés, icône rotative animée.
+  - Modale/Boîte de dialogue accessible (overlay semi-opaque, `aria-modal="true"`).
+- **Animations** : fade/scale doux (`transform: scale(0.98)` -> `scale(1)`) en 150 ms, option `prefers-reduced-motion` pour désactiver.
+- **Utilisation suggérée** : pages d'options avancées, affichage des stats en liste hiérarchique.
+
+## 2. Preset « Shadcn Minimal » (inspiré de shadcn/ui)
+- **Philosophie** : composants Tailwind pré-stylés avec variantes via classes data-attributes (`data-state="open"`).
+- **Identifiant plugin** : `shadcn` (`.discord-stats-container.discord-theme-shadcn`).
+- **Palette** : neutres chauds (#f8fafc, #e2e8f0, #64748b) et accent vert céladon (#34d399). Mode sombre automatique (`@media (prefers-color-scheme: dark)`).
+- **Typographie** : `Geist`, `Satoshi` ou fallback `Inter`, titres en `font-semibold`.
+- **Composants clés** :
+  - `Card` modulaires avec header, description, footer d'actions.
+  - `Tabs` horizontaux, curseur animé sous l'onglet actif (`before:` pseudo-élément).
+  - `Toast`/notifications collantes alignées sur le coin inférieur droit, timers progressifs.
+- **Animations** : `transition-all` 200 ms, `data-state` -> slide/fade (ex. `translate-y-2` -> `translate-y-0`).
+- **Utilisation suggérée** : tableau de bord analytics, onboarding pas à pas.
+
+## 3. Preset « Radix Structure » (inspiré de Radix UI)
+- **Philosophie** : neutralité chromatique, composant piloté par `data-state`/`data-side`, accent sur la cohérence entre les plateformes.
+- **Identifiant plugin** : `radix` (`.discord-stats-container.discord-theme-radix`).
+- **Palette** : dégradés gris-bleu (`--surface: #18181b`, `--surface-alt: #27272a`, `--accent: #6366f1`), contrastes élevés pour l'accessibilité.
+- **Typographie** : `Work Sans` pour titres (`600`), `IBM Plex Sans` pour contenu.
+- **Composants clés** :
+  - `Popover` contextuel avec flèche CSS, ombre douce (`box-shadow: 0 10px 40px rgba(15,23,42,0.35)`).
+  - `Slider` multi-curseurs (pour configurer les intervalles de rafraîchissement).
+  - `Context menu` pour actions rapides sur les profils de serveurs.
+- **Animations** : keyframes directionnelles (`[data-side="top"] { animation: slideDown 200ms ease; }`).
+- **Utilisation suggérée** : configuration granulaire, menus contextualisés dans le bloc Gutenberg.
+
+## 4. Preset « Bootstrap Fluent » (inspiré de Bootstrap 5)
+- **Philosophie** : grille responsive, composants classiques (cards, alertes, badges) avec design modernisé (angles de 0.75rem).
+- **Identifiant plugin** : `bootstrap` (`.discord-stats-container.discord-theme-bootstrap`).
+- **Palette** : bleu primaire (#0d6efd), success (#198754), danger (#dc3545), warning (#ffc107), background clair (#f8f9fa). Mode sombre via classes `.theme-dark`.
+- **Typographie** : `"Helvetica Neue", Arial, sans-serif`, titres en uppercase légère (`text-transform: uppercase; letter-spacing: 0.08em`).
+- **Composants clés** :
+  - `Navbar` sticky avec brand, boutons CTA (ex: « Actualiser les stats »).
+  - `Progress`/barres empilées pour visualiser les quotas d'API.
+  - `Modal` et `Tooltip` compatibles `data-bs-*` (peuvent être reproduits en vanilla JS).
+- **Animations** : transitions standard de Bootstrap (`transition: all .2s ease-in-out;`), boutons hover `filter: brightness(1.05)`.
+- **Utilisation suggérée** : pages de configuration générales, compatibilité thématique avec WordPress classique.
+
+## 5. Preset « Semantic Harmony » (inspiré de Semantic UI)
+- **Philosophie** : langage visuel riche, classes sémantiques (`.ui.primary.button`, `.ui.segment`).
+- **Identifiant plugin** : `semantic` (`.discord-stats-container.discord-theme-semantic`).
+- **Palette** : base pastel (primary #2185d0, secondary #a333c8, positive #21ba45, negative #db2828), arrière-plan `#f9fafb`.
+- **Typographie** : `Lato` (400, 700), `line-height` généreux (1.6).
+- **Composants clés** :
+  - `Segments` et `Items` list pour présenter les profils Discord.
+  - `Steps` horizontaux pour guider la configuration initiale.
+  - `Statistic` avec compteurs XXL et icônes alignées.
+- **Animations** : transitions `ease-in-out` 250 ms, `transform-origin` pour les `Steps` (zoom léger). Effets `shimmer` optionnels via `@keyframes shimmer`.
+- **Utilisation suggérée** : onboarding, page d'aide visuelle ou tutoriels.
+
+## 6. Preset « Anime Pulse » (inspiré d'Anime.js)
+- **Philosophie** : accent sur les micro-animations orchestrées (séquences, timelines), tout en respectant le critère `prefers-reduced-motion`.
+- **Identifiant plugin** : `anime` (`.discord-stats-container.discord-theme-anime`).
+- **Palette** : fond sombre dégradé (`linear-gradient(135deg,#0f172a,#1f2937)`), accents néon cyan (#38bdf8) et magenta (#f472b6).
+- **Typographie** : `Space Grotesk` pour l'effet futuriste, `font-weight: 500-700`.
+- **Composants clés** :
+  - `Hero`/bannière avec chiffres animés (compteurs incrémentés via API).
+  - `Timeline` ou `Stepper` avec points pulsants (`box-shadow` animé).
+  - Boutons CTA avec `hover` élastique (`scale(1.05)` + `rotateX(2deg)`).
+- **Animations** :
+  - `@keyframes pulseGlow` sur les accents (`filter: drop-shadow(0 0 12px currentColor)`).
+  - Timelines JS (si Anime.js disponible) : apparition séquencée des cartes (`opacity`, `translateY`, `delay` par index).
+  - Fallback CSS pour utilisateurs sans JS : transitions `opacity/transform`.
+- **Utilisation suggérée** : pages marketing, démonstrations publiques du widget.
+
+## Bonnes pratiques transverses
+- Prévoir une couche de variables CSS (`--discord-surface`, `--discord-accent`) pour appliquer rapidement chaque preset.
+- Centraliser les animations dans un module pour activer/désactiver selon les préférences utilisateur et les performances.
+- Documenter les dépendances éventuelles (Tailwind, Anime.js) et fournir un fallback CSS natif.
+- Tester les presets avec les composants WordPress (`wp-components`) pour assurer la cohérence avec le back-office.
+
+Ces presets peuvent être combinés ou ajustés selon les besoins : par exemple, adopter la structure Headless UI et appliquer les teintes Shadcn UI, ou intégrer les micro-animations Anime.js sur une base Bootstrap.


### PR DESCRIPTION
## Summary
- add Headless Essence, Shadcn Minimal, Bootstrap Fluent, Semantic Harmony and Anime Pulse styling presets for the Discord stats components
- expose the new presets across helpers, widget controls, admin theme selection and block inspector while updating translation strings
- document preset identifiers in the preset guide for easier reference

## Testing
- not run (styling and configuration updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e62fc890c8832e8cb2a82d68fcd7e7