### PR TITLE
Refactor cron helpers and extend PHPUnit coverage

### DIFF
--- a/discord-bot-jlg/discord-bot-jlg.php
+++ b/discord-bot-jlg/discord-bot-jlg.php
@@ -30,66 +30,7 @@ define('DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION', 300);
 define('DISCORD_BOT_JLG_CRON_HOOK', 'discord_bot_jlg_refresh_cache');
 define('DISCORD_BOT_JLG_ANALYTICS_RETENTION_DEFAULT', 90);
 
-if (!function_exists('discord_bot_jlg_get_cron_interval')) {
-    /**
-     * Renvoie l'intervalle utilisé pour la planification du rafraîchissement automatique.
-     *
-     * @return int
-     */
-    function discord_bot_jlg_get_cron_interval() {
-        $default_interval = (int) DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION;
-
-        if ($default_interval <= 0) {
-            $default_interval = 300;
-        }
-
-        $options = get_option(DISCORD_BOT_JLG_OPTION_NAME, array());
-
-        if (!is_array($options)) {
-            $options = array();
-        }
-
-        $interval = isset($options['cache_duration']) ? (int) $options['cache_duration'] : $default_interval;
-
-        if ($interval < 60) {
-            $interval = 60;
-        } elseif ($interval > 3600) {
-            $interval = 3600;
-        }
-
-        $interval = (int) apply_filters('discord_bot_jlg_cron_interval', $interval);
-
-        if ($interval < 60) {
-            $interval = 60;
-        } elseif ($interval > 3600) {
-            $interval = 3600;
-        }
-
-        return $interval;
-    }
-}
-
-if (!function_exists('discord_bot_jlg_register_cron_schedule')) {
-    /**
-     * Déclare un intervalle de cron dédié au rafraîchissement du cache du plugin.
-     *
-     * @param array $schedules Listes des plannings cron disponibles.
-     *
-     * @return array
-     */
-    function discord_bot_jlg_register_cron_schedule($schedules) {
-        if (!is_array($schedules)) {
-            $schedules = array();
-        }
-
-        $schedules['discord_bot_jlg_refresh'] = array(
-            'interval' => discord_bot_jlg_get_cron_interval(),
-            'display'  => __('Discord Bot JLG cache refresh', 'discord-bot-jlg'),
-        );
-
-        return $schedules;
-    }
-}
+require_once DISCORD_BOT_JLG_PLUGIN_PATH . 'inc/cron.php';
 
 add_filter('cron_schedules', 'discord_bot_jlg_register_cron_schedule');
 

