### PR TITLE
Improve test get_option stub

### DIFF
--- a/discord-bot-jlg/tests/phpunit/bootstrap.php
+++ b/discord-bot-jlg/tests/phpunit/bootstrap.php
@@ -345,8 +345,12 @@ function wp_parse_args($args, $defaults = array()) {
     return array_merge($defaults, $args);
 }
 
-function get_option($name) {
-    return isset($GLOBALS['wp_test_options'][$name]) ? $GLOBALS['wp_test_options'][$name] : false;
+function get_option($name, $default = false) {
+    if (isset($GLOBALS['wp_test_options']) && array_key_exists($name, $GLOBALS['wp_test_options'])) {
+        return $GLOBALS['wp_test_options'][$name];
+    }
+
+    return $default;
 }
 
 function update_option($name, $value, $autoload = null) {


### PR DESCRIPTION
## Summary
- update the PHPUnit bootstrap get_option stub to mirror WordPress' signature
- ensure stored null or falsey values are returned instead of default options

## Testing
- vendor/bin/phpunit --configuration discord-bot-jlg/phpunit.xml.dist *(fails: phpunit binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6552fdc04832e809a7b5f36ab0fd6