### PR TITLE
Address review feedback for Add coverage for cron interval handling

### DIFF
--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -345,8 +345,8 @@ function wp_parse_args($args, $defaults = array()) {
     return array_merge($defaults, $args);
 }
 
-function get_option($name) {
-    return isset($GLOBALS['wp_test_options'][$name]) ? $GLOBALS['wp_test_options'][$name] : false;
+function get_option($name, $default = false) {
+    return isset($GLOBALS['wp_test_options'][$name]) ? $GLOBALS['wp_test_options'][$name] : $default;
 }
 
 function update_option($name, $value, $autoload = null) {


### PR DESCRIPTION
## Summary
- update the PHPUnit bootstrap `get_option` stub to accept the optional default parameter
- return the provided default when an option has not been set so the plugin can be loaded during tests

## Testing
- not run (phpunit binary unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e6552fdc04832e809a7b5f36ab0fd6