### PR TITLE
Ensure cached options respect dynamic filters

### DIFF
--- a/discord-bot-jlg/inc/class-discord-options-repository.php
+++ b/discord-bot-jlg/inc/class-discord-options-repository.php
@@ -89,7 +89,17 @@ class Discord_Bot_JLG_Options_Repository {
             $this->options_cache = $options;
         }
 
-        return $this->options_cache;
+        $options = $this->options_cache;
+
+        if (function_exists('apply_filters')) {
+            $filtered = apply_filters('option_' . $this->option_name, $options, $this->option_name);
+
+            if (is_array($filtered)) {
+                $options = $filtered;
+            }
+        }
+
+        return $options;
     }
 
     /**

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Options_Repository.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Options_Repository.php
@@ -1,0 +1,89 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class Test_Discord_Bot_JLG_Options_Repository extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $GLOBALS['wp_test_options'] = array();
+        $GLOBALS['wp_test_filters'] = array();
+    }
+
+    public function test_get_options_applies_filters_on_each_call() {
+        $option_name = 'discord_bot_jlg_repository_test';
+
+        $repository = new Discord_Bot_JLG_Options_Repository(
+            $option_name,
+            function () {
+                return array('foo' => 'default');
+            }
+        );
+
+        update_option($option_name, array('foo' => 'value'));
+
+        add_filter(
+            'option_' . $option_name,
+            function ($value) {
+                $value['foo'] = 'filtered_once';
+
+                return $value;
+            },
+            10,
+            2
+        );
+
+        $first = $repository->get_options();
+
+        $this->assertArrayHasKey('foo', $first);
+        $this->assertSame('filtered_once', $first['foo']);
+
+        remove_all_filters('option_' . $option_name);
+
+        add_filter(
+            'option_' . $option_name,
+            function ($value) {
+                $value['foo'] = 'filtered_twice';
+
+                return $value;
+            },
+            10,
+            2
+        );
+
+        $second = $repository->get_options();
+
+        $this->assertArrayHasKey('foo', $second);
+        $this->assertSame('filtered_twice', $second['foo']);
+    }
+
+    public function test_get_options_falls_back_to_cached_value_when_filter_returns_non_array() {
+        $option_name = 'discord_bot_jlg_repository_fallback';
+
+        $repository = new Discord_Bot_JLG_Options_Repository(
+            $option_name,
+            function () {
+                return array('bar' => 'baz');
+            }
+        );
+
+        update_option($option_name, array('bar' => 'initial'));
+
+        $baseline = $repository->get_options();
+        $this->assertSame('initial', $baseline['bar']);
+
+        add_filter(
+            'option_' . $option_name,
+            function () {
+                return 'not-an-array';
+            }
+        );
+
+        $filtered = $repository->get_options();
+
+        $this->assertIsArray($filtered);
+        $this->assertSame($baseline['bar'], $filtered['bar']);
+    }
+}


### PR DESCRIPTION
## Summary
- reapply WordPress option filters when returning cached options from `Discord_Bot_JLG_Options_Repository`
- add PHPUnit coverage to confirm filters execute on each request and cached values survive non-array filter output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e670288d78832e864d69c63e2761a8