### PR TITLE
Fix analytics retention sanitization and coverage

### DIFF
--- a/discord-bot-jlg/inc/class-discord-admin.php
+++ b/discord-bot-jlg/inc/class-discord-admin.php
@@ -327,6 +327,14 @@ class Discord_Bot_JLG_Admin {
             'accent_text_color'  => isset($current_options['accent_text_color']) ? discord_bot_jlg_sanitize_color($current_options['accent_text_color']) : '',
         );
 
+        $default_retention = defined('DISCORD_BOT_JLG_ANALYTICS_RETENTION_DEFAULT')
+            ? (int) DISCORD_BOT_JLG_ANALYTICS_RETENTION_DEFAULT
+            : Discord_Bot_JLG_Analytics::DEFAULT_RETENTION_DAYS;
+
+        $current_retention = isset($current_options['analytics_retention_days'])
+            ? max(0, (int) $current_options['analytics_retention_days'])
+            : $default_retention;
+
         $sanitized = array(
             'server_id'      => '',
             'bot_token'      => isset($current_options['bot_token']) ? $current_options['bot_token'] : '',
@@ -355,6 +363,7 @@ class Discord_Bot_JLG_Admin {
                 : 300,
             'custom_css'     => '',
             'default_refresh_interval' => $current_refresh_interval,
+            'analytics_retention_days' => $current_retention,
             'stat_bg_color'      => $existing_colors['stat_bg_color'],
             'stat_text_color'    => $existing_colors['stat_text_color'],
             'accent_color'       => $existing_colors['accent_color'],
@@ -561,7 +570,7 @@ class Discord_Bot_JLG_Admin {
                 : $input['analytics_retention_days'];
 
             if ('' === $raw_retention) {
-                $sanitized['analytics_retention_days'] = $sanitized['analytics_retention_days'];
+                $sanitized['analytics_retention_days'] = $current_retention;
             } else {
                 $retention = absint($raw_retention);
 

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Admin.php
@@ -66,6 +66,7 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
             'custom_css'     => '.existing { color: blue; }',
             'default_theme'  => 'dark',
             'default_refresh_interval' => 120,
+            'analytics_retention_days' => 120,
             'stat_bg_color'      => '#123456',
             'stat_text_color'    => 'rgba(255, 255, 255, 0.9)',
             'accent_color'       => '#654321',
@@ -149,6 +150,30 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                 ),
                 array(
                     'cache_duration' => 450,
+                ),
+            ),
+            'analytics-retention-empty-fallback' => array(
+                array(
+                    'analytics_retention_days' => '',
+                ),
+                array(
+                    'analytics_retention_days' => 120,
+                ),
+            ),
+            'analytics-retention-capped' => array(
+                array(
+                    'analytics_retention_days' => 999,
+                ),
+                array(
+                    'analytics_retention_days' => 365,
+                ),
+            ),
+            'analytics-retention-zero-allowed' => array(
+                array(
+                    'analytics_retention_days' => '0',
+                ),
+                array(
+                    'analytics_retention_days' => 0,
                 ),
             ),
             'custom-css-media-query-preserved' => array(
@@ -550,6 +575,7 @@ class Test_Discord_Bot_JLG_Admin extends WP_UnitTestCase {
                 Discord_Bot_JLG_API::MIN_PUBLIC_REFRESH_INTERVAL,
                 min(3600, (int) $this->saved_options['default_refresh_interval'])
             ),
+            'analytics_retention_days' => max(0, (int) $this->saved_options['analytics_retention_days']),
             'stat_bg_color'      => '#123456',
             'stat_text_color'    => 'rgba(255, 255, 255, 0.9)',
             'accent_color'       => '#654321',


### PR DESCRIPTION
## Summary
- ensure the admin option sanitizer always seeds analytics retention with a valid default
- reuse the saved retention when the field is blank and keep capping values within the allowed range
- extend the admin sanitization tests to cover the new retention behaviours

## Testing
- not run (phpunit unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e639f6fd68832eb6fb5a5e8c6fb874