### PR TITLE
Expose HTTP instrumentation hooks for Discord API

### DIFF
--- a/discord-bot-jlg/docs/improvement-plan.md
+++ b/discord-bot-jlg/docs/improvement-plan.md
@@ -5,7 +5,7 @@ Ce document recense les zones du plugin qui gagneraient à être rapprochées de
 ## `Discord_Bot_JLG_API::get_stats()`
 * **Complexité excessive** : la méthode orchestre la validation des arguments, la résolution du profil, l'accès au cache, les appels HTTP (widget/bot), la fusion des réponses et la persistance des résultats dans un même bloc de plus de 100 lignes. Les projets pro privilégient une séparation claire (patrons « query service », « repository », middleware de résilience) afin de réduire les effets de bord et faciliter les tests unitaires ciblés.【F:discord-bot-jlg/inc/class-discord-api.php†L240-L360】
 * **Résilience perfectible** : l'unique point de sortie pour les erreurs retourne une charge démo, mais il n'existe pas de stratégie de repli graduelle (ex. circuit breaker, quotas par profil, métriques Prometheus) pourtant courante dans les intégrations tierces. Factoriser la gestion des erreurs/rate limiters dans un composant dédié permettrait de suivre le débit réel et de déclencher des alertes proactives.
-* **Observabilité** : aucun hook ou journal structuré n'est exposé avant/après chaque appel distant. Les plateformes pro tracent les échecs via des interfaces (`PSR-3 Logger`, `OpenTelemetry`) pour corréler les anomalies et identifier les profils concernés.
+* **Observabilité** : aucun hook ou journal structuré n'est exposé avant/après chaque appel distant. Les plateformes pro tracent les échecs via des interfaces (`PSR-3 Logger`, `OpenTelemetry`) pour corréler les anomalies et identifier les profils concernés. _Mise à jour 2024-07 : exposition d’actions/filtres (`discord_bot_jlg_pre_http_request`, `discord_bot_jlg_after_http_request`, `discord_bot_jlg_discord_http_event_logged`) pour brancher une télémétrie externe._
 
 ## `Discord_Bot_JLG_API::merge_stats()`
 * **Règles métiers figées** : la fusion des statistiques donne la priorité au widget sans vérifier l'ancienneté, la cohérence des totaux ou les conflits entre sources. Les solutions professionnelles stockent généralement des horodatages et choisissent la source la plus fraîche ou appliquent une pondération configurable.【F:discord-bot-jlg/inc/class-discord-api.php†L444-L538】
@@ -26,3 +26,16 @@ Ce document recense les zones du plugin qui gagneraient à être rapprochées de
 * **Couplage fort avec l'analytics** : l'écriture en base et le logging analytics sont imbriqués. Les applications pro utilisent des bus d'événements ou des jobs asynchrones pour éviter que des erreurs de reporting n'empêchent le cache d'être écrit.【F:discord-bot-jlg/inc/class-discord-api.php†L552-L582】
 * **Absence de métadonnées temporelles** : seul l'instant de mise en cache est implicite. En production, on stocke souvent un horodatage, la latence des appels et la source (widget/bot) pour diagnostiquer les incohérences.
 * **Observabilité** : pas de métriques sur la fraîcheur des snapshots ni de limites pour éviter un flood analytics. Ajouter des quotas et une télémétrie compatible StatsD/Prometheus rapprocherait le plugin des pratiques entreprises.