--- a/discord-bot-jlg/inc/cron.php
+++ b/discord-bot-jlg/inc/cron.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Cron helpers for Discord Bot JLG.
+ *
+ * @package DiscordBotJLG
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('discord_bot_jlg_get_cron_interval')) {
+    /**
+     * Returns the interval used for the automatic cache refresh schedule.
+     *
+     * @return int Interval in seconds.
+     */
+    function discord_bot_jlg_get_cron_interval() {
+        $default_interval = (int) DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION;
+
+        if ($default_interval <= 0) {
+            $default_interval = 300;
+        }
+
+        $options = get_option(DISCORD_BOT_JLG_OPTION_NAME, array());
+
+        if (!is_array($options)) {
+            $options = array();
+        }
+
+        $interval = isset($options['cache_duration'])
+            ? (int) $options['cache_duration']
+            : $default_interval;
+
+        if ($interval < 60) {
+            $interval = 60;
+        } elseif ($interval > 3600) {
+            $interval = 3600;
+        }
+
+        $interval = (int) apply_filters('discord_bot_jlg_cron_interval', $interval);
+
+        if ($interval < 60) {
+            $interval = 60;
+        } elseif ($interval > 3600) {
+            $interval = 3600;
+        }
+
+        return $interval;
+    }
+}
+
+if (!function_exists('discord_bot_jlg_register_cron_schedule')) {
+    /**
+     * Declares the custom cron schedule used for refreshing the cache.
+     *
+     * @param array $schedules Registered cron schedules.
+     *
+     * @return array
+     */
+    function discord_bot_jlg_register_cron_schedule($schedules) {
+        if (!is_array($schedules)) {
+            $schedules = array();
+        }
+
+        $schedules['discord_bot_jlg_refresh'] = array(
+            'interval' => discord_bot_jlg_get_cron_interval(),
+            'display'  => __('Discord Bot JLG cache refresh', 'discord-bot-jlg'),
+        );
+
+        return $schedules;
+    }
+}
+

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Cron.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Cron.php
@@ -1,0 +1,74 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class Test_Discord_Bot_JLG_Cron extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        remove_all_filters('discord_bot_jlg_cron_interval');
+        delete_option(DISCORD_BOT_JLG_OPTION_NAME);
+        $GLOBALS['wp_test_options'] = array();
+    }
+
+    protected function tearDown(): void {
+        remove_all_filters('discord_bot_jlg_cron_interval');
+        delete_option(DISCORD_BOT_JLG_OPTION_NAME);
+
+        parent::tearDown();
+    }
+
+    public function test_get_cron_interval_returns_default_when_option_missing(): void {
+        $this->assertSame(
+            DISCORD_BOT_JLG_DEFAULT_CACHE_DURATION,
+            discord_bot_jlg_get_cron_interval()
+        );
+    }
+
+    public function test_get_cron_interval_enforces_minimum_threshold(): void {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array(
+            'cache_duration' => 5,
+        ));
+
+        $this->assertSame(60, discord_bot_jlg_get_cron_interval());
+    }
+
+    public function test_get_cron_interval_caps_maximum_threshold(): void {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array(
+            'cache_duration' => 7200,
+        ));
+
+        $this->assertSame(3600, discord_bot_jlg_get_cron_interval());
+    }
+
+    public function test_get_cron_interval_rejects_extreme_filter_values(): void {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array(
+            'cache_duration' => 300,
+        ));
+
+        add_filter('discord_bot_jlg_cron_interval', function () {
+            return 999999;
+        });
+
+        $this->assertSame(3600, discord_bot_jlg_get_cron_interval());
+    }
+
+    public function test_register_cron_schedule_uses_sanitized_interval(): void {
+        update_option(DISCORD_BOT_JLG_OPTION_NAME, array(
+            'cache_duration' => 10,
+        ));
+
+        $schedules = discord_bot_jlg_register_cron_schedule(array());
+
+        $this->assertArrayHasKey('discord_bot_jlg_refresh', $schedules);
+        $this->assertSame(60, $schedules['discord_bot_jlg_refresh']['interval']);
+        $this->assertSame(
+            __('Discord Bot JLG cache refresh', 'discord-bot-jlg'),
+            $schedules['discord_bot_jlg_refresh']['display']
+        );
+    }
+}
+

--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -42,6 +42,7 @@ require_once __DIR__ . '/../../inc/class-discord-widget.php';
 require_once __DIR__ . '/../../inc/class-discord-shortcode.php';
 require_once __DIR__ . '/../../inc/class-discord-site-health.php';
 require_once __DIR__ . '/../../inc/class-discord-rest.php';
+require_once __DIR__ . '/../../inc/cron.php';
 
 if (!defined('DISCORD_BOT_JLG_OPTION_NAME')) {
     define('DISCORD_BOT_JLG_OPTION_NAME', 'discord_server_stats_options');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
             <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Http_Client.php</file>
             <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php</file>
             <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Site_Health.php</file>
+            <file>discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Cron.php</file>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
## Summary
- extract the cron interval and schedule helpers into a dedicated include that the plugin bootstraps directly
- add focused PHPUnit tests that exercise interval clamping and schedule registration without requiring WP_UnitTestCase
- ensure the test bootstrap loads the cron helpers and list the new suite in the PHPUnit configuration

## Testing
- vendor/bin/phpunit --configuration discord-bot-jlg/phpunit.xml.dist *(fails: phpunit binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64f73dec8832e93db716957bff513