### PR TITLE
Fix demo previews rendering white text on white backgrounds

### DIFF
--- a/discord-bot-jlg/inc/class-discord-shortcode.php
+++ b/discord-bot-jlg/inc/class-discord-shortcode.php
@@ -600,12 +600,20 @@ class Discord_Bot_JLG_Shortcode {
             $accent_color_alt = $accent_color;
         }
 
+        $auto_text_color = '';
+
         if ('' !== $stat_bg_color) {
             $style_declarations[] = '--discord-surface-background: ' . $stat_bg_color;
+
+            if ('' === $stat_text_color) {
+                $auto_text_color = discord_bot_jlg_get_auto_text_color($stat_bg_color);
+            }
         }
 
         if ('' !== $stat_text_color) {
             $style_declarations[] = '--discord-surface-text: ' . $stat_text_color;
+        } elseif ('' !== $auto_text_color) {
+            $style_declarations[] = '--discord-surface-text: ' . $auto_text_color;
         }
 
         if ('' !== $accent_color) {

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Helpers.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Helpers.php
@@ -322,6 +322,18 @@ class Test_Discord_Bot_JLG_Helpers extends TestCase {
         remove_all_filters('discord_bot_jlg_secret_migrated');
     }
 
+    public function test_get_auto_text_color_prefers_dark_on_light_background() {
+        $this->assertSame('#0b1120', discord_bot_jlg_get_auto_text_color('#ffffff'));
+    }
+
+    public function test_get_auto_text_color_prefers_light_on_dark_background() {
+        $this->assertSame('#ffffff', discord_bot_jlg_get_auto_text_color('#0f172a'));
+    }
+
+    public function test_get_auto_text_color_handles_transparent_background() {
+        $this->assertSame('#0b1120', discord_bot_jlg_get_auto_text_color('rgba(255, 255, 255, 0.6)'));
+    }
+
     /**
      * @dataProvider provide_sanitize_profile_key_inputs
      */

--- a/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
+++ b/discord-bot-jlg/tests/phpunit/Test_Discord_Bot_JLG_Shortcode.php
@@ -264,6 +264,18 @@ class Test_Discord_Bot_JLG_Shortcode extends TestCase {
         $this->assertStringContainsString('--discord-accent-contrast: #0f0f0f', $html);
     }
 
+    public function test_render_shortcode_auto_adds_text_color_for_light_background() {
+        $shortcode = $this->get_shortcode_instance();
+
+        $html = $shortcode->render_shortcode(array(
+            'stat_bg_color'   => '#ffffff',
+            'stat_text_color' => '',
+        ));
+
+        $this->assertStringContainsString('--discord-surface-background: #ffffff', $html);
+        $this->assertStringContainsString('--discord-surface-text: #0b1120', $html);
+    }
+
     public function test_prepare_avatar_url_preserves_fragment_and_nested_query_arguments() {
         $shortcode = $this->get_shortcode_instance();
 


### PR DESCRIPTION
## Summary
- add a helper that computes an accessible stat text color whenever only a background color is supplied
- apply the automatic text-color selection to the shortcode output and the block editor preview so demo stats stay readable
- exercise the new behavior with PHPUnit coverage for the helper and shortcode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ff69711e50832e9db57e03f457e74c