+
+## Synthèse & prochaines étapes
+
+| Action | Objectif | Dépendances | Échéance cible | Statut |
+| --- | --- | --- | --- | --- |
+| Décomposer `get_stats()` en orchestrateur + services spécialisés | Réduire la complexité cyclomatique, introduire instrumentation PSR-3 | Décision d’architecture (docs/code-review.md) | Sprint +1 | À planifier |
+| Introduire un scheduler résilient (`StatsRefreshJob`) | Assurer backoff, idempotence et observabilité des rafraîchissements | Extraction cron (`docs/audit-fonctions.md`) | Sprint +2 | À planifier |
+| Créer un dépôt de profils sécurisé | Chiffrer/rotater les tokens, préparer le multi-tenant | Choix stockage (table custom vs CPT) | Sprint +3 | À cadrer |
+| Étendre l’API analytics (historique présence, annotations) | Supporter les fonctionnalités UX (comparatif, timeline enrichie) | Alignement avec `docs/ux-ui-ameliorations-suite.md` | Sprint +3 | Dépend du refactoring |
+| Ajouter des hooks d’observabilité autour des appels Discord | Brancher des compteurs Prometheus / webhooks d’alerte via actions & filtres | Instrumentation HTTP (hooks exposés) | Sprint +2 | En cours (HTTP instrumenté) |
+| Mettre en place une télémétrie exportable | Alimenter Prometheus/webhooks pour observabilité | Choix outillage (Stack SRE) | Sprint +4 | À cadrer |
+
+> Mise à jour : 2024-07-02 — synchroniser cette table avec `docs/audit-professionnel.md` et `docs/audit-fonctions.md` pour conserver une vue cohérente produit/technique.

--- a/discord-bot-jlg/inc/class-discord-api.php
+++ b/discord-bot-jlg/inc/class-discord-api.php
@@ -2276,7 +2276,40 @@ class Discord_Bot_JLG_API {
             }
         }
 
-        $this->event_logger->log('discord_http', $event_context);
+        $filtered_context = apply_filters(
+            'discord_bot_jlg_discord_http_event_context',
+            $event_context,
+            $channel,
+            $response,
+            $context
+        );
+
+        if (!is_array($filtered_context)) {
+            $filtered_context = $event_context;
+        }
+
+        $should_log = apply_filters(
+            'discord_bot_jlg_should_log_discord_http_event',
+            true,
+            $filtered_context,
+            $channel,
+            $response,
+            $context
+        );
+
+        if (!$should_log) {
+            return;
+        }
+
+        $event = $this->event_logger->log('discord_http', $filtered_context);
+
+        do_action(
+            'discord_bot_jlg_discord_http_event_logged',
+            $event,
+            $channel,
+            $response,
+            $context
+        );
     }
 
     private function log_connector_event($channel, array $context = array()) {

--- a/discord-bot-jlg/inc/class-discord-http.php
+++ b/discord-bot-jlg/inc/class-discord-http.php
@@ -81,6 +81,128 @@ class Discord_Bot_JLG_Http_Client {
             $args = apply_filters('discord_bot_jlg_' . $context . '_request_args', $args, $url);
         }
 
-        return wp_safe_remote_get($url, $args);
+        $request_id = $this->generate_request_id($context);
+
+        /**
+         * Permet de court-circuiter un appel HTTP avant son exécution.
+         *
+         * Retournez un tableau de réponse (`wp_safe_remote_get`) ou un `WP_Error` pour interrompre
+         * l'appel réseau et fournir une réponse personnalisée (ex. cache applicatif, circuit breaker).
+         *
+         * @since 1.2.0
+         *
+         * @param array|WP_Error|null $preempt    Valeur de préemption. Null pour poursuivre l'appel standard.
+         * @param string              $url        URL ciblée.
+         * @param array               $args       Arguments finaux transmis à `wp_safe_remote_get()`.
+         * @param string              $context    Contexte fonctionnel (`widget`, `bot`, ...).
+         * @param string              $request_id Identifiant unique de la requête.
+         */
+        $preempt = apply_filters(
+            'discord_bot_jlg_pre_http_request',
+            null,
+            $url,
+            $args,
+            $context,
+            $request_id
+        );
+
+        /**
+         * Se déclenche avant l'exécution d'un appel HTTP Discord.
+         *
+         * Peut être utilisé pour initialiser un traceur distribué, enregistrer des métriques ou enrichir
+         * un journal externe.
+         *
+         * @since 1.2.0
+         *
+         * @param string $url        URL ciblée.
+         * @param array  $args       Arguments transmis à `wp_safe_remote_get()`.
+         * @param string $context    Contexte fonctionnel (`widget`, `bot`, ...).
+         * @param string $request_id Identifiant unique de la requête.
+         */
+        do_action('discord_bot_jlg_before_http_request', $url, $args, $context, $request_id);
+
+        if (null !== $preempt) {
+            $response = $preempt;
+            $duration_ms = 0;
+        } else {
+            $start_time = microtime(true);
+            $response = wp_safe_remote_get($url, $args);
+            $duration_ms = $this->calculate_duration_ms($start_time);
+        }
+
+        /**
+         * Filtre la réponse HTTP renvoyée par l'appel Discord.
+         *
+         * @since 1.2.0
+         *
+         * @param array|WP_Error $response   Réponse retournée par `wp_safe_remote_get()` (ou par un filtre préemptif).
+         * @param string         $url        URL ciblée.
+         * @param array          $args       Arguments transmis à `wp_safe_remote_get()`.
+         * @param string         $context    Contexte fonctionnel (`widget`, `bot`, ...).
+         * @param string         $request_id Identifiant unique de la requête.
+         * @param int            $duration_ms Durée d'exécution estimée en millisecondes.
+         */
+        $response = apply_filters(
+            'discord_bot_jlg_http_response',
+            $response,
+            $url,
+            $args,
+            $context,
+            $request_id,
+            $duration_ms
+        );
+
+        /**
+         * Se déclenche après l'exécution d'un appel HTTP Discord.
+         *
+         * @since 1.2.0
+         *
+         * @param array|WP_Error $response    Réponse finale transmise à l'appelant.
+         * @param string         $url         URL ciblée.
+         * @param array          $args        Arguments transmis à `wp_safe_remote_get()`.
+         * @param string         $context     Contexte fonctionnel (`widget`, `bot`, ...).
+         * @param string         $request_id  Identifiant unique de la requête.
+         * @param int            $duration_ms Durée d'exécution estimée en millisecondes.
+         */
+        do_action(
+            'discord_bot_jlg_after_http_request',
+            $response,
+            $url,
+            $args,
+            $context,
+            $request_id,
+            $duration_ms
+        );
+
+        return $response;
+    }
+
+    private function generate_request_id($context) {
+        $context = sanitize_key($context);
+        $prefix = 'discord_http';
+
+        if ('' !== $context) {
+            $prefix .= '_' . $context;
+        }
+
+        if (function_exists('wp_unique_id')) {
+            return wp_unique_id($prefix . '_');
+        }
+
+        return uniqid($prefix . '_', true);
+    }
+
+    private function calculate_duration_ms($start_time) {
+        if (!is_float($start_time) && !is_int($start_time)) {
+            return 0;
+        }
+
+        $duration = microtime(true) - (float) $start_time;
+
+        if (!is_finite($duration) || $duration < 0) {
+            $duration = 0;
+        }
+
+        return (int) round($duration * 1000);
     }
 }

