### PR TITLE
Add coverage for cron interval handling

### DIFF
--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Cron.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Cron.php
@@ -1,0 +1,71 @@
+<?php
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+if (!function_exists('discord_bot_jlg_get_cron_interval')) {
+    require_once dirname(__DIR__) . '/discord-bot-jlg.php';
+}
+
+/**
+ * @group discord-bot-jlg
+ */
+class Test_Discord_Bot_JLG_Cron extends WP_UnitTestCase {
+
+    protected function tearDown(): void {
+        remove_all_filters('discord_bot_jlg_cron_interval');
+        delete_option(DISCORD_BOT_JLG_OPTION_NAME);
+        parent::tearDown();
+    }
+
+    public function test_get_cron_interval_returns_default_when_option_missing(): void {
+        delete_option(DISCORD_BOT_JLG_OPTION_NAME);
+
+        $this->assertSame(
+            DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION,
+            discord_bot_jlg_get_cron_interval()
+        );
+    }
+
+    public function test_get_cron_interval_enforces_minimum_threshold(): void {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array(
+            'cache_duration' => 5,
+        ));
+
+        $this->assertSame(60, discord_bot_jlg_get_cron_interval());
+    }
+
+    public function test_get_cron_interval_caps_maximum_threshold(): void {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array(
+            'cache_duration' => 7200,
+        ));
+
+        $this->assertSame(3600, discord_bot_jlg_get_cron_interval());
+    }
+
+    public function test_get_cron_interval_rejects_extreme_filter_values(): void {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array(
+            'cache_duration' => 300,
+        ));
+
+        add_filter('discord_bot_jlg_cron_interval', function () {
+            return 999999;
+        });
+
+        $this->assertSame(3600, discord_bot_jlg_get_cron_interval());
+    }
+
+    public function test_register_cron_schedule_uses_sanitized_interval(): void {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array(
+            'cache_duration' => 10,
+        ));
+
+        $schedules = discord_bot_jlg_register_cron_schedule(array());
+
+        $this->assertArrayHasKey('discord_bot_jlg_refresh', $schedules);
+        $this->assertSame(60, $schedules['discord_bot_jlg_refresh']['interval']);
+        $this->assertSame(
+            __('Discord Bot JLG cache refresh', 'discord-bot-jlg'),
+            $schedules['discord_bot_jlg_refresh']['display']
+        );
+    }
+}

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -15,6 +15,104 @@ if (!defined('DAY_IN_SECONDS')) {
     define('DAY_IN_SECONDS', 86400);
 }
 
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path($file) {
+        return rtrim(dirname($file), '/\\') . '/';
+    }
+}
+
+if (!function_exists('plugin_dir_url')) {
+    function plugin_dir_url($file) {
+        $path = trim(str_replace(dirname(dirname($file)), '', dirname($file)), '/\\');
+
+        if ('' !== $path) {
+            $path .= '/';
+        }
+
+        return 'https://example.com/wp-content/plugins/' . $path;
+    }
+}
+
+if (!function_exists('plugin_basename')) {
+    function plugin_basename($file) {
+        return ltrim(str_replace('\\', '/', $file), '/');
+    }
+}
+
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook($file, $callback) {
+        $GLOBALS['wp_test_activation_hooks'][$file] = $callback;
+    }
+}
+
+if (!function_exists('register_deactivation_hook')) {
+    function register_deactivation_hook($file, $callback) {
+        $GLOBALS['wp_test_deactivation_hooks'][$file] = $callback;
+    }
+}
+
+if (!function_exists('register_uninstall_hook')) {
+    function register_uninstall_hook($file, $callback) {
+        $GLOBALS['wp_test_uninstall_hooks'][$file] = $callback;
+    }
+}
+
+if (!function_exists('load_plugin_textdomain')) {
+    function load_plugin_textdomain($domain, $deprecated = false, $plugin_rel_path = '') {
+        $GLOBALS['wp_test_loaded_textdomains'][$domain] = array(
+            'path' => $plugin_rel_path,
+        );
+    }
+}
+
+if (!function_exists('wp_schedule_event')) {
+    function wp_schedule_event($timestamp, $recurrence, $hook, $args = array()) {
+        $GLOBALS['wp_test_scheduled_events'][] = array(
+            'timestamp'  => $timestamp,
+            'recurrence' => $recurrence,
+            'hook'       => $hook,
+            'args'       => $args,
+        );
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_clear_scheduled_hook')) {
+    function wp_clear_scheduled_hook($hook) {
+        if (!isset($GLOBALS['wp_test_scheduled_events']) || !is_array($GLOBALS['wp_test_scheduled_events'])) {
+            return;
+        }
+
+        $GLOBALS['wp_test_scheduled_events'] = array_values(array_filter(
+            $GLOBALS['wp_test_scheduled_events'],
+            function ($event) use ($hook) {
+                return isset($event['hook']) && $event['hook'] !== $hook;
+            }
+        ));
+    }
+}
+
+if (!function_exists('register_block_type')) {
+    function register_block_type($path, $args = array()) {
+        $GLOBALS['wp_test_registered_blocks'][] = array(
+            'path' => $path,
+            'args' => $args,
+        );
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_set_script_translations')) {
+    function wp_set_script_translations($handle, $domain, $path = '') {
+        $GLOBALS['wp_test_script_translations'][$handle] = array(
+            'domain' => $domain,
+            'path'   => $path,
+        );
+    }
+}
+
 if (!class_exists('WP_Widget')) {
     class WP_Widget {
         public $id_base;
@@ -91,6 +189,12 @@ if (!function_exists('do_shortcode')) {
     function do_shortcode($shortcode) {
         $GLOBALS['discord_bot_jlg_last_shortcode'] = $shortcode;
         return $shortcode;
+    }
+}
+
+if (!function_exists('add_shortcode')) {
+    function add_shortcode($tag, $callback) {
+        $GLOBALS['wp_test_shortcodes'][$tag] = $callback;
     }
 }
 
@@ -246,6 +350,16 @@ function get_option($name) {
 }
 
 function update_option($name, $value, $autoload = null) {
+    $GLOBALS['wp_test_options'][$name] = $value;
+
+    return true;
+}
+
+function add_option($name, $value = '', $deprecated = '', $autoload = 'yes') {
+    if (isset($GLOBALS['wp_test_options'][$name])) {
+        return false;
+    }
+
     $GLOBALS['wp_test_options'][$name] = $value;
 
     return true;


### PR DESCRIPTION
## Summary
- extend the PHPUnit bootstrap with missing WordPress stubs so the main plugin file can be loaded safely in unit tests
- add a cron-specific test suite that covers cache interval sanitisation and schedule registration edge cases

## Testing
- vendor/bin/phpunit --configuration discord-bot-jlg/phpunit.xml.dist *(fails: phpunit binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64f73dec8832e93db716957bff513