--- a/docs/audit-fonctions.md
+++ b/docs/audit-fonctions.md
@@ -7,7 +7,7 @@
 *Pistes inspirées des apps pro :*
 
 - Extraire les appels réseau, la fusion et la persistance dans des services dédiés (pattern « use-case + gateway ») pour pouvoir monitorer chaque étape et appliquer des stratégies de retry ou de circuit-breaker indépendantes.【F:discord-bot-jlg/inc/class-discord-api.php†L334-L358】
-- Ajouter de la télémétrie structurée (logs normalisés, événements analytics) avant/après chaque point de sortie pour faciliter l’observabilité en production.
+- Ajouter de la télémétrie structurée (logs normalisés, événements analytics) avant/après chaque point de sortie pour faciliter l’observabilité en production. _Mise à jour 2024-07 : les nouveaux hooks `discord_bot_jlg_pre_http_request` / `discord_bot_jlg_after_http_request` exposent les métadonnées nécessaires aux métriques externes._
 - Déporter les rafraîchissements lourds dans une file asynchrone (cron, queue, Action Scheduler) afin de ne pas bloquer les requêtes front-office tout en conservant des garanties de fraîcheur similaires aux bots professionnels.
 
 ## 2. `Discord_Bot_JLG_Admin::sanitize_options()`
@@ -29,4 +29,16 @@
 - Enregistrer l’horodatage de la dernière exécution réussie et mettre en place un backoff adaptatif en cas d’échec répété au lieu de reprogrammer systématiquement après `time()+interval`.
 - Utiliser un système de jobs (Action Scheduler, queues Redis) pour éviter les doublons de cron si plusieurs sites partagent la même configuration, et suivre chaque tentative via des métriques consolidées.
 - Vérifier l’état du verrou côté API (`Discord_Bot_JLG_API`) avant planification afin de prévenir les chevauchements de rafraîchissements, à l’image des orchestrateurs de bots professionnels.
+
+## Plan d’action priorisé
+
+| Priorité | Action | Livrable attendu | Statut |
+| --- | --- | --- | --- |
+| 🚨 Haute | Extraire un service `StatsRefreshJob` qui encapsule la logique de cron et le verrouillage pour permettre l’ajout d’un backoff exponentiel configurable.【F:discord-bot-jlg/discord-bot-jlg.php†L394-L417】 | Nouvelle classe + tests d’intégration cron | À cadrer |
+| 🚨 Haute | Scinder `Discord_Bot_JLG_API::get_stats()` en façade + connecteurs HTTP séparés (widget/bot) avec instrumentation PSR-3 pour suivre les échecs et la latence.【F:discord-bot-jlg/inc/class-discord-api.php†L240-L358】 | Services dédiés + journalisation structurée | À cadrer |
+| ⚠️ Moyenne | Introduire un gestionnaire de profils (`ProfilesRepository`) afin de sortir la persistance des tokens de la méthode `sanitize_options()` et préparer le chiffrement applicatif.【F:discord-bot-jlg/inc/class-discord-admin.php†L283-L472】 | Classe repository + migration d’option | À prioriser |
+| ⚠️ Moyenne | Ajouter des hooks d’observabilité (actions/filters) autour des appels Discord pour brancher des compteurs Prometheus ou des webhooks d’alerte.【F:discord-bot-jlg/inc/class-discord-api.php†L1991-L2133】 | Hooks documentés + échantillons de métriques | En cours (HTTP instrumenté) |
+| ✅ Faible | Documenter un scénario de tests automatisés couvrant la fusion `merge_stats()` avec des fixtures multi-sources pour préparer l’extraction en stratégie pluggable.【F:discord-bot-jlg/inc/class-discord-api.php†L444-L538】 | Cas de tests + checklist QA | En cours de rédaction |
+
+> ℹ️ Statuts mis à jour le 2024-07-02. Synchroniser cette table avec le plan global (`docs/code-review.md`) à chaque sprint.
 

--- a/docs/audit-professionnel.md
+++ b/docs/audit-professionnel.md
@@ -78,3 +78,15 @@
 
 ---
 En priorisant ces évolutions, l'extension pourra rivaliser avec les solutions professionnelles tout en capitalisant sur les fondations techniques déjà solides.
+
+## Tableau de suivi (vue produit)
+
+| Thème | Problème identifié | Solution proposée | Impact attendu | Priorité |
+| --- | --- | --- | --- | --- |
+| Multi-tenant | Profils et secrets stockés dans une option unique non segmentée.【F:discord-bot-jlg/inc/class-discord-admin.php†L428-L642】 | Migrer vers un dépôt dédié (table custom ou CPT) avec capacités par profil et clés API périmétrées. | Accès délégué par serveur, conformité sécurité accrue. | 🚨 Haute |
+| Observabilité | Journal REST non exploité dans des outils externes, absence d’alertes en temps réel.【F:discord-bot-jlg/inc/class-discord-api.php†L1991-L2133】 | Ajouter exports Prometheus/OpenTelemetry, webhooks et seuils configurables. | Réduction du MTTR, supervision proactive. | 🚨 Haute |
+| Fiabilité API | Cron linéaire sans backoff ni idempotence.【F:discord-bot-jlg/discord-bot-jlg.php†L394-L417】 | Implémenter une file asynchrone + backoff exponentiel + verrouillage distribué. | Moins de rate-limit, meilleure fraîcheur des données. | ⚠️ Moyenne |
+| UX Analytics | Timeline admin limitée (pas de zoom, pas d’annotations).【F:docs/ux-ui-ameliorations-suite.md†L40-L69】 | Ajouter sélecteurs de période, annotations et exports (CSV/PNG). | Adoption analytics, insights actionnables. | ⚠️ Moyenne |
+| Packaging | `node_modules/` versionné, pipeline CI absent.【F:docs/code-review.md†L39-L60】 | Ignorer les dépendances vendoriées, définir un workflow CI (tests, lint). | Déploiements reproductibles, repo allégé. | ✅ Faible |
+
+> Dernière révision : 2024-07-02 — voir également `docs/audit-fonctions.md` pour le détail des extractions techniques.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -33,6 +33,8 @@ Le plugin « Discord Bot - JLG » fournit une intégration très complète (cr
 * **Testabilité** : des classes plus petites et injectées rendent possible la couverture unitaire des scénarios critiques (rate limiting, fallback, sanitisation des options) sans devoir charger l'ensemble de WordPress.
 * **Maintenance** : la séparation des couches évite que des changements dans le front (ex. nouveaux champs de formulaire) n'impactent la logique réseau ou le suivi analytique.
 
+> Mise à jour 2024-07 : une première étape d’instrumentation est en place via les hooks `discord_bot_jlg_pre_http_request`, `discord_bot_jlg_after_http_request` et le filtre `discord_bot_jlg_discord_http_event_context`, ce qui facilite l’agrégation de métriques externes en attendant l’extraction complète des services.
+
 ## Étapes suggérées
 1. Introduire un autoloader et définir un namespace de base (`DiscordBotJLG\`).
 2. Extraire progressivement les responsabilités principales (`OptionsRepository`, `CacheManager`, `DiscordHttpClient`, `SettingsPage`…).
@@ -40,3 +42,13 @@ Le plugin « Discord Bot - JLG » fournit une intégration très complète (cr
 4. Nettoyer le dépôt (`.gitignore` pour `node_modules/`, documentation de la stack de build/test).
 
 En procédant par itérations (extraction d'un service à la fois), le refactoring restera maîtrisé tout en apportant des bénéfices immédiats sur la qualité du code.
+
+## Suivi des chantiers
+
+- [ ] Créer un autoloader Composer (`composer.json`, PSR-4 `DiscordBotJLG\`) et déplacer les classes extraites dans `src/`.
+- [ ] Extraire `Discord_Bot_JLG_API::get_stats()` en orchestrateur + services `WidgetClient`, `BotClient`, `StatsMerger` avec interface commune.【F:discord-bot-jlg/inc/class-discord-api.php†L240-L358】
+- [ ] Refondre `Discord_Bot_JLG_Admin` en sous-modules (`SettingsPage`, `ProfilesSection`, `DisplaySection`) et couvrir chaque module par des tests PHPUnit ciblés.【F:discord-bot-jlg/inc/class-discord-admin.php†L8-L155】
+- [ ] Déplacer la planification cron et le verrouillage dans un service injectable (`StatsRefreshJob`) afin de permettre des tests unitaires du scheduling.【F:discord-bot-jlg/discord-bot-jlg.php†L394-L417】
+- [ ] Nettoyer le dépôt (ajout de `node_modules/` au `.gitignore`, documentation du workflow `npm test` + `phpunit`).【F:package.json†L1-L16】
+
+> Mise à jour : 2024-07-02 — synchroniser avec `docs/audit-fonctions.md` pour l’état détaillé de chaque extraction.

--- a/docs/comparaison-apps-pro.md
+++ b/docs/comparaison-apps-pro.md
@@ -1,5 +1,12 @@
 # Comparaison avec des applications professionnelles
 
+## Résumé exécutif (2024-07)
+
+- **Robustesse opérationnelle** : la collecte actuelle est fiable mais manque de backoff, de retry différenciés et de supervision exportable (Prometheus/Webhooks).【F:docs/comparaison-apps-pro.md†L17-L54】 Priorité haute pour préparer des SLA.
+- **Gouvernance & secrets** : stockage des tokens en clair et option unique pour tous les profils — migrer vers une architecture multi-tenant dédiée et introduire chiffrement/rotation automatisée.【F:docs/comparaison-apps-pro.md†L41-L63】
+- **Expérience analytics** : analytics solides mais sans segmentation, exports ni notifications. Compléter avec comparaisons multi-profils et centre d’alertes (voir `docs/ux-ui-ameliorations-suite.md`).【F:docs/comparaison-apps-pro.md†L5-L36】
+- **Outillage développeur** : aligner le packaging (CI, dist-archive, .gitignore) pour approcher les standards SaaS, en cohérence avec `docs/code-review.md`.
+
 ## Forces actuelles
 - **Chaîne de collecte robuste** : la récupération combine widget public, bot et modes de secours pour éviter les interruptions d’affichage, tout en journalisant les erreurs et en conservant des statistiques de repli.【F:discord-bot-jlg/inc/class-discord-api.php†L240-L358】【F:discord-bot-jlg/inc/class-discord-api.php†L406-L489】
 - **Administration avancée** : les options couvrent profils multiples, thèmes, icônes, libellés, CTA et cache, avec sanitisation systématique pour sécuriser les entrées.【F:discord-bot-jlg/inc/class-discord-admin.php†L213-L423】【F:discord-bot-jlg/inc/class-discord-admin.php†L642-L907】
@@ -64,3 +71,11 @@ Les éditeurs SaaS matures se distinguent aussi par la qualité de leur outillag
 1. **Capitaliser sur les tests existants** : généraliser l’exécution automatisée des suites PHPUnit et Jest (mock HTTP, scénarios front) dans un pipeline CI pour détecter les régressions avant déploiement public.【F:discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_API.php†L1-L34】【F:tests/js/discord-bot-jlg.test.js†L1-L160】
 2. **Documenter le packaging avancé** : compléter le README avec des guides marché (traductions, exigences RGPD, matrice de support) et proposer des scripts de build (Composer, `wp dist-archive`) afin de reproduire les standards de livraison des solutions pro.【F:README.md†L1-L120】【F:discord-bot-jlg/discord-bot-jlg.php†L123-L198】
 3. **Structurer la traçabilité** : coupler les hooks de nettoyage/install avec un journal d’opérations (création/suppression de profils, purges, appels REST) pour simplifier les audits de sécurité et la gestion des incidents.【F:discord-bot-jlg/discord-bot-jlg.php†L123-L167】【F:discord-bot-jlg/inc/class-discord-analytics.php†L164-L217】
+
+## Points de convergence avec les autres plans
+
+- **Refactoring API/cron** : suivre le `Plan d'amélioration` pour décomposer l’accès aux stats et introduire un scheduler résilient partagé (docs/audit-fonctions.md).
+- **UX & presets** : exploiter les recommandations UX pour proposer des fonctionnalités différenciantes une fois la base technique renforcée (docs/ux-ui-ameliorations-suite.md, docs/presets-ui.md).
+- **Observabilité** : capitaliser sur l’audit professionnel pour prioriser l’export de métriques et les webhooks dans le backlog technique (docs/code-review.md).
+
+> Mise à jour : 2024-07-02 — ce résumé doit ouvrir chaque revue stratégique afin de vérifier l’avancement des actions listées ci-dessus.

--- a/docs/presets-ui.md
+++ b/docs/presets-ui.md
@@ -84,3 +84,13 @@ Ce document rassemble plusieurs pistes de presets graphiques pouvant être inté
 - Tester les presets avec les composants WordPress (`wp-components`) pour assurer la cohérence avec le back-office.
 
 Ces presets peuvent être combinés ou ajustés selon les besoins : par exemple, adopter la structure Headless UI et appliquer les teintes Shadcn UI, ou intégrer les micro-animations Anime.js sur une base Bootstrap.
+
+## Mise en œuvre progressive
+
+1. **Phase 1 – Documentation & tokens** : définir un fichier de variables CSS commun (`discord-theme-tokens.css`) afin de centraliser les couleurs, rayons et espacements. Cette étape conditionne l’implémentation rapide de chaque preset.
+2. **Phase 2 – Presets admin** : appliquer `Headless Essence` et `Bootstrap Fluent` aux écrans d’options existants pour valider la compatibilité avec `wp-components` (test manuel + capture). Priorité aux composants réutilisés (accordéons, onglets, modales).
+3. **Phase 3 – Front public** : intégrer `Shadcn Minimal` et `Radix Structure` comme thèmes sélectionnables dans les options (`discord_bot_jlg_theme`), avec prévisualisation côté bloc Gutenberg.
+4. **Phase 4 – Animations avancées** : activer `Anime Pulse` sur la page de démonstration et documenter les dépendances éventuelles (fallback CSS si Anime.js absent). Prévoir un toggle global « Réduire les animations ».
+5. **Phase 5 – Industrialisation** : automatiser la génération des variantes (PostCSS/Tailwind) et documenter les tests visuels (Percy, Playwright) pour garantir la stabilité des thèmes.
+
+> Mettre à jour cette feuille de route après chaque livraison de preset afin d’assurer la cohérence avec le plan UX détaillé (`docs/ux-ui-ameliorations-suite.md`).

--- a/docs/ux-ui-ameliorations-suite.md
+++ b/docs/ux-ui-ameliorations-suite.md
@@ -1,5 +1,12 @@
 # Améliorations UX/UI supplémentaires inspirées des outils professionnels
 
+## Synthèse rapide (2024-07)
+
+- **Comparaison multi-profils** : objectif sprint +2 pour un MVP en deux panneaux (desktop) et carrousel (mobile). Nécessite la mutualisation du cache et un nouvel attribut `profiles[]` partagé entre bloc/shortcode.【F:docs/ux-ui-ameliorations-suite.md†L5-L27】
+- **Explorateur de présence segmenté** : dépend de l’extension de l’API analytics pour exposer les séries historiques `presence_breakdown`. Prévoir une itération de recherche utilisateur avec les CM pilotes.【F:docs/ux-ui-ameliorations-suite.md†L29-L57】
+- **Timeline analytique enrichie** : à coupler avec le chantier observabilité pour consolider annotations et exports dans le back-office.【F:docs/ux-ui-ameliorations-suite.md†L59-L83】
+- **Signalétique proactive & sparkline multi-couches** : livrables complémentaires pour renforcer la perception de fraîcheur des données et l’orientation action.【F:docs/ux-ui-ameliorations-suite.md†L85-L133】
+
 ## 1. Tableau comparatif multi-profils
 - **Constat** : chaque instance du bloc ou du shortcode ne pointe que vers un profil serveur unique via l’attribut `profile`, ce qui limite les comparaisons simultanées.【F:discord-bot-jlg/block/discord-stats/block.json†L263-L269】【F:discord-bot-jlg/inc/class-discord-shortcode.php†L666-L672】
 - **Inspiration pro** : les suites analytics Discord/Slack destinées aux équipes communautaires offrent des vues côte à côte pour benchmarquer plusieurs espaces.
@@ -84,3 +91,12 @@
   - Étendre la configuration Chart.js pour gérer plusieurs datasets, légendes dynamiques et zones colorées.
   - Ajouter une logique de détection d’anomalies côté PHP ou JS (calcul d’écart-type glissant) et stocker les playbooks associés dans une option WordPress.
   - Prévoir un mécanisme de presets (JSON) pour enregistrer/partager des configurations de métriques via le bloc.
+
+## Prochaines étapes
+
+1. Valider le découpage produit (MVP vs. évolutions avancées) avec l’équipe communauté et documenter les exigences analytics complémentaires (export CSV, annotations) dans `docs/audit-professionnel.md`.
+2. Démarrer un prototype Figma pour le comparatif multi-profils et collecter du feedback sur la hiérarchie visuelle avant implémentation.
+3. Préparer un backlog technique partagé avec `docs/code-review.md` pour aligner les évolutions front sur l’extraction des services (mutualisation du cache multi-profils, API analytics étendue).
+4. Planifier des tests utilisateurs ciblés (3 administrateurs, 3 membres communauté) afin de mesurer la compréhension des nouveaux panneaux et ajuster la microcopie.
+
+> État mis à jour le 2024-07-02 — synchroniser avec les tableaux de suivi produit et technique pour garantir la cohérence des priorités.


### PR DESCRIPTION
## Summary
- Add pre/post HTTP hooks, response filters and unique request identifiers to the Discord HTTP client to support external telemetry and short-circuiting
- Allow filtering and conditional persistence of Discord HTTP event logs while emitting an action when a log entry is stored
- Document the new observability hooks and update the technical roadmap to reflect the instrumentation progress

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e68e7b466c832ea068bffe86825073